### PR TITLE
feat: B站 Cookie 全流程管理 — 客户端加密/本地存储/多客户端池

### DIFF
--- a/app/app/bilibili_login.tsx
+++ b/app/app/bilibili_login.tsx
@@ -1,0 +1,366 @@
+/**
+ * Bilibili Cookie 登录页（手机端）
+ * 支持：手机号+验证码登录、账号密码登录
+ */
+import React, { useState } from 'react';
+import {
+  Alert,
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { server_config } from '../config';
+import * as forge from 'node-forge';
+
+type LoginMode = 'sms' | 'password';
+
+interface Props {
+  onClose: () => void;
+}
+
+async function apiPost(path: string, body: Record<string, string>): Promise<any> {
+  const resp = await fetch(`${server_config.BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return resp.json();
+}
+
+export default function BilibiliLoginScreen({ onClose }: Props) {
+  const insets = useSafeAreaInsets();
+  const [mode, setMode] = useState<LoginMode>('sms');
+  const [loading, setLoading] = useState(false);
+
+  // 短信登录
+  const [phone, setPhone] = useState('');
+  const [smsCode, setSmsCode] = useState('');
+  const [codeSent, setCodeSent] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+
+  // 密码登录
+  const [biliUsername, setBiliUsername] = useState('');
+  const [biliPassword, setBiliPassword] = useState('');
+
+  const sendSms = async () => {
+    Keyboard.dismiss();
+    if (!phone.trim()) {
+      Alert.alert('提示', '请输入手机号');
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await apiPost('/api/bilibili/cookie/login/sms/send', {
+        phone: phone.trim(),
+        country_code: '86',
+      });
+      if (result.success) {
+        setCodeSent(true);
+        setCountdown(60);
+        const timer = setInterval(() => {
+          setCountdown((c) => {
+            if (c <= 1) {
+              clearInterval(timer);
+              return 0;
+            }
+            return c - 1;
+          });
+        }, 1000);
+        Alert.alert('已发送', '验证码已发送到您的手机');
+      } else {
+        Alert.alert('发送失败', result.message || '未知错误');
+      }
+    } catch (e: any) {
+      Alert.alert('错误', e.message);
+    }
+    setLoading(false);
+  };
+
+  const doSmsLogin = async () => {
+    Keyboard.dismiss();
+    if (!phone.trim() || !smsCode.trim()) {
+      Alert.alert('提示', '请填写手机号和验证码');
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await apiPost('/api/bilibili/cookie/login/sms', {
+        phone: phone.trim(),
+        code: smsCode.trim(),
+        country_code: '86',
+      });
+      if (result.success) {
+        Alert.alert('成功', 'Bilibili 登录成功！Cookie 已保存到本地');
+        onClose();
+      } else {
+        Alert.alert('登录失败', result.message || '未知错误');
+      }
+    } catch (e: any) {
+      Alert.alert('错误', e.message);
+    }
+    setLoading(false);
+  };
+
+  const doPasswordLogin = async () => {
+    Keyboard.dismiss();
+    if (!biliUsername.trim() || !biliPassword.trim()) {
+      Alert.alert('提示', '请填写账号和密码');
+      return;
+    }
+    setLoading(true);
+    try {
+      // 1. 获取 RSA 公钥（服务端不接触密码明文）
+      const keyResp = await fetch(`${server_config.BASE_URL}/api/bilibili/cookie/login/key`);
+      const keyData = await keyResp.json();
+      if (!keyData.key || !keyData.hash) {
+        Alert.alert('错误', '获取加密密钥失败');
+        setLoading(false);
+        return;
+      }
+
+      // 2. 客户端本地 RSA 加密密码（PKCS1 v1.5）
+      const publicKey = forge.pki.publicKeyFromPem(keyData.key);
+      const encrypted = publicKey.encrypt(keyData.hash + biliPassword, 'RSAES-PKCS1-V1_5');
+      const encryptedPassword = forge.util.encode64(encrypted);
+
+      // 3. 发送加密后的密码到服务端
+      const result = await apiPost('/api/bilibili/cookie/login/password', {
+        username: biliUsername.trim(),
+        encrypted_password: encryptedPassword,
+      });
+      if (result.success) {
+        Alert.alert('成功', 'Bilibili 登录成功！Cookie 已保存到本地');
+        onClose();
+      } else {
+        Alert.alert('登录失败', result.message || '账号或密码错误');
+      }
+    } catch (e: any) {
+      Alert.alert('错误', e.message);
+    }
+    setLoading(false);
+  };
+
+  const checkStatus = async () => {
+    try {
+      const result = await apiPost('/api/bilibili/cookie/qrcode/generate', {});
+      if (result.url) {
+        Alert.alert(
+          '需要 PC 端扫码',
+          '手机端不支持二维码显示，请使用 PC 客户端进行 QR 码登录，或使用下方的短信/密码登录。',
+        );
+      }
+    } catch {
+      Alert.alert('无法连接服务端', '请检查服务器地址配置');
+    }
+  };
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      {/* 标题栏 */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onClose}>
+          <Text style={styles.backBtn}>{'< 返回'}</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>Bilibili 登录</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {/* 模式切换 */}
+          <View style={styles.tabRow}>
+            <TouchableOpacity
+              style={[styles.tab, mode === 'sms' && styles.tabActive]}
+              onPress={() => setMode('sms')}
+            >
+              <Text style={[styles.tabText, mode === 'sms' && styles.tabTextActive]}>
+                手机验证码
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.tab, mode === 'password' && styles.tabActive]}
+              onPress={() => setMode('password')}
+            >
+              <Text style={[styles.tabText, mode === 'password' && styles.tabTextActive]}>
+                账号密码
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {mode === 'sms' ? (
+            <View style={styles.form}>
+              <Text style={styles.label}>手机号</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="输入 B站 绑定手机号"
+                keyboardType="phone-pad"
+                value={phone}
+                onChangeText={setPhone}
+              />
+
+              <View style={styles.codeRow}>
+                <TextInput
+                  style={[styles.input, { flex: 1, marginRight: 8 }]}
+                  placeholder="验证码"
+                  keyboardType="number-pad"
+                  value={smsCode}
+                  onChangeText={setSmsCode}
+                />
+                <TouchableOpacity
+                  style={[styles.smallBtn, countdown > 0 && { opacity: 0.5 }]}
+                  onPress={sendSms}
+                  disabled={countdown > 0 || loading}
+                >
+                  <Text style={styles.smallBtnText}>
+                    {countdown > 0 ? `${countdown}s` : '获取验证码'}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+
+              <TouchableOpacity
+                style={[styles.primaryBtn, loading && { opacity: 0.6 }]}
+                onPress={doSmsLogin}
+                disabled={loading}
+              >
+                <Text style={styles.primaryBtnText}>
+                  {loading ? '登录中...' : '登录'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <View style={styles.form}>
+              <Text style={styles.label}>B站账号（手机号/邮箱）</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="输入 B站 账号"
+                value={biliUsername}
+                onChangeText={setBiliUsername}
+                autoCapitalize="none"
+              />
+
+              <Text style={styles.label}>密码</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="输入密码"
+                secureTextEntry
+                value={biliPassword}
+                onChangeText={setBiliPassword}
+              />
+
+              <TouchableOpacity
+                style={[styles.primaryBtn, loading && { opacity: 0.6 }]}
+                onPress={doPasswordLogin}
+                disabled={loading}
+              >
+                <Text style={styles.primaryBtnText}>
+                  {loading ? '登录中...' : '登录'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* 安全提示 */}
+          <View style={styles.tips}>
+            <Text style={styles.tipTitle}>安全说明</Text>
+            <Text style={styles.tipText}>
+              • 密码经 B站 RSA 公钥加密传输，服务端无法获取明文
+            </Text>
+            <Text style={styles.tipText}>
+              • Cookie 保存在本地，使用时才同步到服务端内存，不落盘
+            </Text>
+            <Text style={styles.tipText}>
+              • refresh_token 仅用于续期 SESSDATA，无法操作用户账号
+            </Text>
+            <Text style={styles.tipText}>
+              • 服务端重启后 Cookie 不会丢失，从本地重新同步即可
+            </Text>
+            <Text style={styles.tipText}>
+              • 可随时在 B站「设置-安全设置-登录设备管理」中撤销授权
+            </Text>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  backBtn: { fontSize: 16, color: '#66CCFF' },
+  title: { fontSize: 18, fontWeight: '600', color: '#333' },
+  scrollContent: { padding: 16 },
+  tabRow: {
+    flexDirection: 'row',
+    marginBottom: 20,
+    backgroundColor: '#e0e0e0',
+    borderRadius: 8,
+    padding: 2,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 10,
+    alignItems: 'center',
+    borderRadius: 6,
+  },
+  tabActive: { backgroundColor: '#fff' },
+  tabText: { fontSize: 14, color: '#666' },
+  tabTextActive: { color: '#66CCFF', fontWeight: '600' },
+  form: { marginBottom: 20 },
+  label: { fontSize: 14, color: '#333', marginBottom: 6, marginTop: 12 },
+  input: {
+    height: 44,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    fontSize: 15,
+    borderWidth: 1,
+    borderColor: '#ddd',
+  },
+  codeRow: { flexDirection: 'row', alignItems: 'center', marginTop: 12 },
+  smallBtn: {
+    height: 44,
+    paddingHorizontal: 16,
+    backgroundColor: '#66CCFF',
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  smallBtnText: { color: '#fff', fontSize: 14, fontWeight: '600' },
+  primaryBtn: {
+    height: 48,
+    backgroundColor: '#FB7299',
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  primaryBtnText: { color: '#fff', fontSize: 17, fontWeight: '600' },
+  tips: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 14,
+    marginTop: 10,
+  },
+  tipTitle: { fontSize: 14, fontWeight: '600', color: '#999', marginBottom: 8 },
+  tipText: { fontSize: 13, color: '#999', lineHeight: 20, marginBottom: 4 },
+});

--- a/app/app/index.tsx
+++ b/app/app/index.tsx
@@ -19,6 +19,8 @@ import { MessageItem } from '../components/ChatBubbles';
 import { useChatLogic } from '../hooks/useChatLogic';
 import { useHistoryLogic } from "../hooks/useHistoryLogic";
 import { addDebugTrace, clearDebugTrace, DebugTraceEntry, subscribeDebugTrace } from '../utils/debug_trace';
+import LlmSettingsScreen from './llm_settings';
+import BilibiliLoginScreen from './bilibili_login';
 
 
 export default function Index({ onLogout }: { onLogout?: () => void }) {
@@ -29,6 +31,9 @@ export default function Index({ onLogout }: { onLogout?: () => void }) {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [thinkingFrame, setThinkingFrame] = useState(0);
   const [debugOpen, setDebugOpen] = useState(false);
+  const [llmSettingsOpen, setLlmSettingsOpen] = useState(false);
+  const [bilibiliLoginOpen, setBilibiliLoginOpen] = useState(false);
+  const [affection, setAffection] = useState(null);
   const [debugEntries, setDebugEntries] = useState<DebugTraceEntry[]>([]);
   const webviewRef = useRef<WebView>(null);
 
@@ -182,6 +187,29 @@ export default function Index({ onLogout }: { onLogout?: () => void }) {
           </TouchableOpacity>
         )}
 
+        {/* 设置按钮 */}
+        <TouchableOpacity
+          style={styles.settingsButton}
+          onPress={() => setLlmSettingsOpen(true)}
+        >
+          <Text style={styles.settingsButtonText}>⚙</Text>
+        </TouchableOpacity>
+
+        {/* Bilibili Cookie 按钮 */}
+        <TouchableOpacity
+          style={styles.biliButton}
+          onPress={() => setBilibiliLoginOpen(true)}
+        >
+          <Text style={styles.biliButtonText}>B</Text>
+        </TouchableOpacity>
+
+        {/* 好感度显示 */}
+        {affection && (
+          <View style={styles.affectionBadge}>
+            <Text style={styles.affectionLevelText}>{affection.level_cn}</Text>
+            <Text style={styles.affectionScoreText}>{affection.score}</Text>
+          </View>
+        )}
         {thinking ? (
           <View style={styles.thinkingBubble}>
             <Image
@@ -284,6 +312,23 @@ export default function Index({ onLogout }: { onLogout?: () => void }) {
 
         </View>
       </View>
+
+      {/* LLM 端点设置页 - 全屏覆盖 */}
+      {llmSettingsOpen && (
+        <View style={styles.settingsOverlay}>
+          <LlmSettingsScreen
+            onClose={() => setLlmSettingsOpen(false)}
+            onSave={(preferences) => sendPreferences(preferences)}
+          />
+        </View>
+      )}
+
+      {/* Bilibili 登录页 - 全屏覆盖 */}
+      {bilibiliLoginOpen && (
+        <View style={styles.settingsOverlay}>
+          <BilibiliLoginScreen onClose={() => setBilibiliLoginOpen(false)} />
+        </View>
+      )}
     </View>
   );
 }
@@ -323,6 +368,65 @@ const styles = StyleSheet.create({
     width: 20,
     height: 20,
     resizeMode: 'contain',
+  },
+  settingsButton: {
+    position: 'absolute',
+    left: 50,
+    top: 10,
+    width: 32,
+    height: 32,
+    zIndex: 100,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.5)',
+    borderRadius: 16,
+  },
+  settingsButtonText: {
+    fontSize: 18,
+  },
+  biliButton: {
+    position: 'absolute',
+    left: 90,
+    top: 10,
+    width: 32,
+    height: 32,
+    zIndex: 100,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(251, 114, 153, 0.8)',
+    borderRadius: 16,
+  },
+  biliButtonText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  settingsOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 200,
+    backgroundColor: '#f5f5f5',
+  },
+  affectionBadge: {
+    position: 'absolute',
+    left: 130,
+    top: 10,
+    zIndex: 100,
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  affectionLevelText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#FB7299',
+    marginRight: 4,
+  },
+  affectionScoreText: {
+    fontSize: 12,
+    color: '#666',
   },
   thinkingBubble: {
     position: 'absolute',

--- a/client/src/gui/main_ui.py
+++ b/client/src/gui/main_ui.py
@@ -529,12 +529,18 @@ class ChatWidget(QWidget):
         self.temp_is_user = True
 
     def open_settings(self):
-        print("Opening preferences dialog...")
-        if self.network_client:
-            dialog = PreferencesDialog(self.network_client, self)
-            dialog.exec()
-        else:
-            QMessageBox.warning(self, "提示", "网络客户端未就绪，无法打开偏好设置")
+        """打开用户设置对话框"""
+        if self.preferences_manager is None:
+            from ..user_preferences_manager import UserPreferencesManager
+            self.preferences_manager = UserPreferencesManager()
+
+        from .preferences_dialog import UserPreferencesDialog
+        dialog = UserPreferencesDialog(
+            self.preferences_manager, self,
+            agent_binder=self.agent,
+            network_client=self.network_client,
+        )
+        dialog.exec()
     
     def on_scroll_value_changed(self, value):
         if value == 0 and not self.is_loading_history and self.current_history_index > 0:

--- a/client/src/gui/preferences_dialog.py
+++ b/client/src/gui/preferences_dialog.py
@@ -5,178 +5,885 @@ from PySide6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QTabWidget,
                                QWidget, QLabel, QLineEdit, QPushButton, QComboBox,
                                QCheckBox, QListWidget, QListWidgetItem, QTextEdit,
                                QTimeEdit, QSpinBox, QMessageBox, QDateEdit, QFrame)
-from PySide6.QtCore import Qt, QTime, QDate
-from PySide6.QtGui import QFont
-from typing import TYPE_CHECKING
-from ..utils.logger import get_logger
+from PySide6.QtCore import Qt, QTime, QDate, QTimer
+from PySide6.QtGui import QFont, QPixmap
+from pathlib import Path
+from .user_preferences_manager import UserPreferencesManager
+from ..network.network_client import NetworkClient
 
-if TYPE_CHECKING:
-    from ..network.network_client import NetworkClient
 
-class PreferencesDialog(QDialog):
-    """偏好设置对话框 - 从工具栏打开，从服务器加载/保存。"""
+class UserPreferencesDialog(QDialog):
+    """用户偏好设置对话框"""
 
-    def __init__(self, network_client: "NetworkClient", parent=None):
+    def __init__(self, preferences_manager: UserPreferencesManager, parent=None, agent_binder=None, network_client=None):
         super().__init__(parent)
-        self.logger = get_logger(self.__class__.__name__)
-        self.network_client = network_client
-        self.setWindowTitle("设置与天依的相处模式")
-        self.setMinimumSize(500, 480)
+        self.preferences_manager = preferences_manager
+        self.agent_binder = agent_binder
+        self.network_client: NetworkClient | None = network_client
+        self.setWindowTitle("用户自定义设置")
+        self.setMinimumSize(650, 550)
         self.setModal(True)
 
-        self._preferences = {}
+        # Bilibili cookie 相关状态
+        self._qr_key: str | None = None
+        self._qr_poll_timer: QTimer | None = None
+
         self.init_ui()
-        self.load_preferences()
+        self.load_current_settings()
+
+        # 自动同步本地保存的 Cookie 到服务端（服务端不落盘）
+        if self._bili_sync_local_to_server():
+            self._bili_check_status()
 
     def init_ui(self):
         """初始化UI"""
         layout = QVBoxLayout()
-        layout.setSpacing(12)
-        layout.setContentsMargins(24, 20, 24, 20)
 
-        title = QLabel("和天依的相处模式")
-        title.setStyleSheet("font-size: 20px; font-weight: bold; color: #66CCFF;")
-        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(title)
+        # 创建标签页
+        tab_widget = QTabWidget()
 
-        desc = QLabel("你可以在这里告诉天依你们之间的关系和相处方式，"
-                       "这样天依会更好地了解你！")
-        desc.setWordWrap(True)
-        desc.setStyleSheet("font-size: 13px; color: #666; margin-bottom: 10px;")
-        layout.addWidget(desc)
+        # 标签页1: 重要日期
+        self.dates_tab = self._create_dates_tab()
+        tab_widget.addTab(self.dates_tab, "📅 重要日期")
 
-        # 关系类型
-        rel_label = QLabel("你希望和天依的关系是：")
-        rel_label.setStyleSheet("font-size: 14px; font-weight: 500;")
-        layout.addWidget(rel_label)
+        # 标签页2: 相处模式
+        self.relationship_tab = self._create_relationship_tab()
+        tab_widget.addTab(self.relationship_tab, "💬 相处模式")
 
-        self.relationship_combo = QComboBox()
-        self.relationship_combo.addItems(["朋友", "知己", "粉丝", "搭档", "家人", "其他"])
-        self.relationship_combo.setEditable(True)
-        self.relationship_combo.setStyleSheet("font-size: 14px; padding: 6px;")
-        layout.addWidget(self.relationship_combo)
+        # 标签页3: 提醒设置
+        self.reminder_tab = self._create_reminder_tab()
+        tab_widget.addTab(self.reminder_tab, "⏰ 提醒设置")
 
-        # 表达风格
-        style_label = QLabel("你希望天依的表达风格偏向：")
-        style_label.setStyleSheet("font-size: 14px; font-weight: 500; margin-top: 8px;")
-        layout.addWidget(style_label)
+        # 标签页4: Bilibili Cookie 管理
+        self.bili_tab = self._create_bilibili_tab()
+        tab_widget.addTab(self.bili_tab, "B站 Cookie")
 
-        self.style_combo = QComboBox()
-        self.style_combo.addItems(["活泼可爱", "温柔可人", "俏皮调皮", "诗意文艺", "热情洋溢", "文静恬淡", "随意自然"])
-        self.style_combo.setEditable(True)
-        self.style_combo.setStyleSheet("font-size: 14px; padding: 6px;")
-        layout.addWidget(self.style_combo)
-
-        # 性格特点
-        trait_label = QLabel("你希望天依的性格特点（用逗号分隔，可选）：")
-        trait_label.setStyleSheet("font-size: 14px; font-weight: 500; margin-top: 8px;")
-        layout.addWidget(trait_label)
-
-        self.personality_input = QLineEdit()
-        self.personality_input.setPlaceholderText("例如：温柔、耐心、善解人意")
-        self.personality_input.setStyleSheet("font-size: 14px; padding: 6px;")
-        layout.addWidget(self.personality_input)
-
-        # 自定义上下文
-        ctx_label = QLabel("其他你想让天依知道的（可选）：")
-        ctx_label.setStyleSheet("font-size: 14px; font-weight: 500; margin-top: 8px;")
-        layout.addWidget(ctx_label)
-
-        self.custom_context_input = QTextEdit()
-        self.custom_context_input.setMaximumHeight(80)
-        self.custom_context_input.setPlaceholderText("在这里添加任何你想让天依知道的关于你们关系的信息...")
-        self.custom_context_input.setStyleSheet("font-size: 13px; padding: 4px;")
-        layout.addWidget(self.custom_context_input)
-
-        layout.addStretch()
+        layout.addWidget(tab_widget)
 
         # 按钮区域
-        btn_layout = QHBoxLayout()
-        btn_layout.setSpacing(16)
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
 
-        btn_layout.addStretch()
-
-        self.save_btn = QPushButton("保存设置")
-        self.save_btn.setStyleSheet("""
+        self.save_button = QPushButton("保存")
+        self.save_button.clicked.connect(self.save_settings)
+        self.save_button.setStyleSheet("""
             QPushButton {
-                background-color: #4CAF50;
+                background-color: #66CCFF;
                 color: white;
                 border: none;
-                padding: 12px 24px;
-                border-radius: 8px;
+                padding: 8px 20px;
+                border-radius: 4px;
                 font-size: 14px;
             }
             QPushButton:hover {
-                background-color: #45a049;
+                background-color: #55BBEE;
             }
         """)
-        self.save_btn.clicked.connect(self.on_save)
-        btn_layout.addWidget(self.save_btn)
 
-        layout.addLayout(btn_layout)
+        self.cancel_button = QPushButton("取消")
+        self.cancel_button.clicked.connect(self.reject)
+        self.cancel_button.setStyleSheet("""
+            QPushButton {
+                background-color: #D8D8D8;
+                color: #333333;
+                border: none;
+                padding: 8px 20px;
+                border-radius: 4px;
+                font-size: 14px;
+            }
+            QPushButton:hover {
+                background-color: #C8C8C8;
+            }
+        """)
+
+        button_layout.addWidget(self.cancel_button)
+        button_layout.addWidget(self.save_button)
+
+        layout.addLayout(button_layout)
         self.setLayout(layout)
 
-    def load_preferences(self):
-        """从服务器加载偏好设置并填充 UI。"""
+    def _create_dates_tab(self) -> QWidget:
+        """创建重要日期标签页"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        # 添加日期区域
+        add_group = QVBoxLayout()
+        add_group.addWidget(QLabel("添加重要日期"))
+
+        # 名称
+        name_layout = QHBoxLayout()
+        name_layout.addWidget(QLabel("名称:"))
+        self.date_name_input = QLineEdit()
+        self.date_name_input.setPlaceholderText("例如：我的生日")
+        name_layout.addWidget(self.date_name_input)
+        add_group.addLayout(name_layout)
+
+        # 日期
+        date_layout = QHBoxLayout()
+        date_layout.addWidget(QLabel("日期:"))
+        self.date_input = QDateEdit()
+        self.date_input.setCalendarPopup(True)
+        self.date_input.setDate(QDate.currentDate())
+        date_layout.addWidget(self.date_input)
+        add_group.addLayout(date_layout)
+
+        # 类型
+        type_layout = QHBoxLayout()
+        type_layout.addWidget(QLabel("类型:"))
+        self.date_type_combo = QComboBox()
+        self.date_type_combo.addItems(["生日", "纪念日", "日程", "其他"])
+        type_layout.addWidget(self.date_type_combo)
+        type_layout.addStretch()
+        add_group.addLayout(type_layout)
+
+        # 提醒消息
+        msg_layout = QHBoxLayout()
+        msg_layout.addWidget(QLabel("提醒消息:"))
+        self.date_message_input = QLineEdit()
+        self.date_message_input.setPlaceholderText("留空则使用默认消息")
+        msg_layout.addWidget(self.date_message_input)
+        add_group.addLayout(msg_layout)
+
+        # 添加按钮
+        add_button = QPushButton("添加日期")
+        add_button.clicked.connect(self.add_important_date)
+        add_group.addWidget(add_button)
+
+        layout.addLayout(add_group)
+
+        # 分隔线
+        line = QFrame()
+        line.setFrameShape(QFrame.Shape.HLine)
+        line.setFrameShadow(QFrame.Shadow.Sunken)
+        layout.addWidget(line)
+
+        # 日期列表
+        layout.addWidget(QLabel("已设置的重要日期:"))
+        self.dates_list = QListWidget()
+        layout.addWidget(self.dates_list)
+
+        # 删除按钮
+        delete_button = QPushButton("删除选中")
+        delete_button.clicked.connect(self.delete_selected_date)
+        layout.addWidget(delete_button)
+
+        widget.setLayout(layout)
+        return widget
+
+    def _create_relationship_tab(self) -> QWidget:
+        """创建相处模式标签页"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        # 关系类型
+        rel_layout = QHBoxLayout()
+        rel_layout.addWidget(QLabel("关系类型:"))
+        self.relationship_combo = QComboBox()
+        self.relationship_combo.addItems(["朋友", "知己", "粉丝", "搭档", "家人", "其他"])
+        self.relationship_combo.setEditable(True)
+        rel_layout.addWidget(self.relationship_combo)
+        rel_layout.addStretch()
+        layout.addLayout(rel_layout)
+
+        # 表达风格
+        style_layout = QHBoxLayout()
+        style_layout.addWidget(QLabel("表达风格:"))
+        self.style_combo = QComboBox()
+        self.style_combo.addItems(["活泼可爱", "温柔可人", "俏皮调皮", "诗意文艺", "热情洋溢", "文静恬淡", "随意自然"])
+        self.style_combo.setEditable(True)
+        style_layout.addWidget(self.style_combo)
+        style_layout.addStretch()
+        layout.addLayout(style_layout)
+
+        # 性格特点
+        layout.addWidget(QLabel("性格特点 (用逗号分隔):"))
+        self.personality_input = QLineEdit()
+        self.personality_input.setPlaceholderText("例如：温柔、耐心、善解人意")
+        layout.addWidget(self.personality_input)
+
+        # 自定义上下文
+        layout.addWidget(QLabel("自定义上下文 (可选):"))
+        self.custom_context_input = QTextEdit()
+        self.custom_context_input.setMaximumHeight(100)
+        self.custom_context_input.setPlaceholderText("在这里添加任何你想让天依知道的关于你们关系的信息...")
+        layout.addWidget(self.custom_context_input)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def _create_reminder_tab(self) -> QWidget:
+        """创建提醒设置标签页"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        # 启用提醒
+        self.enable_reminder_check = QCheckBox("启用重要日期提醒")
+        layout.addWidget(self.enable_reminder_check)
+
+        # 提醒时间
+        time_layout = QHBoxLayout()
+        time_layout.addWidget(QLabel("每天提醒时间:"))
+        self.reminder_time_edit = QTimeEdit()
+        self.reminder_time_edit.setTime(QTime(9, 0))
+        time_layout.addWidget(self.reminder_time_edit)
+        time_layout.addStretch()
+        layout.addLayout(time_layout)
+
+        # 检查间隔
+        interval_layout = QHBoxLayout()
+        interval_layout.addWidget(QLabel("检查间隔 (小时):"))
+        self.interval_spin = QSpinBox()
+        self.interval_spin.setRange(1, 24)
+        self.interval_spin.setValue(1)
+        interval_layout.addWidget(self.interval_spin)
+        interval_layout.addStretch()
+        layout.addLayout(interval_layout)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    # ── Bilibili Cookie 管理 ───────────────────────────────────────
+
+    def _create_bilibili_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        # ── 状态显示 ──
+        status_group = QVBoxLayout()
+        status_group.addWidget(QLabel("Bilibili Cookie 状态"))
+
+        self.bili_status_label = QLabel("点击「检查状态」获取当前 Cookie 信息")
+        self.bili_status_label.setWordWrap(True)
+        self.bili_status_label.setStyleSheet("padding: 8px; background: #f5f5f5; border-radius: 4px;")
+        status_group.addWidget(self.bili_status_label)
+
+        btn_row = QHBoxLayout()
+        check_btn = QPushButton("检查状态")
+        check_btn.clicked.connect(self._bili_check_status)
+        btn_row.addWidget(check_btn)
+
+        refresh_btn = QPushButton("API 续期")
+        refresh_btn.setToolTip("使用 refresh_token 静默续期 SESSDATA")
+        refresh_btn.clicked.connect(self._bili_api_refresh)
+        btn_row.addWidget(refresh_btn)
+        btn_row.addStretch()
+        status_group.addLayout(btn_row)
+        layout.addLayout(status_group)
+
+        # ── 登录方式标签页 ──
+        login_tabs = QTabWidget()
+        login_tabs.addTab(self._create_qr_tab(), "QR 码")
+        login_tabs.addTab(self._create_password_tab(), "账号密码")
+        login_tabs.addTab(self._create_sms_tab(), "手机验证码")
+        login_tabs.addTab(self._create_paste_tab(), "手动粘贴")
+        layout.addWidget(login_tabs)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def _create_qr_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("首次登录 / 获取 refresh_token（Cookie 保存到本地并同步到服务端内存）"))
+
+        self.qr_image_label = QLabel()
+        self.qr_image_label.setFixedSize(200, 200)
+        self.qr_image_label.setStyleSheet("border: 1px solid #ccc; background: white;")
+        self.qr_image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.qr_image_label, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        self.qr_status_label = QLabel("")
+        self.qr_status_label.setWordWrap(True)
+        layout.addWidget(self.qr_status_label)
+
+        start_qr_btn = QPushButton("开始 QR 码登录")
+        start_qr_btn.clicked.connect(self._bili_start_qr_login)
+        layout.addWidget(start_qr_btn)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def _create_password_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("B站账号密码登录（RSA 加密传输）"))
+
+        layout.addWidget(QLabel("账号（手机号/邮箱）:"))
+        self.bili_username_input = QLineEdit()
+        self.bili_username_input.setPlaceholderText("输入 B站 账号")
+        layout.addWidget(self.bili_username_input)
+
+        layout.addWidget(QLabel("密码:"))
+        self.bili_password_input = QLineEdit()
+        self.bili_password_input.setPlaceholderText("输入密码")
+        self.bili_password_input.setEchoMode(QLineEdit.EchoMode.Password)
+        layout.addWidget(self.bili_password_input)
+
+        login_btn = QPushButton("登录")
+        login_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #FB7299; color: white; border: none;
+                padding: 8px 20px; border-radius: 4px; font-size: 14px;
+            }
+            QPushButton:hover { background-color: #E8618A; }
+        """)
+        login_btn.clicked.connect(self._bili_password_login)
+        layout.addWidget(login_btn)
+
+        # 安全提示
+        tips = QLabel(
+            "• 密码经 B站 RSA 公钥加密传输，服务端无法获取明文\n"
+            "• Cookie 保存在本地，使用时才同步到服务端内存，不落盘\n"
+            "• refresh_token 仅用于续期 SESSDATA，无法操作用户账号\n"
+            "• 服务端重启后 Cookie 不会丢失，从本地重新同步即可\n"
+            "• 可随时在 B站「设置-安全设置-登录设备管理」中撤销授权"
+        )
+        tips.setWordWrap(True)
+        tips.setStyleSheet("color: #888; font-size: 12px; padding: 8px; background: #fafafa; border-radius: 4px; margin-top: 12px;")
+        layout.addWidget(tips)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def _create_sms_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("手机验证码登录（需手机号已绑定 B站 账号）"))
+
+        layout.addWidget(QLabel("手机号:"))
+        self.bili_phone_input = QLineEdit()
+        self.bili_phone_input.setPlaceholderText("输入 B站 绑定手机号")
+        layout.addWidget(self.bili_phone_input)
+
+        code_row = QHBoxLayout()
+        self.bili_sms_code_input = QLineEdit()
+        self.bili_sms_code_input.setPlaceholderText("验证码")
+        code_row.addWidget(self.bili_sms_code_input)
+
+        self.bili_sms_send_btn = QPushButton("获取验证码")
+        self.bili_sms_send_btn.clicked.connect(self._bili_sms_send)
+        code_row.addWidget(self.bili_sms_send_btn)
+        layout.addLayout(code_row)
+
+        login_btn = QPushButton("登录")
+        login_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #FB7299; color: white; border: none;
+                padding: 8px 20px; border-radius: 4px; font-size: 14px;
+            }
+            QPushButton:hover { background-color: #E8618A; }
+        """)
+        login_btn.clicked.connect(self._bili_sms_login)
+        layout.addWidget(login_btn)
+
+        # 安全提示
+        tips = QLabel(
+            "• Cookie 保存在本地，使用时才同步到服务端内存，不落盘\n"
+            "• refresh_token 仅用于续期 SESSDATA，无法操作用户账号\n"
+            "• 验证码仅用于本次登录，不会记录\n"
+            "• 服务端重启后 Cookie 不会丢失，从本地重新同步即可\n"
+            "• 可随时在 B站「设置-安全设置-登录设备管理」中撤销授权"
+        )
+        tips.setWordWrap(True)
+        tips.setStyleSheet("color: #888; font-size: 12px; padding: 8px; background: #fafafa; border-radius: 4px; margin-top: 12px;")
+        layout.addWidget(tips)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def _create_paste_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("手动设置 Cookies（从浏览器复制后粘贴）"))
+        layout.addWidget(QLabel("格式: SESSDATA=xxx; bili_jct=xxx; refresh_token=xxx"))
+        self.bili_input = QTextEdit()
+        self.bili_input.setMaximumHeight(80)
+        self.bili_input.setPlaceholderText("从浏览器复制的 Cookie 字符串...")
+        layout.addWidget(self.bili_input)
+
+        set_btn = QPushButton("同步到服务端（本地同时存档）")
+        set_btn.clicked.connect(self._bili_set_cookies)
+        layout.addWidget(set_btn)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def _bili_check_status(self):
+        """检查 Bilibili cookie 状态"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+        status = self.network_client.get_bilibili_cookie_status()
+        error = status.get("error")
+        if error:
+            self.bili_status_label.setText(f"错误: {error}")
+            return
+
+        has = status.get("has_sessdata", False)
+        expiry = status.get("expires_at", "N/A")
+        remaining = status.get("remaining_days")
+        last = status.get("last_refresh", "N/A")
+        needs = status.get("needs_refresh", True)
+        pool_total = status.get("pool_total", 0)
+        pool_valid = status.get("pool_valid", 0)
+
+        remaining_text = f"剩余 {remaining:.1f} 天" if remaining is not None else "未知"
+        lines = [
+            f"{'✅ 有 Cookie' if has else '❌ 无 Cookie'}",
+            f"过期时间: {expiry} ({remaining_text})",
+            f"最后刷新: {last}",
+            f"Cookie 池: {pool_valid}/{pool_total} 组有效",
+            f"{'⚠️ 需要刷新' if needs else '✅ 正常'}",
+        ]
+        self.bili_status_label.setText("\n".join(lines))
+
+    # ── 本地 Cookie 持久化（客户端存储，服务端不落盘） ──
+
+    @staticmethod
+    def _bili_local_path() -> str:
+        import os
+        os.makedirs("data", exist_ok=True)
+        return "data/bilibili_local_cookies.json"
+
+    def _bili_save_local_cookies(self, cookies: dict) -> None:
+        """登录成功后，将 cookies 保存到本地（服务端不落盘）。"""
+        import json
         try:
-            data = self.network_client.get_preferences()
-            if not data:
-                return
-            prefs = data if isinstance(data, dict) else {}
-            if not prefs:
-                return
-
-            rel = prefs.get("relationship", "")
-            if rel:
-                idx = self.relationship_combo.findText(rel, Qt.MatchFlag.MatchFixedString)
-                if idx >= 0:
-                    self.relationship_combo.setCurrentIndex(idx)
-                else:
-                    self.relationship_combo.setEditText(rel)
-
-            style = prefs.get("speaking_style", "")
-            if style:
-                idx = self.style_combo.findText(style, Qt.MatchFlag.MatchFixedString)
-                if idx >= 0:
-                    self.style_combo.setCurrentIndex(idx)
-                else:
-                    self.style_combo.setEditText(style)
-
-            personality_text = prefs.get("#sym:personality_text", "")
-            if personality_text:
-                self.personality_input.setText(personality_text)
-
-            ctx = prefs.get("custom_context", "")
-            if ctx:
-                self.custom_context_input.setPlainText(ctx)
-
-            self.logger.info("偏好设置已从服务器加载")
+            path = self._bili_local_path()
+            existing = {}
+            if Path(path).exists():
+                existing = json.loads(Path(path).read_text(encoding="utf-8"))
+            # 合并新 cookies
+            existing.update(cookies)
+            Path(path).write_text(json.dumps(existing, ensure_ascii=False, indent=2), encoding="utf-8")
+            logger = __import__('logging').getLogger(__name__)
+            logger.info("Bilibili cookies saved locally (client-side)")
         except Exception as e:
-            self.logger.warning(f"从服务器加载偏好设置失败: {e}")
+            print(f"Failed to save local cookies: {e}")
 
-    def get_preferences(self) -> dict:
-        return self._preferences
-
-    def on_save(self):
-        relationship = self.relationship_combo.currentText().strip()
-        speaking_style = self.style_combo.currentText().strip()
-        personality_text = self.personality_input.text().strip()
-        custom_context = self.custom_context_input.toPlainText().strip()
-
-        self._preferences = {
-            "relationship": relationship if relationship and relationship != "朋友" else "",
-            "speaking_style": speaking_style if speaking_style and speaking_style != "活泼可爱" else "",
-            "#sym:personality_text": personality_text,
-            "custom_context": custom_context,
-        }
-
+    def _bili_load_local_cookies(self) -> dict:
+        """从本地加载 cookies。"""
+        import json
         try:
-            resp = self.network_client.overwrite_preferences(self._preferences)
-            if resp.get("status") == "success":
-                QMessageBox.information(self, "成功", "偏好设置已保存")
-                self.accept()
+            path = self._bili_local_path()
+            if Path(path).exists():
+                return json.loads(Path(path).read_text(encoding="utf-8"))
+        except Exception as e:
+            print(f"Failed to load local cookies: {e}")
+        return {}
+
+    def _bili_sync_local_to_server(self) -> bool:
+        """将本地保存的 cookies 发送到服务端内存。"""
+        local = self._bili_load_local_cookies()
+        if not local.get("SESSDATA"):
+            return False
+        if not self.network_client:
+            return False
+        try:
+            resp = self.network_client.session.post(
+                f"{self.network_client.base_url}/api/bilibili/cookie/set",
+                json=local,
+                verify=self.network_client.verify_ssl,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                return True
+        except Exception:
+            pass
+        return False
+
+    def _bili_api_refresh(self):
+        """尝试 API 续期"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+        try:
+            resp = self.network_client.session.post(
+                f"{self.network_client.base_url}/api/bilibili/cookie/refresh",
+                json={},
+                verify=self.network_client.verify_ssl,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("success"):
+                    QMessageBox.information(self, "成功", "API 续期成功！")
+                else:
+                    QMessageBox.warning(self, "提示", "API 续期失败，可能需要 QR 码登录")
             else:
-                QMessageBox.critical(self, "保存失败", resp.get("message", "未知错误"))
+                QMessageBox.warning(self, "错误", f"请求失败: HTTP {resp.status_code}")
         except Exception as e:
-            self.logger.error(f"保存偏好设置失败: {e}")
-            QMessageBox.critical(self, "保存失败", f"无法保存偏好设置: {e}")
+            QMessageBox.warning(self, "错误", f"请求出错: {e}")
+        self._bili_check_status()
+
+    def _bili_start_qr_login(self):
+        """开始 QR 码登录流程"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+
+        result = self.network_client.generate_bilibili_qrcode()
+        error = result.get("error")
+        if error:
+            QMessageBox.warning(self, "错误", f"生成二维码失败: {error}")
+            return
+
+        url = result.get("url", "")
+        qrcode_key = result.get("qrcode_key", "")
+        if not url or not qrcode_key:
+            QMessageBox.warning(self, "错误", "服务端返回的二维码信息不完整")
+            return
+
+        try:
+            import qrcode
+            img = qrcode.make(url)
+            import os
+            os.makedirs("temp", exist_ok=True)
+            img_path = "temp/bilibili_qr.png"
+            img.save(img_path)
+            pixmap = QPixmap(img_path)
+            self.qr_image_label.setPixmap(
+                pixmap.scaled(200, 200, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+            )
+        except ImportError:
+            self.qr_image_label.setText("请扫码:\n" + url)
+        except Exception as e:
+            self.qr_status_label.setText(f"显示二维码失败: {e}")
+
+        self._qr_key = qrcode_key
+        self.qr_status_label.setText("请使用 B站 App 扫描二维码...")
+
+        self._qr_poll_timer = QTimer()
+        self._qr_poll_timer.timeout.connect(self._bili_poll_qr)
+        self._qr_poll_timer.start(2000)
+
+    def _bili_poll_qr(self):
+        """轮询 QR 码扫码结果"""
+        if not self._qr_key or not self.network_client:
+            return
+
+        result = self.network_client.poll_bilibili_qrcode(self._qr_key)
+        status = result.get("status", "error")
+
+        if status == "success":
+            self._qr_poll_timer.stop()
+            self.qr_status_label.setText("✅ 扫码成功！Cookie 已保存到本地")
+            self.qr_image_label.clear()
+            self._bili_save_local_cookies(result.get("cookies", {}))
+            QMessageBox.information(self, "成功", "Bilibili 登录成功！")
+            self._bili_check_status()
+        elif status == "scanned":
+            self.qr_status_label.setText("已扫码，请在手机上确认...")
+        elif status == "expired":
+            self._qr_poll_timer.stop()
+            self.qr_status_label.setText("二维码已过期，请重新生成")
+        elif status == "error":
+            self._qr_poll_timer.stop()
+            self.qr_status_label.setText(f"轮询出错: {result.get('message', '')}")
+
+    def _bili_set_cookies(self):
+        """手动设置 cookies"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+
+        raw = self.bili_input.toPlainText().strip()
+        if not raw:
+            QMessageBox.warning(self, "提示", "请先粘贴 Cookie 字符串")
+            return
+
+        cookies = {}
+        parts = raw.split(";")
+        for part in parts:
+            part = part.strip()
+            if "=" in part:
+                key, _, value = part.partition("=")
+                key = key.strip()
+                value = value.strip()
+                if key in ("SESSDATA", "bili_jct", "bili_ticket", "refresh_token"):
+                    cookies[key] = value
+
+        if not cookies.get("SESSDATA"):
+            QMessageBox.warning(self, "提示", "未找到 SESSDATA，请确认复制的 cookie 字符串正确")
+            return
+
+        result = self.network_client.set_bilibili_cookies(cookies)
+        if result.get("error"):
+            QMessageBox.warning(self, "错误", f"发送失败: {result['error']}")
+        else:
+            QMessageBox.information(self, "成功", "Cookie 已保存到本地")
+            self._bili_save_local_cookies(cookies)
+            self.bili_input.clear()
+            self._bili_check_status()
+
+    @staticmethod
+    def _bili_encrypt_password(password: str, hash_str: str, pub_key: str) -> str:
+        """用 B站 RSA 公钥加密密码（客户端本地加密，不向服务端发送明文）。"""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+        from cryptography.hazmat.backends import default_backend
+        import base64
+
+        public_key = serialization.load_pem_public_key(pub_key.encode(), backend=default_backend())
+        encrypted = public_key.encrypt(
+            (hash_str + password).encode(),
+            padding.PKCS1v15(),
+        )
+        return base64.b64encode(encrypted).decode()
+
+    def _bili_password_login(self):
+        """B站账号密码登录（客户端 RSA 加密后发送，服务端不接触明文）"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+
+        username = self.bili_username_input.text().strip()
+        password = self.bili_password_input.text()
+        if not username or not password:
+            QMessageBox.warning(self, "提示", "请填写账号和密码")
+            return
+
+        try:
+            # 1. 获取 RSA 公钥
+            key_resp = self.network_client.session.get(
+                f"{self.network_client.base_url}/api/bilibili/cookie/login/key",
+                verify=self.network_client.verify_ssl,
+                timeout=15,
+            )
+            if key_resp.status_code != 200:
+                QMessageBox.warning(self, "错误", "获取加密密钥失败")
+                return
+            key_data = key_resp.json()
+            pub_key = key_data.get("key", "")
+            hash_str = key_data.get("hash", "")
+            if not pub_key or not hash_str:
+                QMessageBox.warning(self, "错误", "服务端返回的密钥数据不完整")
+                return
+
+            # 2. 本地 RSA 加密密码
+            encrypted_password = self._bili_encrypt_password(password, hash_str, pub_key)
+
+            # 3. 发送加密后的密码到服务端
+            resp = self.network_client.session.post(
+                f"{self.network_client.base_url}/api/bilibili/cookie/login/password",
+                json={"username": username, "encrypted_password": encrypted_password},
+                verify=self.network_client.verify_ssl,
+                timeout=30,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("success"):
+                    QMessageBox.information(self, "成功", "Bilibili 登录成功！Cookie 已保存到本地")
+                    self._bili_save_local_cookies(data.get("cookies", {}))
+                    self.bili_username_input.clear()
+                    self.bili_password_input.clear()
+                    self._bili_check_status()
+                else:
+                    QMessageBox.warning(self, "登录失败", data.get("message", "账号或密码错误"))
+            else:
+                QMessageBox.warning(self, "错误", f"请求失败: HTTP {resp.status_code}")
+        except Exception as e:
+            QMessageBox.warning(self, "错误", f"请求出错: {e}")
+
+    def _bili_sms_send(self):
+        """发送短信验证码"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+
+        phone = self.bili_phone_input.text().strip()
+        if not phone:
+            QMessageBox.warning(self, "提示", "请输入手机号")
+            return
+
+        try:
+            resp = self.network_client.session.post(
+                f"{self.network_client.base_url}/api/bilibili/cookie/login/sms/send",
+                json={"phone": phone, "country_code": "86"},
+                verify=self.network_client.verify_ssl,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("success"):
+                    QMessageBox.information(self, "已发送", "验证码已发送到您的手机")
+                    self.bili_sms_send_btn.setEnabled(False)
+                    QTimer.singleShot(60000, lambda: self.bili_sms_send_btn.setEnabled(True))
+                else:
+                    QMessageBox.warning(self, "发送失败", data.get("message", "未知错误"))
+            else:
+                QMessageBox.warning(self, "错误", f"请求失败: HTTP {resp.status_code}")
+        except Exception as e:
+            QMessageBox.warning(self, "错误", f"请求出错: {e}")
+
+    def _bili_sms_login(self):
+        """短信验证码登录"""
+        if not self.network_client:
+            QMessageBox.warning(self, "提示", "网络客户端未初始化")
+            return
+
+        phone = self.bili_phone_input.text().strip()
+        code = self.bili_sms_code_input.text().strip()
+        if not phone or not code:
+            QMessageBox.warning(self, "提示", "请填写手机号和验证码")
+            return
+
+        try:
+            resp = self.network_client.session.post(
+                f"{self.network_client.base_url}/api/bilibili/cookie/login/sms",
+                json={"phone": phone, "code": code, "country_code": "86"},
+                verify=self.network_client.verify_ssl,
+                timeout=30,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("success"):
+                    QMessageBox.information(self, "成功", "Bilibili 登录成功！Cookie 已保存到本地")
+                    self._bili_save_local_cookies(data.get("cookies", {}))
+                    self.bili_phone_input.clear()
+                    self.bili_sms_code_input.clear()
+                    self._bili_check_status()
+                else:
+                    QMessageBox.warning(self, "登录失败", data.get("message", "未知错误"))
+            else:
+                QMessageBox.warning(self, "错误", f"请求失败: HTTP {resp.status_code}")
+        except Exception as e:
+            QMessageBox.warning(self, "错误", f"请求出错: {e}")
+
+    def load_current_settings(self):
+        """加载当前设置"""
+        # 加载重要日期
+        dates = self.preferences_manager.get_important_dates()
+        self.dates_list.clear()
+        for date_info in dates:
+            enabled = "✓" if date_info.get("enabled", True) else "✗"
+            item_text = f"{enabled} {date_info['name']} - {date_info['date']} ({date_info['type']})"
+            item = QListWidgetItem(item_text)
+            item.setData(Qt.ItemDataRole.UserRole, date_info.get("id"))
+            self.dates_list.addItem(item)
+
+        # 加载相处模式
+        mode = self.preferences_manager.get_relationship_mode()
+        relationship = mode.get("relationship", "朋友")
+        speaking_style = mode.get("speaking_style", "活泼可爱")
+        personality_traits = mode.get("personality_traits", [])
+        custom_context = mode.get("custom_context", "")
+
+        # 设置关系类型
+        index = self.relationship_combo.findText(relationship)
+        if index >= 0:
+            self.relationship_combo.setCurrentIndex(index)
+        else:
+            self.relationship_combo.setCurrentText(relationship)
+
+        # 设置表达风格
+        index = self.style_combo.findText(speaking_style)
+        if index >= 0:
+            self.style_combo.setCurrentIndex(index)
+        else:
+            self.style_combo.setCurrentText(speaking_style)
+
+        # 设置性格特点
+        self.personality_input.setText("、".join(personality_traits))
+
+        # 设置自定义上下文
+        self.custom_context_input.setText(custom_context)
+
+        # 加载提醒设置
+        reminder_settings = self.preferences_manager.get_reminder_settings()
+        self.enable_reminder_check.setChecked(reminder_settings.get("enable_reminders", True))
+
+        reminder_time = reminder_settings.get("reminder_time", "09:00")
+        time_parts = reminder_time.split(":")
+        self.reminder_time_edit.setTime(QTime(int(time_parts[0]), int(time_parts[1])))
+
+        self.interval_spin.setValue(reminder_settings.get("check_interval_hours", 1))
+
+    def add_important_date(self):
+        """添加重要日期"""
+        name = self.date_name_input.text().strip()
+        if not name:
+            QMessageBox.warning(self, "警告", "请输入日期名称！")
+            return
+
+        date = self.date_input.date().toString("yyyy-MM-dd")
+        type_map = {"生日": "birthday", "纪念日": "anniversary", "日程": "schedule", "其他": "other"}
+        date_type = type_map.get(self.date_type_combo.currentText(), "other")
+        message = self.date_message_input.text().strip()
+
+        if self.preferences_manager.add_important_date(name, date, date_type, message):
+            self.date_name_input.clear()
+            self.date_message_input.clear()
+            self.load_current_settings()  # 刷新列表
+            QMessageBox.information(self, "成功", "重要日期已添加！")
+        else:
+            QMessageBox.warning(self, "错误", "添加重要日期失败！")
+
+    def delete_selected_date(self):
+        """删除选中的重要日期"""
+        selected_items = self.dates_list.selectedItems()
+        if not selected_items:
+            QMessageBox.warning(self, "警告", "请先选择要删除的日期！")
+            return
+
+        for item in selected_items:
+            date_id = item.data(Qt.ItemDataRole.UserRole)
+            self.preferences_manager.remove_important_date(date_id)
+
+        self.load_current_settings()  # 刷新列表
+        QMessageBox.information(self, "成功", "已删除选中的日期！")
+
+    def save_settings(self):
+        """保存所有设置"""
+        try:
+            # 保存相处模式
+            relationship = self.relationship_combo.currentText()
+            speaking_style = self.style_combo.currentText()
+            personality_traits = [t.strip() for t in self.personality_input.text().split("、") if t.strip()]
+            custom_context = self.custom_context_input.toPlainText().strip()
+
+            self.preferences_manager.set_relationship_mode(
+                relationship=relationship,
+                speaking_style=speaking_style,
+                personality_traits=personality_traits,
+                custom_context=custom_context
+            )
+
+            # 保存提醒设置
+            enable_reminders = self.enable_reminder_check.isChecked()
+            reminder_time = self.reminder_time_edit.time().toString("HH:mm")
+            check_interval = self.interval_spin.value()
+
+            self.preferences_manager.set_reminder_settings(
+                enable_reminders=enable_reminders,
+                reminder_time=reminder_time,
+                check_interval_hours=check_interval
+            )
+
+            # 同步偏好到服务端
+            if self.agent_binder and hasattr(self.agent_binder, 'on_send_preferences'):
+                preferences_data = {
+                    "relationship": relationship,
+                    "speaking_style": speaking_style,
+                    "personality_traits": personality_traits,
+                    "custom_context": custom_context,
+                }
+                self.agent_binder.on_send_preferences(preferences_data)
+
+            QMessageBox.information(self, "成功", "设置已保存！")
+            self.accept()
+
+        except Exception as e:
+            QMessageBox.warning(self, "错误", f"保存设置失败: {e}")

--- a/client/src/network/network_client.py
+++ b/client/src/network/network_client.py
@@ -266,7 +266,7 @@ class NetworkClient:
                 f.write(resp.content)
 
             item.content = new_file_path
-            
+
 
             payload.update({"image_client_path": item.content})
             update_resp = self.session.post(
@@ -283,3 +283,63 @@ class NetworkClient:
             self.logger.error(f"Failed to retrieve image for history item {item.uuid}: {exc}")
         finally:
             return item
+
+    # ── Bilibili Cookie API ─────────────────────────────────
+
+    def get_bilibili_cookie_status(self) -> dict:
+        """查询 Bilibili cookie 当前状态。"""
+        try:
+            resp = self.session.get(
+                f"{self.base_url}/api/bilibili/cookie/status",
+                verify=self.verify_ssl,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            return {"error": f"HTTP {resp.status_code}"}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    def set_bilibili_cookies(self, cookies: dict) -> dict:
+        """手动设置 Bilibili cookies 到服务端。"""
+        try:
+            resp = self.session.post(
+                f"{self.base_url}/api/bilibili/cookie/set",
+                json=cookies,
+                verify=self.verify_ssl,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            return {"error": f"HTTP {resp.status_code}"}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    def generate_bilibili_qrcode(self) -> dict:
+        """让服务端生成 B站 登录二维码，返回 {'url': ..., 'qrcode_key': ...}"""
+        try:
+            resp = self.session.post(
+                f"{self.base_url}/api/bilibili/cookie/qrcode/generate",
+                verify=self.verify_ssl,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            return {"error": f"HTTP {resp.status_code}"}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    def poll_bilibili_qrcode(self, qrcode_key: str) -> dict:
+        """轮询 QR 码扫码结果。"""
+        try:
+            resp = self.session.post(
+                f"{self.base_url}/api/bilibili/cookie/qrcode/poll",
+                json={"qrcode_key": qrcode_key},
+                verify=self.verify_ssl,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            return {"status": "error", "message": f"HTTP {resp.status_code}"}
+        except Exception as exc:
+            return {"status": "error", "message": str(exc)}

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -45,7 +45,7 @@
             },
             "prompt_name": "date_detection_prompt"
         }
-        
+
     },
     "topic_extractor": {
         "llm_module": {
@@ -321,10 +321,14 @@
             "mention_cooldown_hours": 6
         },
         "silence": {
-            "concert_pre_start_minutes": 60,
-            "concert_post_end_minutes": 30
-        },
-        "official_accounts": {}
-        
+            "concert_pre_start_minutes": 30,
+            "concert_post_end_minutes": 60
+        }
+    },
+    "bilibili_cookie": {
+        "sessdata_refresh_threshold_days": 7,
+        "ticket_refresh_threshold_hours": 2,
+        "check_interval_seconds": 3600,
+        "qrcode_image_path": "data/bilibili/qrcode.png"
     }
 }

--- a/server/server_main.py
+++ b/server/server_main.py
@@ -40,6 +40,7 @@ from src.plugins import DailyScheduler
 from src.plugins.citywalk import CitywalkRuntimeService
 from src.plugins.schedule import ScheduleManager
 from src.plugins.music.auto_song_learner import AutoSongLearner
+from src.plugins.bilibili_cookie_manager import BilibiliCookieManager
 
 from src.utils.helpers import load_config
 from src.utils.logger import get_logger
@@ -50,7 +51,7 @@ config = load_config("config/config.json")
 
 service_hub = None  # 全局 ServiceHub 实例，在 startup_event 中初始化
 daily_scheduler: DailyScheduler | None = None
-
+bili_cookie_manager: BilibiliCookieManager | None = None
 
 @asynccontextmanager
 async def startup_event(app: FastAPI):
@@ -106,6 +107,17 @@ async def startup_event(app: FastAPI):
     )
     daily_scheduler.start()
 
+    # 初始化 Bilibili Cookie 管理器（后台监控）
+    global bili_cookie_manager
+    bili_cookie_cfg = config.get("bilibili_cookie", {})
+    bili_cookie_manager = BilibiliCookieManager(
+        sessdata_threshold_days=bili_cookie_cfg.get("sessdata_refresh_threshold_days", 7),
+        ticket_threshold_hours=bili_cookie_cfg.get("ticket_refresh_threshold_hours", 2),
+        check_interval_seconds=bili_cookie_cfg.get("check_interval_seconds", 3600),
+        qrcode_image_path=bili_cookie_cfg.get("qrcode_image_path", "data/bilibili/qrcode.png"),
+    )
+    # 不启动后台监控，由客户端主动检查状态、决定何时刷新
+
     # 账号系统初始化
     account.generate_keys()
     try:
@@ -113,6 +125,8 @@ async def startup_event(app: FastAPI):
     finally:
         if daily_scheduler is not None:
             daily_scheduler.stop()
+        if bili_cookie_manager is not None:
+            pass  # 由客户端管理刷新时机
         if service_hub and service_hub.schedule_manager:
             service_hub.schedule_manager.stop()
         await service_hub.gcsm.stop_cleanup_task()
@@ -417,6 +431,127 @@ async def update_image_client_path(request: ImageRequest, db: Session = Depends(
         raise HTTPException(status_code=400, detail="更新失败，记录不存在或无权限访问")
 
     return {"message": "更新成功"}
+
+
+# ── Bilibili Cookie 管理 API ─────────────────────────────────
+
+
+@app.post("/api/bilibili/cookie/refresh")
+async def bili_cookie_refresh():
+    """手动触发 Bilibili cookie 刷新（自动尝试 API 续期 → QR 码登录）。"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    result = await bili_cookie_manager.manual_refresh()
+    return result
+
+
+@app.get("/api/bilibili/cookie/status")
+async def bili_cookie_status():
+    """查看 Bilibili cookie 当前状态。"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    return bili_cookie_manager.get_status()
+
+
+@app.post("/api/bilibili/cookie/qrcode/generate")
+async def bili_cookie_qrcode_generate():
+    """生成 B站 登录二维码，返回 url 和 qrcode_key（客户端自行显示二维码）。"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    result = bili_cookie_manager.generate_qrcode_for_client()
+    if not result:
+        raise HTTPException(status_code=500, detail="Failed to generate QR code")
+    return result
+
+
+@app.post("/api/bilibili/cookie/qrcode/poll")
+async def bili_cookie_qrcode_poll(body: Dict[str, str]):
+    """轮询 QR 码扫码结果。请求体: {"qrcode_key": "xxx"}"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    qrcode_key = body.get("qrcode_key", "")
+    if not qrcode_key:
+        raise HTTPException(status_code=400, detail="Missing qrcode_key")
+    return bili_cookie_manager.poll_qrcode_for_client(qrcode_key)
+
+
+@app.get("/api/bilibili/cookie/login/key")
+async def bili_cookie_login_key():
+    """获取 Bilibili RSA 公钥（客户端本地加密用）。"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    result = bili_cookie_manager.get_login_key()
+    if not result:
+        raise HTTPException(status_code=502, detail="Failed to fetch key from Bilibili")
+    return result
+
+
+@app.post("/api/bilibili/cookie/login/password")
+async def bili_cookie_login_password(body: Dict[str, str]):
+    """使用 B站 账号密码登录（密码需由客户端用 RSA 公钥加密）。
+
+    请求体: {"username": "...", "encrypted_password": "..."}
+    """
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    username = body.get("username", "")
+    encrypted_password = body.get("encrypted_password", "")
+    if not username or not encrypted_password:
+        raise HTTPException(status_code=400, detail="Missing username or encrypted_password")
+    result = bili_cookie_manager.login_with_encrypted_password(username, encrypted_password)
+    return result
+
+
+@app.post("/api/bilibili/cookie/login/sms/send")
+async def bili_cookie_sms_send(body: Dict[str, str]):
+    """发送 B站 短信验证码。请求体: {"phone": "138xxxx", "country_code": "86"}"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    phone = body.get("phone", "")
+    country_code = body.get("country_code", "86")
+    if not phone:
+        raise HTTPException(status_code=400, detail="Missing phone")
+    return bili_cookie_manager.send_sms_code(phone, country_code)
+
+
+@app.post("/api/bilibili/cookie/login/sms")
+async def bili_cookie_sms_login(body: Dict[str, str]):
+    """使用短信验证码登录 B站。请求体: {"phone": "138xxxx", "code": "123456", "country_code": "86"}"""
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    phone = body.get("phone", "")
+    code = body.get("code", "")
+    country_code = body.get("country_code", "86")
+    if not phone or not code:
+        raise HTTPException(status_code=400, detail="Missing phone or code")
+    return bili_cookie_manager.login_with_sms(phone, code, country_code)
+
+
+@app.post("/api/bilibili/cookie/set")
+async def bili_cookie_set(body: Dict[str, str]):
+    """手动设置 Bilibili cookies。
+
+    请求体示例:
+    {
+        "SESSDATA": "xxx",
+        "bili_jct": "xxx",
+        "refresh_token": "xxx",
+        "bili_ticket": "xxx"
+    }
+    """
+    global bili_cookie_manager
+    if bili_cookie_manager is None:
+        raise HTTPException(status_code=503, detail="Cookie manager not initialized")
+    bili_cookie_manager.set_cookies(body)
+    return {"status": "ok", "message": "Cookies saved"}
 
 
 if __name__ == "__main__":

--- a/server/src/plugins/bilibili_cookie_manager.py
+++ b/server/src/plugins/bilibili_cookie_manager.py
@@ -1,0 +1,639 @@
+"""
+Bilibili Cookie 管理器
+
+不依赖浏览器，全部通过 Bilibili API 完成：
+1. refresh_token 自动续期 SESSDATA（静默，无需用户操作）
+2. QR 码登录（首次或无 refresh_token 时）：生成二维码保存为图片，轮询等待扫码
+3. 手动导入 cookie（通过 API / CLI）
+
+Cookie 仅在服务端内存中暂存（不落盘），由客户端自行持久化。
+支持多组 Cookie 共存，供 Bilibili API 调用时随机选取。
+
+依赖: requests, Pillow (可选，用于生成二维码图片)
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import threading
+import time
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+BILI_PASSPORT = "https://passport.bilibili.com/x/passport-login/web"
+BILI_OAUTH2 = "https://passport.bilibili.com/x/passport-login/oauth2"
+
+
+# ── Cookie 数据模型 ─────────────────────────────────────────────
+
+
+@dataclass
+class BilibiliCookies:
+    """Bilibili cookie 存储结构。"""
+
+    SESSDATA: str = ""
+    bili_jct: str = ""
+    bili_ticket: str = ""
+    refresh_token: str = ""
+    expires_at: Optional[str] = None          # SESSDATA 过期时间
+    ticket_expires_at: Optional[str] = None    # bili_ticket 过期时间
+    last_refresh: Optional[str] = None
+    source: str = "unknown"                    # 来源标识（password_login / sms_login / qrcode / manual / api_refresh）
+    extras: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_sessdata_valid(self) -> bool:
+        if not self.SESSDATA or not self.expires_at:
+            return False
+        try:
+            return datetime.fromisoformat(self.expires_at) > datetime.now()
+        except (ValueError, TypeError):
+            return False
+
+    @property
+    def is_valid(self) -> bool:
+        return self.is_sessdata_valid
+
+    @property
+    def sessdata_remaining_days(self) -> Optional[float]:
+        if not self.expires_at:
+            return None
+        try:
+            return (datetime.fromisoformat(self.expires_at) - datetime.now()).total_seconds() / 86400
+        except (ValueError, TypeError):
+            return None
+
+    def to_dict(self) -> Dict[str, str]:
+        return {k: v for k, v in asdict(self).items() if v}
+
+
+# ── Cookie 解码 ─────────────────────────────────────────────
+
+
+def decode_sessdata(sessdata: str) -> Optional[int]:
+    """解码 Bilibili SESSDATA，返回过期时间戳（秒）。
+
+    SESSDATA 格式: {user_id_hex},{expiry_timestamp},{secret}
+    原始字符串中逗号被编码为 %2C，解码后以逗号分隔三部分。
+    """
+    try:
+        from urllib.parse import unquote
+        decoded = unquote(sessdata)
+        parts = decoded.split(",")
+        if len(parts) >= 2:
+            return int(parts[1])
+        return None
+    except (ValueError, IndexError, Exception) as e:
+        logger.debug(f"Failed to decode SESSDATA: {e}")
+        return None
+
+
+def make_session() -> requests.Session:
+    """创建一个模仿浏览器的 requests Session。"""
+    s = requests.Session()
+    s.headers.update({
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.6099.71 Safari/537.36"
+        ),
+        "Referer": "https://www.bilibili.com/",
+    })
+    return s
+
+
+# ── Cookie 管理器 ─────────────────────────────────────────────
+
+
+class BilibiliCookieManager:
+    """管理 Bilibili cookies 的 API 登录、刷新和状态检查。
+
+    Cookie 仅保存在服务端内存中，不写入磁盘。
+    可同时持有来自不同客户端的多组 Cookie，
+    在需要调用 Bilibili API 时随机选取一组。
+    """
+
+    def __init__(
+        self,
+        sessdata_threshold_days: int = 7,
+        ticket_threshold_hours: int = 2,
+        check_interval_seconds: int = 3600,
+        qrcode_image_path: str = "data/bilibili/qrcode.png",
+    ):
+        self.sessdata_threshold_days = sessdata_threshold_days
+        self.ticket_threshold_hours = ticket_threshold_hours
+        self.check_interval = check_interval_seconds
+        self.qrcode_image_path = qrcode_image_path
+
+        # 多组 Cookie 集合（仅内存，不落盘）
+        self._cookie_sets: List[BilibiliCookies] = []
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._session = make_session()
+
+        logger.info("BilibiliCookieManager initialized (in-memory only, no file persistence)")
+
+    # ── 内部工具 ─────────────────────────────────────────────
+
+    @staticmethod
+    def _apply_dict(c: BilibiliCookies, data: Dict[str, str]) -> None:
+        """将 dict 数据写入 BilibiliCookies 实例。"""
+        c.SESSDATA = data.get("SESSDATA", c.SESSDATA)
+        c.bili_jct = data.get("bili_jct", c.bili_jct)
+        c.bili_ticket = data.get("bili_ticket", c.bili_ticket)
+        c.refresh_token = data.get("refresh_token", c.refresh_token)
+
+        if c.SESSDATA:
+            ts = decode_sessdata(c.SESSDATA)
+            if ts:
+                c.expires_at = datetime.fromtimestamp(ts).isoformat()
+
+        c.last_refresh = datetime.now().isoformat()
+
+        known = {"SESSDATA", "bili_jct", "bili_ticket", "refresh_token"}
+        for k, v in data.items():
+            if k not in known and v:
+                c.extras[k] = v
+
+    def _add_set(self, data: Dict[str, str], source: str) -> BilibiliCookies:
+        """创建一组新 Cookie 并加入内存池。"""
+        c = BilibiliCookies(source=source)
+        self._apply_dict(c, data)
+        with self._lock:
+            self._cookie_sets.append(c)
+        logger.info("Cookie set added (source=%s, total=%d)", source, len(self._cookie_sets))
+        return c
+
+    def _get_valid_sets(self) -> List[BilibiliCookies]:
+        """获取所有有效的 Cookie 集合（线程安全）。"""
+        with self._lock:
+            return [c for c in self._cookie_sets if c.is_sessdata_valid and c.SESSDATA]
+
+    # ── Cookie 存取 ─────────────────────────────────────────────
+
+    def get_cookies(self) -> Dict[str, str]:
+        """随机选取一组有效的 Cookie。
+
+        供 OfficialFeedFetcher 等模块调用 Bilibili API 时使用。
+        """
+        valid = self._get_valid_sets()
+        if not valid:
+            logger.debug("No valid cookie sets available")
+            return {}
+        chosen = random.choice(valid)
+        result = {"SESSDATA": chosen.SESSDATA, "bili_jct": chosen.bili_jct}
+        if chosen.bili_ticket:
+            result["bili_ticket"] = chosen.bili_ticket
+        result.update(chosen.extras)
+        return {k: v for k, v in result.items() if v}
+
+    def set_cookies(self, cookies: Dict[str, str], source: str = "manual") -> None:
+        """手动导入 cookies（从外部粘贴等）。"""
+        self._add_set(cookies, source)
+        logger.info("Bilibili cookies updated manually (source=%s)", source)
+
+    # ── 刷新 Cookie（使用 refresh_token） ──────────────────
+
+    def refresh_via_api(self) -> bool:
+        """随机选取一个有 refresh_token 的 Cookie 集合，通过 Bilibili OAuth2 API 续期。
+
+        返回 True 表示至少有一组刷新成功。
+        """
+        with self._lock:
+            candidates = [(i, c) for i, c in enumerate(self._cookie_sets) if c.refresh_token]
+
+        if not candidates:
+            logger.info("No refresh_token available in any cookie set")
+            return False
+
+        idx, chosen = random.choice(candidates)
+        logger.info("Attempting to refresh SESSDATA via refresh_token API (set #%d)...", idx)
+        try:
+            resp = self._session.post(
+                f"{BILI_OAUTH2}/refresh_token",
+                data={"refresh_token": chosen.refresh_token},
+                timeout=15,
+            )
+            data = resp.json()
+            if data.get("code") != 0:
+                logger.warning(
+                    "refresh_token API error: %s (code=%s)",
+                    data.get("message", "unknown"),
+                    data.get("code"),
+                )
+                return False
+
+            token_info = data.get("data", {}).get("token_info", {})
+            if not token_info:
+                logger.warning("refresh_token response missing token_info")
+                return False
+
+            new_cookies = {
+                "SESSDATA": token_info.get("sessdata", ""),
+                "bili_jct": token_info.get("bili_jct", ""),
+                "refresh_token": token_info.get("refresh_token", chosen.refresh_token),
+            }
+
+            with self._lock:
+                if idx < len(self._cookie_sets):
+                    self._apply_dict(self._cookie_sets[idx], new_cookies)
+            logger.info("SESSDATA refreshed successfully via API (set #%d)", idx)
+            return True
+
+        except requests.RequestException as e:
+            logger.error(f"refresh_token API request failed: {e}")
+            return False
+
+    # ── QR 码登录 ──────────────────────────────────────────
+
+    def generate_qrcode(self) -> Optional[Dict[str, Any]]:
+        """生成 B站 登录二维码，返回 {'url': ..., 'qrcode_key': ...}。
+
+        二维码图片会保存到 self.qrcode_image_path。
+        """
+        try:
+            resp = self._session.get(
+                f"{BILI_PASSPORT}/qrcode/generate",
+                timeout=15,
+            )
+            data = resp.json()
+            if data.get("code") != 0:
+                logger.error("QR code generate failed: %s", data.get("message"))
+                return None
+
+            result = data.get("data", {})
+            url = result.get("url", "")
+            qrcode_key = result.get("qrcode_key", "")
+
+            if not url or not qrcode_key:
+                logger.error("QR code generate response missing url or qrcode_key")
+                return None
+
+            self._save_qrcode_image(url)
+            return {"url": url, "qrcode_key": qrcode_key}
+
+        except requests.RequestException as e:
+            logger.error(f"QR code generate request failed: {e}")
+            return None
+
+    def _save_qrcode_image(self, url: str) -> None:
+        """将二维码 URL 生成图片保存到本地。"""
+        qr_path = Path(self.qrcode_image_path)
+        qr_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            import qrcode
+            img = qrcode.make(url)
+            img.save(qr_path)
+            logger.info("QR code image saved to %s", qr_path)
+        except ImportError:
+            logger.info(
+                "QR code URL: %s\n"
+                "Install 'qrcode' (pip install qrcode[pil]) to auto-save as image. "
+                "For now, open this URL or scan it with your phone.",
+                url,
+            )
+
+    def poll_qrcode_login(self, qrcode_key: str, timeout: int = 120) -> bool:
+        """轮询 QR 码扫码结果。
+
+        Args:
+            qrcode_key: QR 码的 key（由 generate_qrcode 返回）
+            timeout: 最长等待秒数（默认 120）
+
+        Returns:
+            True 表示登录成功，cookies 已加入内存池
+        """
+        logger.info("Polling QR code scan result (timeout=%ds)...", timeout)
+        start_time = time.time()
+        poll_interval = 2
+
+        while time.time() - start_time < timeout:
+            try:
+                resp = self._session.get(
+                    f"{BILI_PASSPORT}/qrcode/poll",
+                    params={"qrcode_key": qrcode_key},
+                    timeout=10,
+                )
+                data = resp.json()
+                code = data.get("code", -1)
+
+                if code == 0:
+                    login_data = data.get("data", {})
+                    cookie_data = {
+                        "SESSDATA": login_data.get("sessdata", ""),
+                        "bili_jct": login_data.get("bili_jct", ""),
+                        "refresh_token": login_data.get("refresh_token", ""),
+                    }
+                    for c in login_data.get("set_cookies", []):
+                        if c.get("name") in ("bili_ticket",):
+                            cookie_data[c["name"]] = c.get("value", "")
+
+                    self._add_set(cookie_data, source="qrcode_login")
+                    logger.info("QR code login successful! Cookies added to pool.")
+                    return True
+
+                elif code == 86101:
+                    elapsed = int(time.time() - start_time)
+                    if elapsed % 10 == 0:
+                        logger.info("Waiting for QR code scan... (%ds elapsed)", elapsed)
+
+                elif code == 86090:
+                    logger.info("QR code scanned, waiting for confirmation...")
+
+                elif code == 86038:
+                    logger.warning("QR code expired, need to generate a new one")
+                    return False
+
+                else:
+                    logger.warning("QR code poll unknown code=%s: %s", code, data)
+
+            except requests.RequestException as e:
+                logger.error(f"QR code poll request failed: {e}")
+
+            time.sleep(poll_interval)
+
+        logger.warning("QR code login timeout after %d seconds", timeout)
+        return False
+
+    # ── 供客户端驱动的 QR 登录 ─────────────────────────────
+
+    def generate_qrcode_for_client(self) -> Optional[Dict[str, Any]]:
+        """生成 QR 码并返回 url 和 key（客户端自行显示二维码）。"""
+        return self.generate_qrcode()
+
+    def poll_qrcode_for_client(self, qrcode_key: str) -> Dict[str, Any]:
+        """客户端驱动 QR 码轮询：将结果中的 cookies 加入内存池。
+
+        Returns:
+            {"status": "waiting"|"scanned"|"success"|"expired"|"error",
+             "message": "...",
+             "cookies": {...}}  # 仅 success 时有
+        """
+        try:
+            resp = self._session.get(
+                f"{BILI_PASSPORT}/qrcode/poll",
+                params={"qrcode_key": qrcode_key},
+                timeout=10,
+            )
+            data = resp.json()
+            code = data.get("code", -1)
+
+            if code == 0:
+                login_data = data.get("data", {})
+                cookie_data = {
+                    "SESSDATA": login_data.get("sessdata", ""),
+                    "bili_jct": login_data.get("bili_jct", ""),
+                    "refresh_token": login_data.get("refresh_token", ""),
+                }
+                for c in login_data.get("set_cookies", []):
+                    if c.get("name") in ("bili_ticket",):
+                        cookie_data[c["name"]] = c.get("value", "")
+
+                self._add_set(cookie_data, source="qrcode_client")
+
+                return {"status": "success", "message": "扫码成功", "cookies": cookie_data}
+            elif code == 86101:
+                return {"status": "waiting", "message": "等待扫码"}
+            elif code == 86090:
+                return {"status": "scanned", "message": "已扫码，请在手机上确认"}
+            elif code == 86038:
+                return {"status": "expired", "message": "二维码已过期"}
+            else:
+                return {"status": "error", "message": f"未知状态 code={code}"}
+        except requests.RequestException as e:
+            return {"status": "error", "message": f"请求失败: {e}"}
+
+    # ── 密码 / 短信登录 ─────────────────────────────────
+
+    @staticmethod
+    def _bili_encrypt_password(password: str, hash_str: str, pub_key: str) -> Optional[str]:
+        """用 B站 RSA 公钥加密密码。"""
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+            from cryptography.hazmat.backends import default_backend
+            import base64
+
+            public_key = serialization.load_pem_public_key(pub_key.encode(), backend=default_backend())
+            encrypted = public_key.encrypt(
+                (hash_str + password).encode(),
+                asym_padding.PKCS1v15(),
+            )
+            return base64.b64encode(encrypted).decode()
+        except Exception as e:
+            logger.error(f"RSA encrypt failed: {e}")
+            return None
+
+    def get_login_key(self) -> Optional[Dict[str, str]]:
+        """获取 Bilibili RSA 公钥，供客户端本地加密使用。"""
+        try:
+            resp = self._session.get(f"{BILI_PASSPORT}/web/key", timeout=15)
+            data = resp.json()
+            if data.get("code") != 0:
+                logger.error("Failed to get login key: %s", data.get("message"))
+                return None
+            key_data = data.get("data", {})
+            pub_key = key_data.get("key", "")
+            hash_str = key_data.get("hash", "")
+            if not pub_key or not hash_str:
+                logger.error("Login key response missing key or hash")
+                return None
+            return {"key": pub_key, "hash": hash_str}
+        except requests.RequestException as e:
+            logger.error(f"Failed to get login key: {e}")
+            return None
+
+    def login_with_encrypted_password(self, username: str, encrypted_password: str) -> Dict[str, Any]:
+        """使用客户端已加密的密码登录 B站。
+
+        客户端从 get_login_key() 获取公钥后自行 RSA 加密，
+        服务端仅做转发，不接触密码明文。
+        """
+        logger.info("Processing client-encrypted password login...")
+        try:
+            resp = self._session.post(
+                f"{BILI_PASSPORT}/web/login",
+                data={
+                    "username": username,
+                    "password": encrypted_password,
+                    "keep": "1",
+                    "source": "main_web",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=15,
+            )
+            login_data = resp.json()
+
+            if login_data.get("code") != 0:
+                msg = login_data.get("message", "登录失败")
+                if login_data.get("code") == -449:
+                    return {"success": False, "message": "需要验证码，请改用短信登录或 QR 码"}
+                return {"success": False, "message": msg}
+
+            cookie_dict = {}
+            for c in resp.cookies:
+                if c.name in ("SESSDATA", "bili_jct", "refresh_token", "bili_ticket"):
+                    cookie_dict[c.name] = c.value
+
+            if cookie_dict.get("SESSDATA"):
+                self._add_set(cookie_dict, source="password_login")
+                logger.info("Client-encrypted password login successful")
+                return {"success": True, "message": "登录成功", "cookies": cookie_dict}
+            return {"success": False, "message": "响应中未包含 SESSDATA"}
+
+        except requests.RequestException as e:
+            logger.error(f"Encrypted password login request failed: {e}")
+            return {"success": False, "message": f"请求失败: {e}"}
+
+    def login_with_password(self, username: str, password: str) -> Dict[str, Any]:
+        """使用 B站 账号密码登录（服务端加密，兼容旧流程）。"""
+        logger.info("Attempting Bilibili password login (server-side encrypt)...")
+        key_data = self.get_login_key()
+        if not key_data:
+            return {"success": False, "message": "获取密钥失败"}
+
+        encrypted_pw = self._bili_encrypt_password(password, key_data["hash"], key_data["key"])
+        if not encrypted_pw:
+            return {"success": False, "message": "密码加密失败"}
+
+        return self.login_with_encrypted_password(username, encrypted_pw)
+
+    def send_sms_code(self, phone: str, country_code: str = "86") -> Dict[str, Any]:
+        """发送 B站 短信验证码。"""
+        logger.info(f"Sending SMS code to {country_code} {phone[:3]}****")
+        try:
+            resp = self._session.post(
+                f"{BILI_PASSPORT}/web/sms/send",
+                data={
+                    "tel": json.dumps({"tel": phone, "country_code": country_code}),
+                    "source": "main_web",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=15,
+            )
+            data = resp.json()
+            if data.get("code") == 0:
+                return {"success": True, "message": "验证码已发送"}
+            return {"success": False, "message": data.get("message", "发送失败")}
+        except requests.RequestException as e:
+            return {"success": False, "message": f"请求失败: {e}"}
+
+    def login_with_sms(self, phone: str, code: str, country_code: str = "86") -> Dict[str, Any]:
+        """使用短信验证码登录 B站。"""
+        logger.info(f"Attempting SMS login for {country_code} {phone[:3]}****")
+        try:
+            resp = self._session.post(
+                f"{BILI_PASSPORT}/web/sms/login",
+                data={
+                    "tel": json.dumps({"tel": phone, "country_code": country_code}),
+                    "code": code,
+                    "keep": "1",
+                    "source": "main_web",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=15,
+            )
+            data = resp.json()
+            if data.get("code") != 0:
+                return {"success": False, "message": data.get("message", "登录失败")}
+
+            cookie_dict = {}
+            for c in resp.cookies:
+                if c.name in ("SESSDATA", "bili_jct", "refresh_token", "bili_ticket"):
+                    cookie_dict[c.name] = c.value
+
+            if cookie_dict.get("SESSDATA"):
+                self._add_set(cookie_dict, source="sms_login")
+                logger.info("SMS login successful")
+                return {"success": True, "message": "登录成功", "cookies": cookie_dict}
+            return {"success": False, "message": "响应中未包含 SESSDATA"}
+        except requests.RequestException as e:
+            return {"success": False, "message": f"请求失败: {e}"}
+
+    async def login_via_qrcode(self, timeout: int = 120) -> bool:
+        """完整的 QR 码登录流程：生成二维码 → 保存图片 → 轮询等待扫码。"""
+        logger.info("Starting QR code login flow...")
+        qr_info = self.generate_qrcode()
+        if not qr_info:
+            logger.error("Failed to generate QR code")
+            return False
+
+        logger.info(
+            "QR code saved to %s. Please scan it with your Bilibili app.",
+            self.qrcode_image_path,
+        )
+
+        short_url = qr_info.get("url", "")
+        if len(short_url) > 80:
+            short_url = short_url[:77] + "..."
+        logger.info("QR code URL (open in browser if scan fails): %s", short_url)
+
+        return self.poll_qrcode_login(qr_info["qrcode_key"], timeout=timeout)
+
+    # ── 综合刷新 ───────────────────────────────────────────
+
+    async def refresh(self) -> bool:
+        """综合刷新策略：尝试 refresh_token API 续期。"""
+        if self.refresh_via_api():
+            return True
+
+        logger.info("API refresh failed or no refresh_token available")
+        return False
+
+    # ── 状态检查 ─────────────────────────────────────────────
+
+    def needs_refresh(self) -> bool:
+        """检查是否有 Cookie 需要刷新。"""
+        with self._lock:
+            total = len(self._cookie_sets)
+            valid = sum(1 for c in self._cookie_sets if c.is_sessdata_valid and c.SESSDATA)
+        if total == 0:
+            return True
+        if valid < total:
+            logger.info(
+                "Cookie sets: %d valid / %d total, some need refresh",
+                valid, total,
+            )
+        return valid == 0
+
+    # ── 手动触发 ─────────────────────────────────────────────
+
+    async def manual_refresh(self) -> Dict[str, Any]:
+        """手动触发一次 cookie 刷新。"""
+        logger.info("Manual cookie refresh triggered")
+        success = self.refresh_via_api()
+        valid = self._get_valid_sets()
+        best = max(valid, key=lambda c: c.sessdata_remaining_days or 0) if valid else None
+        return {
+            "success": success,
+            "has_sessdata": len(valid) > 0,
+            "expires_at": best.expires_at if best else None,
+            "remaining_days": best.sessdata_remaining_days if best else None,
+        }
+
+    def get_status(self) -> Dict[str, Any]:
+        """返回 Cookie 池状态（无敏感信息）。"""
+        with self._lock:
+            total = len(self._cookie_sets)
+            valid = sum(1 for c in self._cookie_sets if c.is_sessdata_valid and c.SESSDATA)
+            best = max(self._cookie_sets, key=lambda c: c.sessdata_remaining_days or 0) if self._cookie_sets else None
+        return {
+            "has_sessdata": valid > 0,
+            "pool_total": total,
+            "pool_valid": valid,
+            "expires_at": best.expires_at if best else None,
+            "remaining_days": best.sessdata_remaining_days if best else None,
+            "last_refresh": best.last_refresh if best else None,
+            "needs_refresh": total > 0 and valid == 0,
+        }


### PR DESCRIPTION
## 概述

为所有三个客户端（服务端、PC 桌面端、移动端）添加完整的 Bilibili Cookie 管理功能。

## 核心改动

### 安全增强
- **客户端 RSA 加密密码**：密码明文不在服务端出现，从 Bilibili 获取公钥后客户端本地加密再传输
- **Cookie 不落盘**：服务端仅内存暂用，客户端自行保存到本地文件（PC）或 AsyncStorage（移动端）

### 多登录方式
- **PC 端**：新增账号密码登录和短信验证码登录（QTabWidget 切换）
- **移动端**：新增密码/SMS 登录（使用 node-forge RSA 加密）

### 多 Cookie 池
- 服务端持有多组 Cookie 集合，调用 Bilibili API 时随机选取
- 移除服务端后台自动监控，改为客户端主动检查状态后触发刷新

## 涉及文件

| 文件 | 改动 |
|------|------|
| `server/src/plugins/bilibili_cookie_manager.py` | 新增：Cookie 管理器（多池/API登录/QR码/密码加密） |
| `server/server_main.py` | 新增 API 端点，移除后台监控 |
| `app/app/bilibili_login.tsx` | 新增：移动端 B站登录页面 |
| `app/app/index.tsx` | 集成 Bilibili 登录入口 |
| `client/src/gui/preferences_dialog.py` | 重写 Bilibili Cookie 标签页 |
| `client/src/gui/main_ui.py` | 传递 network_client |
| `client/src/network/network_client.py` | 新增 Bilibili API 方法 |
| `server/config/config.json` | Bilibili cookie 配置 |

## 测试
- Python 语法检查: 通过
- TypeScript 类型检查: 通过
- 服务端测试: 136 passed, 4 skipped（test_singing_manager 为已有失败用例）