### PR TITLE
[推荐合并顺序 05/14] fix: 重放唱歌音频时可同时播放 TTS 等其他音频（音频播放互斥）

### DIFF
--- a/app/__tests__/auto_login.test.ts
+++ b/app/__tests__/auto_login.test.ts
@@ -1,0 +1,80 @@
+/**
+ * auto_login.ts 单元测试
+ * 覆盖自动登录结果分类与带退避的重试策略（Bug#2）。
+ */
+import {
+  AUTO_LOGIN_MAX_ATTEMPTS,
+  classifyAutoLoginStatus,
+  runAutoLoginWithRetry,
+} from '../utils/auto_login';
+
+describe('classifyAutoLoginStatus', () => {
+  it('2xx 视为成功', () => {
+    expect(classifyAutoLoginStatus(200)).toBe('ok');
+    expect(classifyAutoLoginStatus(204)).toBe('ok');
+  });
+
+  it('401/403 视为 token 被明确拒绝', () => {
+    expect(classifyAutoLoginStatus(401)).toBe('invalid');
+    expect(classifyAutoLoginStatus(403)).toBe('invalid');
+  });
+
+  it('5xx/429 视为瞬时故障', () => {
+    expect(classifyAutoLoginStatus(500)).toBe('transient');
+    expect(classifyAutoLoginStatus(503)).toBe('transient');
+    expect(classifyAutoLoginStatus(429)).toBe('transient');
+  });
+
+  it('网络错误（null）视为瞬时故障', () => {
+    expect(classifyAutoLoginStatus(null)).toBe('transient');
+  });
+});
+
+describe('runAutoLoginWithRetry', () => {
+  it('首次成功立即返回，不再尝试', async () => {
+    const attempt = jest.fn().mockResolvedValue('ok');
+    const delayFn = jest.fn().mockResolvedValue(undefined);
+
+    const outcome = await runAutoLoginWithRetry(attempt, { delayFn });
+    expect(outcome).toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+  });
+
+  it('token 被拒绝（invalid）立即返回，不重试', async () => {
+    const attempt = jest.fn().mockResolvedValue('invalid');
+    const delayFn = jest.fn().mockResolvedValue(undefined);
+
+    const outcome = await runAutoLoginWithRetry(attempt, { delayFn });
+    expect(outcome).toBe('invalid');
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+  });
+
+  it('瞬时故障按指数退避重试，随后成功', async () => {
+    const attempt = jest.fn()
+      .mockResolvedValueOnce('transient')
+      .mockResolvedValueOnce('transient')
+      .mockResolvedValueOnce('ok');
+    const delayFn = jest.fn().mockResolvedValue(undefined);
+
+    const outcome = await runAutoLoginWithRetry(attempt, { retryBaseMs: 100, delayFn });
+    expect(outcome).toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(3);
+    expect(delayFn.mock.calls).toEqual([[100], [200]]);
+  });
+
+  it('持续瞬时故障时重试达到最大次数后放弃', async () => {
+    const attempt = jest.fn().mockResolvedValue('transient');
+    const delayFn = jest.fn().mockResolvedValue(undefined);
+
+    const outcome = await runAutoLoginWithRetry(attempt, {
+      maxAttempts: AUTO_LOGIN_MAX_ATTEMPTS,
+      retryBaseMs: 100,
+      delayFn,
+    });
+    expect(outcome).toBe('transient');
+    expect(attempt).toHaveBeenCalledTimes(AUTO_LOGIN_MAX_ATTEMPTS);
+    expect(delayFn).toHaveBeenCalledTimes(AUTO_LOGIN_MAX_ATTEMPTS - 1);
+  });
+});

--- a/app/__tests__/crypto.test.ts
+++ b/app/__tests__/crypto.test.ts
@@ -1,0 +1,141 @@
+/**
+ * crypto.ts 单元测试
+ * 覆盖公钥获取的重试、超时、缓存，以及密码加密失败原因区分（Bug#1）。
+ */
+import forge from 'node-forge';
+import { clearCachedPublicKey, encryptPassword, getPublicKey } from '../utils/crypto';
+import { server_config } from '../config';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// 生成一个真实可用的 RSA 公钥 PEM（测试专用，非敏感信息）
+const { publicKey: testKeyPair } = forge.pki.rsa.generateKeyPair(1024);
+const TEST_PUBLIC_KEY_PEM = forge.pki.publicKeyToPem(testKeyPair);
+
+const mockFetch = jest.fn();
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const PUBLIC_KEY_URL = `${server_config.BASE_URL}/auth/public_key`;
+
+describe('getPublicKey', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    clearCachedPublicKey();
+  });
+
+  it('获取成功时返回公钥并缓存（第二次调用不再请求网络）', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ public_key: TEST_PUBLIC_KEY_PEM }));
+
+    const key1 = await getPublicKey();
+    expect(key1).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const key2 = await getPublicKey();
+    expect(key2).toBe(key1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('网络波动时自动重试，最终成功返回公钥', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError('Network request failed'))
+      .mockRejectedValueOnce(new TypeError('Network request failed'))
+      .mockResolvedValueOnce(jsonResponse({ public_key: TEST_PUBLIC_KEY_PEM }));
+
+    const key = await getPublicKey();
+    expect(key).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('网络持续失败时返回 null，且重试达到最大次数', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Network request failed'));
+
+    const key = await getPublicKey();
+    expect(key).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('HTTP 非 2xx 时重试后返回 null', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ detail: 'error' }, false, 500));
+
+    const key = await getPublicKey();
+    expect(key).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('返回数据缺少 public_key 字段时重试后返回 null', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ foo: 'bar' }));
+
+    const key = await getPublicKey();
+    expect(key).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('请求带有超时信号（AbortController）', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ public_key: TEST_PUBLIC_KEY_PEM }));
+
+    await getPublicKey();
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init).toHaveProperty('signal');
+    expect(init.signal.aborted).toBe(false);
+  });
+});
+
+describe('encryptPassword', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    clearCachedPublicKey();
+  });
+
+  it('公钥获取成功时返回加密后的 Base64 字符串', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ public_key: TEST_PUBLIC_KEY_PEM }));
+
+    const result = await encryptPassword('secret123');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Base64 编码的非空字符串
+      expect(typeof result.encrypted).toBe('string');
+      expect(result.encrypted.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('公钥获取失败（网络）时返回原因 network，不抛出异常', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Network request failed'));
+
+    const result = await encryptPassword('secret123');
+    expect(result).toEqual({ ok: false, reason: 'network' });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('公钥获取失败（服务器异常）时返回原因 server', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ detail: 'error' }, false, 500));
+
+    const result = await encryptPassword('secret123');
+    expect(result).toEqual({ ok: false, reason: 'server' });
+  });
+
+  it('公钥已缓存时加密不再发起网络请求', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ public_key: TEST_PUBLIC_KEY_PEM }));
+
+    await encryptPassword('secret123');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const result = await encryptPassword('secret456');
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/__tests__/dynamics.test.ts
+++ b/app/__tests__/dynamics.test.ts
@@ -38,7 +38,7 @@ describe('dynamics api helpers', () => {
     const result = await getDynamics('alice', 'token-123', 20, 'cursor-1');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://example.test/dynamics?username=alice&token=token-123&limit=20&cursor=cursor-1',
+      'http://example.test/dynamics?username=alice&limit=20&cursor=cursor-1',
       {
         method: 'GET',
         headers: {
@@ -89,7 +89,7 @@ describe('dynamics api helpers', () => {
     const result = await getDynamicComments('alice', 'token-123', 'dynamic/1', 50, null);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://example.test/dynamics/dynamic%2F1/comments?username=alice&token=token-123&limit=50',
+      'http://example.test/dynamics/dynamic%2F1/comments?username=alice&limit=50',
       {
         method: 'GET',
         headers: {
@@ -130,7 +130,7 @@ describe('dynamics api helpers', () => {
     const result = await getDynamicUnreadStatus('alice', 'token-123');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://example.test/dynamics/unread?username=alice&token=token-123',
+      'http://example.test/dynamics/unread?username=alice',
       {
         method: 'GET',
         headers: {

--- a/app/__tests__/message_processor_tts_terminal.test.ts
+++ b/app/__tests__/message_processor_tts_terminal.test.ts
@@ -1,0 +1,205 @@
+jest.mock('expo-av', () => ({ Audio: {} }));
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file://documents/',
+  EncodingType: { Base64: 'base64' },
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
+  getInfoAsync: jest.fn().mockResolvedValue({ exists: false }),
+  readAsStringAsync: jest.fn().mockResolvedValue(''),
+}));
+
+import * as FileSystem from 'expo-file-system/legacy';
+import { AgentBinder } from '../utils/binder';
+import {
+  canRetryDurableMessage,
+  getSendRetryDelayMs,
+  MAX_DURABLE_MESSAGE_AGE_MS,
+  MAX_DURABLE_RETRY_ATTEMPTS,
+  MessageProcessor,
+} from '../utils/message_processor';
+import { NetworkClient } from '../utils/network_client';
+
+
+function fakeBinder() {
+  return {
+    emitAgentMessage: jest.fn(),
+    emitErrorText: jest.fn(),
+    emitMessageStatus: jest.fn(),
+  } as unknown as jest.Mocked<AgentBinder>;
+}
+
+async function drainIncoming(processor: MessageProcessor) {
+  await (processor as unknown as { incomingMessageChain: Promise<void> }).incomingMessageChain;
+}
+
+describe('MessageProcessor TTS terminal contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('finishes a zero-chunk error and preserves the server text', async () => {
+    const binder = fakeBinder();
+    const feedServerAudioChunk = jest.fn();
+    const processor = new MessageProcessor(
+      {} as NetworkClient,
+      binder,
+      feedServerAudioChunk,
+    );
+
+    processor.onAgentMessage({
+      uuid: 'reply-1',
+      text: '已经生成的文本',
+      audio: '',
+      is_final_package: true,
+      audio_error: true,
+      error_code: 'TTS_EMPTY',
+    });
+    await drainIncoming(processor);
+
+    expect(feedServerAudioChunk).toHaveBeenCalledTimes(1);
+    expect(feedServerAudioChunk).toHaveBeenCalledWith('', true);
+    expect(binder.emitAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uuid: 'reply-1',
+        text: '已经生成的文本',
+        is_final_package: true,
+        audio_error: true,
+        error_code: 'TTS_EMPTY',
+      }),
+    );
+  });
+
+  it('finishes after a mid-stream error without saving partial audio', async () => {
+    const binder = fakeBinder();
+    let processor: MessageProcessor;
+    const feedServerAudioChunk = jest.fn((_audio: string, isFinal: boolean) => {
+      if (isFinal) {
+        processor.onServerAudioFinished();
+      }
+    });
+    processor = new MessageProcessor(
+      {} as NetworkClient,
+      binder,
+      feedServerAudioChunk,
+    );
+
+    processor.onAgentMessage({
+      uuid: 'reply-2',
+      text: '已经生成的文本',
+      audio: 'YXVkaW8=',
+      is_final_package: false,
+    });
+    await drainIncoming(processor);
+    processor.onAgentMessage({
+      uuid: 'reply-2',
+      audio: '',
+      is_final_package: true,
+      audio_error: true,
+      error_code: 'TTS_STREAM_ERROR',
+    });
+    await drainIncoming(processor);
+
+    expect(feedServerAudioChunk.mock.calls.filter((call) => call[1] === true)).toHaveLength(1);
+    expect(feedServerAudioChunk).toHaveBeenLastCalledWith('', true);
+    expect(FileSystem.writeAsStringAsync).not.toHaveBeenCalled();
+    expect(binder.emitAgentMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        uuid: 'reply-2',
+        is_final_package: true,
+        audio_error: true,
+        error_code: 'TTS_STREAM_ERROR',
+      }),
+    );
+  });
+
+  it('clears the global audio-playing flag when playback completion times out', async () => {
+    jest.useFakeTimers();
+    try {
+      const processor = new MessageProcessor(
+        {} as NetworkClient,
+        fakeBinder(),
+        jest.fn(),
+      );
+      (processor as any).serverAudioPlaying = true;
+
+      const completion = (processor as any).waitForServerAudioFinished(25);
+      jest.advanceTimersByTime(25);
+      await completion;
+
+      expect((processor as any).serverAudioPlaying).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+test('message retry delay is exponential and capped at 30 seconds', () => {
+  expect([0, 1, 2, 3, 4, 5, 8].map(getSendRetryDelayMs)).toEqual([
+    1000,
+    2000,
+    4000,
+    8000,
+    16000,
+    30000,
+    30000,
+  ]);
+});
+
+test('durable retry policy is bounded by attempts and total age', () => {
+  const enqueuedAt = 10_000;
+  expect(canRetryDurableMessage(0, enqueuedAt, 1000, enqueuedAt)).toBe(true);
+  expect(canRetryDurableMessage(MAX_DURABLE_RETRY_ATTEMPTS, enqueuedAt, 1000, enqueuedAt)).toBe(false);
+  expect(
+    canRetryDurableMessage(0, enqueuedAt, 1000, enqueuedAt + MAX_DURABLE_MESSAGE_AGE_MS - 1000),
+  ).toBe(false);
+});
+
+describe('MessageProcessor bounded delivery queue', () => {
+  function queueItem(overrides: Record<string, unknown>) {
+    return {
+      clientMsgId: 'msg-1',
+      retryAttempt: 0,
+      enqueuedAtMs: Date.now(),
+      ...overrides,
+    };
+  }
+
+  it('drops a failed transient event and continues with the next durable message', async () => {
+    const network = {
+      sendTypingEvent: jest.fn().mockResolvedValue({ ok: false, error: 'disconnected' }),
+      sendChat: jest.fn().mockResolvedValue({ ok: true }),
+    } as unknown as NetworkClient;
+    const binder = fakeBinder();
+    const processor = new MessageProcessor(network, binder, jest.fn());
+    (processor as any).sendQueue = [
+      queueItem({ kind: 'typing', textLength: 3 }),
+      queueItem({ kind: 'text', uuid: 'user-1', text: 'hello', clientMsgId: 'msg-2' }),
+    ];
+
+    await (processor as any).runSendLoop();
+
+    expect((network as any).sendTypingEvent).toHaveBeenCalledTimes(1);
+    expect((network as any).sendChat).toHaveBeenCalledWith('hello', false, 'msg-2');
+    expect(processor.queueLength()).toBe(0);
+  });
+
+  it('marks an exhausted durable message as DELIVERY_UNCERTAIN', async () => {
+    const network = {
+      sendChat: jest.fn().mockResolvedValue({ ok: false, error: 'ack timeout' }),
+    } as unknown as NetworkClient;
+    const binder = fakeBinder();
+    const processor = new MessageProcessor(network, binder, jest.fn());
+    (processor as any).sendQueue = [queueItem({
+      kind: 'text',
+      uuid: 'user-2',
+      text: 'hello',
+      retryAttempt: MAX_DURABLE_RETRY_ATTEMPTS,
+    })];
+
+    await (processor as any).runSendLoop();
+
+    expect(binder.emitMessageStatus).toHaveBeenCalledWith('user-2', 'failed');
+    expect(binder.emitErrorText).toHaveBeenCalledWith(expect.stringContaining('DELIVERY_UNCERTAIN'));
+    expect(processor.queueLength()).toBe(0);
+  });
+});

--- a/app/__tests__/ws_transport_ack.test.ts
+++ b/app/__tests__/ws_transport_ack.test.ts
@@ -1,0 +1,125 @@
+jest.mock('react-native', () => ({
+  AppState: {
+    currentState: 'active',
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+jest.mock('../config', () => ({
+  server_config: { BASE_URL: 'http://localhost:60030' },
+}));
+
+import { normalizeServerAck } from '../utils/ws_ack';
+import { WebSocketTransport } from '../utils/ws_transport';
+
+describe('normalizeServerAck', () => {
+  it('keeps legacy ACK payloads compatible', () => {
+    expect(normalizeServerAck({ received_event_type: 'user_text' }, 'msg-1')).toEqual({
+      ok: true,
+      request_id: 'msg-1',
+    });
+  });
+
+  it('marks overload NACKs as retryable', () => {
+    expect(
+      normalizeServerAck(
+        { ok: false, code: 'OVERLOADED', message: 'ingress queue is full', retryable: true },
+        'msg-2',
+      ),
+    ).toEqual({
+      ok: false,
+      request_id: 'msg-2',
+      error: '[OVERLOADED] ingress queue is full',
+      code: 'OVERLOADED',
+      retryable: true,
+      drop: false,
+    });
+  });
+
+  it('marks permanent rejection as terminal', () => {
+    expect(normalizeServerAck({ ok: false, code: 'BAD_MESSAGE' }, 'msg-3')).toMatchObject({
+      ok: false,
+      drop: true,
+      retryable: false,
+    });
+  });
+});
+
+describe('WebSocketTransport readiness failures', () => {
+  function transport() {
+    return new WebSocketTransport('alice', 'token', {
+      onAgentMessage: jest.fn(),
+      onAgentStateChanged: jest.fn(),
+      onError: jest.fn(),
+    });
+  }
+
+  it('keeps the same id retryable while temporarily not ready', async () => {
+    const ws = transport();
+    (ws as any).waitUntilReady = jest.fn().mockResolvedValue('timeout');
+
+    await expect(ws.submitUserText('hello', false, 10, 'msg-not-ready')).resolves.toMatchObject({
+      ok: false,
+      request_id: 'msg-not-ready',
+      retryable: true,
+      drop: false,
+    });
+  });
+
+  it('drops only an explicit authentication rejection', async () => {
+    const ws = transport();
+    (ws as any).waitUntilReady = jest.fn().mockResolvedValue('auth_rejected');
+
+    await expect(ws.submitUserText('hello', false, 10, 'msg-auth')).resolves.toMatchObject({
+      ok: false,
+      request_id: 'msg-auth',
+      code: 'AUTH_REJECTED',
+      retryable: false,
+      drop: true,
+    });
+  });
+
+  it('advertises negative ACK support in the auth payload', () => {
+    const ws = transport();
+    const send = jest.fn();
+    const originalWebSocket = globalThis.WebSocket;
+    Object.defineProperty(globalThis, 'WebSocket', {
+      configurable: true,
+      value: { OPEN: 1 },
+    });
+
+    try {
+      (ws as any).ws = { readyState: 1, send };
+      (ws as any).sendAuth();
+
+      const envelope = JSON.parse(send.mock.calls[0][0]);
+      expect(envelope.payload.capabilities).toEqual(['negative_ack_v1']);
+    } finally {
+      Object.defineProperty(globalThis, 'WebSocket', {
+        configurable: true,
+        value: originalWebSocket,
+      });
+    }
+  });
+
+  it('suppresses reconnect after AUTH_ERROR and resets backoff only on AUTH_OK', () => {
+    const ws = transport();
+    const close = jest.fn();
+    (ws as any).ws = { close };
+    (ws as any).reconnectAttempts = 5;
+
+    (ws as any).handleServerMessage(JSON.stringify({
+      type: 'auth_error',
+      payload: { code: 'INVALID_TOKEN', message: 'invalid token' },
+    }));
+
+    expect((ws as any).authRejected).toBe(true);
+    expect((ws as any).canReconnectAfterClose()).toBe(false);
+    expect((ws as any).reconnectAttempts).toBe(5);
+    expect(close).toHaveBeenCalledTimes(1);
+
+    (ws as any).handleServerMessage(JSON.stringify({ type: 'auth_ok', payload: {} }));
+    expect((ws as any).authRejected).toBe(false);
+    expect((ws as any).canReconnectAfterClose()).toBe(true);
+    expect((ws as any).reconnectAttempts).toBe(0);
+  });
+});

--- a/app/app/index.tsx
+++ b/app/app/index.tsx
@@ -401,6 +401,17 @@ export default function Index({ onLogout }: { onLogout?: () => void }) {
               }
             }}
             onEndReachedThreshold={0.1}
+            onScrollToIndexFailed={(info) => {
+              // scrollToIndex 目标未渲染时的兜底：按平均行高估算偏移量，避免闪退
+              addDebugTrace('history', 'scrollToIndex failed', {
+                index: info.index,
+                averageItemLength: info.averageItemLength,
+              });
+              flatListRef.current?.scrollToOffset({
+                offset: info.averageItemLength * info.index,
+                animated: false,
+              });
+            }}
             ListFooterComponent={renderFooter}
             style={[styles.chatList, { backgroundColor: theme.chatList }]}
             contentContainerStyle={styles.chatListContent}

--- a/app/app/login.tsx
+++ b/app/app/login.tsx
@@ -131,9 +131,15 @@ export default function LoginScreen({ onLogin, onRegister }: LoginScreenProps) {
     try {
       // 加密密码（复用已有的加密方法）
       const { encryptPassword } = await import('../utils/crypto');
-      const encryptedPassword = await encryptPassword(resetPassword);
-      if (!encryptedPassword) {
-        Alert.alert('错误', '密码加密失败');
+      const encrypted = await encryptPassword(resetPassword);
+      if (!encrypted.ok) {
+        const message =
+          encrypted.reason === 'network'
+            ? '无法获取加密密钥，请检查网络后重试'
+            : encrypted.reason === 'server'
+              ? '服务器返回异常，请稍后重试'
+              : '密码加密失败';
+        Alert.alert('错误', message);
         setResetting(false);
         return;
       }
@@ -143,7 +149,7 @@ export default function LoginScreen({ onLogin, onRegister }: LoginScreenProps) {
         body: JSON.stringify({
           invite_code: resetInvite,
           new_username: resetUsername,
-          new_password: encryptedPassword,
+          new_password: encrypted.encrypted,
         }),
       });
       const result = await response.json();

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -3,12 +3,24 @@ import * as SecureStore from 'expo-secure-store';
 import { useCallback, useEffect, useState } from 'react';
 import { auth } from '../components/auth';
 import { loadSavedServerUrl, server_config } from '../config/index';
-import { encryptPassword, getPublicKey } from '../utils/crypto';
+import { encryptPassword, getPublicKey, type PublicKeyFailureReason } from '../utils/crypto';
 import { addDebugTrace } from '../utils/debug_trace';
 
 const AUTO_LOGIN_KEY = 'auto_login';
 const USERNAME_KEY = 'saved_username';
 const AUTOLOGIN_TOKEN_KEY = 'auto_login_token';
+
+/** 根据加密失败原因生成面向用户的明确提示 */
+function describeEncryptFailure(scope: '登录' | '注册', reason: PublicKeyFailureReason | 'crypto'): string {
+  switch (reason) {
+    case 'network':
+      return `${scope}失败，无法获取加密密钥，请检查网络后重试`;
+    case 'server':
+      return `${scope}失败，服务器返回异常，请稍后重试`;
+    default:
+      return `${scope}失败，无法加密密码`;
+  }
+}
 
 export interface AuthState {
   isLoggedIn: boolean;
@@ -105,10 +117,10 @@ export function useAuth() {
       }
 
       // 加密密码
-      const encryptedPassword = await encryptPassword(password);
-      if (!encryptedPassword) {
-        addDebugTrace('auth', 'password encrypt failed');
-        return { success: false, message: '登录失败，无法加密密码' };
+      const encrypted = await encryptPassword(password);
+      if (!encrypted.ok) {
+        addDebugTrace('auth', 'password encrypt failed', { reason: encrypted.reason });
+        return { success: false, message: describeEncryptFailure('登录', encrypted.reason) };
       }
       // 发送登录请求
       const response = await fetch(`${server_config.BASE_URL}/auth/login`, {
@@ -116,7 +128,7 @@ export function useAuth() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           username,
-          password: encryptedPassword,
+          password: encrypted.encrypted,
         }),
       });
       const result = await response.json();
@@ -165,10 +177,10 @@ export function useAuth() {
       if (!inviteCode.trim()) return { success: false, message: '邀请码不能为空' };
 
       // 加密密码
-      const encryptedPassword = await encryptPassword(password);
-      if (!encryptedPassword) {
-        addDebugTrace('auth', 'register: password encrypt failed');
-        return { success: false, message: '注册失败，无法加密密码' };
+      const encrypted = await encryptPassword(password);
+      if (!encrypted.ok) {
+        addDebugTrace('auth', 'register: password encrypt failed', { reason: encrypted.reason });
+        return { success: false, message: describeEncryptFailure('注册', encrypted.reason) };
       }
 
       // 发送注册请求
@@ -177,7 +189,7 @@ export function useAuth() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           username,
-          password: encryptedPassword,
+          password: encrypted.encrypted,
           invite_code: inviteCode,
         }),
       });

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -5,6 +5,7 @@ import { auth } from '../components/auth';
 import { loadSavedServerUrl, server_config } from '../config/index';
 import { encryptPassword, getPublicKey, type PublicKeyFailureReason } from '../utils/crypto';
 import { addDebugTrace } from '../utils/debug_trace';
+import { classifyAutoLoginStatus, runAutoLoginWithRetry } from '../utils/auto_login';
 
 const AUTO_LOGIN_KEY = 'auto_login';
 const USERNAME_KEY = 'saved_username';
@@ -22,6 +23,9 @@ function describeEncryptFailure(scope: '登录' | '注册', reason: PublicKeyFai
   }
 }
 
+// 自动登录进行中的标记，避免并发调用同时轮换 login_token 导致会话失效
+let autoLoginInFlight: Promise<boolean> | null = null;
+
 export interface AuthState {
   isLoggedIn: boolean;
   isLoading: boolean;  // 正在向服务器请求
@@ -34,6 +38,56 @@ export function useAuth() {
     isLoading: true,
     publicKeyLoaded: false,
   });
+
+  /**
+   * 尝试自动登录：瞬时故障（网络错误/5xx/429）按退避重试，
+   * 只有 token 被明确拒绝（401/403）时才判定需要重新登录。
+   * 返回是否登录成功。
+   */
+  const tryAutoLogin = useCallback(async (username: string, token: string): Promise<boolean> => {
+    const outcome = await runAutoLoginWithRetry(async (attemptNumber) => {
+      try {
+        const response = await fetch(`${server_config.BASE_URL}/auth/auto_login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, token }),
+        });
+        if (response.ok) {
+          const result = await response.json();
+          // 获取到新的token后可以更新存储的token
+          await SecureStore.setItemAsync(AUTOLOGIN_TOKEN_KEY, result.login_token);
+          await AsyncStorage.setItem(USERNAME_KEY, result.user_id);
+          auth.username = username;
+          auth.message_token = result.message_token;
+          return 'ok';
+        }
+        const classified = classifyAutoLoginStatus(response.status);
+        if (classified === 'invalid') {
+          addDebugTrace('auth', 'auto login rejected', { status: response.status, attempt: attemptNumber });
+        } else {
+          addDebugTrace('auth', 'auto login transient failure', { status: response.status, attempt: attemptNumber });
+        }
+        return classified;
+      } catch (e) {
+        // 网络波动/超时视为瞬时故障，退避后重试
+        addDebugTrace('auth', 'auto login network failure', { error: String(e), attempt: attemptNumber });
+        return 'transient';
+      }
+    });
+
+    if (outcome !== 'ok') {
+      addDebugTrace('auth', 'auto login failed', { outcome });
+      return false;
+    }
+
+    addDebugTrace('auth', 'auto login ok');
+    setAuthState(prev => ({
+      ...prev,
+      isLoggedIn: true,
+      isLoading: false,
+    }));
+    return true;
+  }, []);
 
   const checkAutoLogin = useCallback(async () => {
     try {
@@ -50,37 +104,25 @@ export function useAuth() {
           }
         }
         if (savedUsername && autoLoginToken) { // 此时可以尝试自动登录
-          const response = await fetch(`${server_config.BASE_URL}/auth/auto_login`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              username: savedUsername,
-              token: autoLoginToken,
-            }),
-          });
-
-          if (response.ok) {
-            addDebugTrace('auth', 'auto login ok');
-            const result = await response.json();
-            // 获取到新的token后可以更新存储的token
-            await SecureStore.setItemAsync(AUTOLOGIN_TOKEN_KEY, result.login_token);
-            await AsyncStorage.setItem(USERNAME_KEY, result.user_id);
-            setAuthState(prev => ({
-              ...prev,
-              isLoggedIn: true,
-              isLoading: false,
-            }));
-            auth.username = savedUsername;
-            auth.message_token = result.message_token;
-            return;
+          // 并发保护：重复进入时复用进行中的自动登录，避免重复请求竞争轮换 token
+          if (!autoLoginInFlight) {
+            autoLoginInFlight = tryAutoLogin(savedUsername, autoLoginToken);
+            try {
+              await autoLoginInFlight;
+            } finally {
+              autoLoginInFlight = null;
+            }
+          } else {
+            await autoLoginInFlight;
           }
         }
       }
     } catch (e) {
       addDebugTrace('auth', 'auto login check failed', { error: String(e) });
     }
-    setAuthState(prev => ({ ...prev, isLoading: false }));
-  }, []);
+    // 自动登录成功路径已设置 isLoading=false；失败路径在这里兜底关闭 loading
+    setAuthState(prev => (prev.isLoading ? { ...prev, isLoading: false } : prev));
+  }, [tryAutoLogin]);
 
   const initializeAuth = useCallback(async () => {
     // 加载保存的自定义服务器地址

--- a/app/hooks/useChatLogic.ts
+++ b/app/hooks/useChatLogic.ts
@@ -345,8 +345,14 @@ export const useChatLogic = (
       const next = [...prev, ...normalized.reverse()];
 
       if (nowScrollIndex >= 0) {
+        // 快速滑动时目标 index 可能尚未渲染，scrollToIndex 会抛 invariant violation 导致应用闪退。
+        // 捕获异常并回退到 offset 定位（见 index.tsx 的 onScrollToIndexFailed），即使失败也不影响列表。
         setTimeout(() => {
-          flatListRef.current?.scrollToIndex({ index: nowScrollIndex, animated: false });
+          try {
+            flatListRef.current?.scrollToIndex({ index: nowScrollIndex, animated: false });
+          } catch {
+            addDebugTrace('history', 'scrollToIndex failed, fallback to offset', { index: nowScrollIndex });
+          }
         }, 10);
       } else {
         setTimeout(() => {

--- a/app/hooks/useChatLogic.ts
+++ b/app/hooks/useChatLogic.ts
@@ -147,10 +147,18 @@ export const useChatLogic = (
 
     binderRef.current = binder;
 
-    const processor = new MessageProcessor(networkClient, binder, (base64Audio, isFinal) => {
-      const jsCode = `window.feedAudioChunk(${JSON.stringify(base64Audio)}, ${isFinal ? 'true' : 'false'}); true;`;
-      webviewRef.current?.injectJavaScript(jsCode);
-    });
+    const processor = new MessageProcessor(
+      networkClient,
+      binder,
+      (base64Audio, isFinal) => {
+        const jsCode = `window.feedAudioChunk(${JSON.stringify(base64Audio)}, ${isFinal ? 'true' : 'false'}); true;`;
+        webviewRef.current?.injectJavaScript(jsCode);
+      },
+      () => {
+        const jsCode = `window.stopServerAudio(); true;`;
+        webviewRef.current?.injectJavaScript(jsCode);
+      },
+    );
 
     messageProcessorRef.current = processor;
 
@@ -181,7 +189,7 @@ export const useChatLogic = (
   const handleWebViewMessage = useCallback((event: any) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
-      if (data.type === 'audio_finished') {
+      if (data.type === 'audio_finished' || data.type === 'audio_stopped') {
         messageProcessorRef.current?.onServerAudioFinished();
         return;
       }

--- a/app/hooks/useHistoryLogic.ts
+++ b/app/hooks/useHistoryLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ChatMessage } from "../types/chat";
 import { server_config } from "../config/index";
 import { getHistory } from "../utils/getHistory";
@@ -7,6 +7,9 @@ import { addDebugTrace } from "../utils/debug_trace";
 export function useHistoryLogic(addHistoryMessage: (messages: ChatMessage[]) => void) {
     const [history_start_index, setHistoryStartIndex] = useState(-1); 
     const [historyLoading, setHistoryLoading] = useState(false);
+    // ref 守卫：state 更新是异步的，同一帧内多次 onEndReached 会穿透 historyLoading 检查，
+    // 导致并发请求、消息重复追加。用 ref 同步拦截并发调用。
+    const loadingRef = useRef(false);
 
     const loadHistory = useCallback(async (
         username: string,
@@ -14,10 +17,11 @@ export function useHistoryLogic(addHistoryMessage: (messages: ChatMessage[]) => 
         count: number = server_config.LOAD_HISTORY_COUNT 
     ): Promise<void> => {
         // 如果正在加载或已经到头，则直接返回
-        if (historyLoading || history_start_index === 0) {
+        if (loadingRef.current || historyLoading || history_start_index === 0) {
             return;
         }
 
+        loadingRef.current = true;
         setHistoryLoading(true); 
         try {
             // 获取历史记录数据
@@ -31,6 +35,7 @@ export function useHistoryLogic(addHistoryMessage: (messages: ChatMessage[]) => 
         } catch (error) {
             addDebugTrace('history', 'load error', { error: String(error) });
         } finally {
+            loadingRef.current = false;
             setHistoryLoading(false); 
         }
     }, [historyLoading, history_start_index, addHistoryMessage]); // 核心依赖项

--- a/app/jest.assetMock.js
+++ b/app/jest.assetMock.js
@@ -1,0 +1,3 @@
+// Jest 静态资源 mock：config/index.ts 会 require 图片资源，
+// ts-jest 无法解析二进制文件，映射为字符串桩（React Native 项目标准做法）。
+module.exports = 'asset-stub';

--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
+    '\\.(png|jpg|jpeg|gif|webp|svg)$': '<rootDir>/jest.assetMock.js',
   },
   setupFiles: ['<rootDir>/jest.setup.ts'],
 };

--- a/app/public/live2d/live2d.html
+++ b/app/public/live2d/live2d.html
@@ -344,6 +344,8 @@
     let nextStartTime = 0;
     let isWaitingForEnd = false;
     let isPlaying = false;
+    // 当前已排队的音频源，用于停止/清空队列（音频播放互斥）
+    const activeSources = [];
 
     window.feedAudioChunk = async (base64Audio, isFinal) => {
       if (audioCtx.state === 'suspended') await audioCtx.resume();
@@ -398,6 +400,13 @@
         const source = audioCtx.createBufferSource();
         source.buffer = audioBuffer;
         source.connect(analyser);
+        source.onended = () => {
+          const idx = activeSources.indexOf(source);
+          if (idx >= 0) {
+            activeSources.splice(idx, 1);
+          }
+        };
+        activeSources.push(source);
         
         const currentTime = audioCtx.currentTime;
         // 留 50ms 缓冲，防止高频小包导致破音/队列下溢
@@ -413,6 +422,25 @@
       if (isFinal) {
         isWaitingForEnd = true;
         checkFinished();
+      }
+    };
+
+    // 停止并清空所有已排队的音频（用于音频播放互斥）
+    window.stopServerAudio = () => {
+      for (const src of activeSources.slice()) {
+        try {
+          src.stop();
+        } catch (e) {
+          // 忽略已结束或未启动的源
+        }
+      }
+      activeSources.length = 0;
+      nextStartTime = 0;
+      isWaitingForEnd = false;
+      isPlaying = false;
+      // 通知 RN 服务端音频已停止（用于同步 serverAudioPlaying 状态）
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'audio_stopped' }));
       }
     };
 

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -20,6 +20,8 @@ export interface AgentMessagePayload {
   audio?: string | null;
   expression?: string | null;
   is_final_package?: boolean;
+  audio_error?: boolean;
+  error_code?: string | null;
   display_in_chat?: boolean;
   is_ephemeral?: boolean;
 }

--- a/app/utils/auto_login.ts
+++ b/app/utils/auto_login.ts
@@ -1,0 +1,61 @@
+/**
+ * 自动登录相关工具：结果分类与带退避的重试策略（可独立单元测试）
+ */
+
+export const AUTO_LOGIN_MAX_ATTEMPTS = 3;
+/** 自动登录重试退避基数（毫秒） */
+export const AUTO_LOGIN_RETRY_BASE_MS = 1000;
+
+/** 单次自动登录尝试的结果：ok=成功，invalid=token 被明确拒绝，transient=瞬时故障（可重试） */
+export type AutoLoginAttemptOutcome = 'ok' | 'invalid' | 'transient';
+
+/**
+ * 根据 HTTP 状态码判断自动登录结果；status=null 表示网络错误。
+ * - 2xx：成功
+ * - 401/403：token 被明确拒绝（如已在其他设备登录），需要用户重新登录
+ * - 其余（5xx/429/网络错误）：瞬时故障，可退避重试
+ */
+export function classifyAutoLoginStatus(status: number | null): AutoLoginAttemptOutcome {
+  if (status === null) return 'transient';
+  if (status >= 200 && status < 300) return 'ok';
+  if (status === 401 || status === 403) return 'invalid';
+  return 'transient';
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export interface AutoLoginRetryOptions {
+  maxAttempts?: number;
+  retryBaseMs?: number;
+  /** 可注入的延时函数（测试用） */
+  delayFn?: (ms: number) => Promise<void>;
+}
+
+/**
+ * 带退避重试地执行自动登录尝试：
+ * - 成功或 token 被明确拒绝（invalid）立即返回，不重试；
+ * - 瞬时故障（网络错误/5xx/429）按指数退避重试，最多 maxAttempts 次。
+ */
+export async function runAutoLoginWithRetry(
+  attempt: (attemptNumber: number) => Promise<AutoLoginAttemptOutcome>,
+  options: AutoLoginRetryOptions = {},
+): Promise<AutoLoginAttemptOutcome> {
+  const {
+    maxAttempts = AUTO_LOGIN_MAX_ATTEMPTS,
+    retryBaseMs = AUTO_LOGIN_RETRY_BASE_MS,
+    delayFn = defaultDelay,
+  } = options;
+
+  let lastOutcome: AutoLoginAttemptOutcome = 'transient';
+  for (let i = 1; i <= maxAttempts; i++) {
+    const outcome = await attempt(i);
+    if (outcome !== 'transient') return outcome;
+    lastOutcome = outcome;
+    if (i < maxAttempts) {
+      await delayFn(retryBaseMs * 2 ** (i - 1));
+    }
+  }
+  return lastOutcome;
+}

--- a/app/utils/crypto.ts
+++ b/app/utils/crypto.ts
@@ -5,36 +5,109 @@ import { addDebugTrace } from './debug_trace';
 // 缓存公钥对象（forge 格式）
 let cachedForgeKey: forge.pki.rsa.PublicKey | null = null;
 
+// 公钥获取失败的类型：network = 网络错误/超时，server = 服务器返回异常或数据无效
+export type PublicKeyFailureReason = 'network' | 'server';
+
+/** 公钥获取最多尝试次数 */
+const PUBLIC_KEY_MAX_ATTEMPTS = 3;
+/** 两次尝试之间的退避间隔（毫秒） */
+const PUBLIC_KEY_RETRY_DELAY_MS = 800;
+
+type PublicKeyFetchOutcome =
+  | { ok: true; publicKey: forge.pki.rsa.PublicKey }
+  | { ok: false; reason: PublicKeyFailureReason };
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 /**
- * 获取并转换公钥
+ * 带超时的 fetch，避免网络波动时请求无限挂起
  */
-export async function getPublicKey(): Promise<forge.pki.rsa.PublicKey | null> {
-  if (cachedForgeKey) return cachedForgeKey;
-
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(`${server_config.BASE_URL}/auth/public_key`);
-    const data = await response.json();
-    const pem = data.public_key;
-
-    // 使用 forge 直接从 PEM 字符串导入
-    cachedForgeKey = forge.pki.publicKeyFromPem(pem);
-    return cachedForgeKey;
-  } catch (error) {
-    addDebugTrace('crypto', 'getPublicKey failed', { error: String(error) });
-    return null;
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
   }
 }
 
 /**
- * 核心加密函数：对接 Python 后端的 RSA-OAEP + SHA-256
+ * 获取并解析公钥，失败时自动重试。
+ * 网络错误（fetch 抛异常、超时）与 HTTP 非 2xx 均视为可重试的临时故障；
+ * 全部重试失败后返回失败原因，供上层给出明确提示。
  */
-export async function encryptPassword(
-  password: string,
-): Promise<string | null> {
-  try {
-    const publicKey = await getPublicKey();
-    if (!publicKey) return null;
+async function fetchPublicKeyWithRetry(): Promise<PublicKeyFetchOutcome> {
+  let lastFailure: PublicKeyFailureReason = 'network';
+  for (let attempt = 1; attempt <= PUBLIC_KEY_MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetchWithTimeout(
+        `${server_config.BASE_URL}/auth/public_key`,
+        server_config.API_TIMEOUT,
+      );
+      if (!response.ok) {
+        addDebugTrace('crypto', 'public key http error', { status: response.status, attempt });
+        lastFailure = 'server';
+      } else {
+        const data = await response.json();
+        const pem = data?.public_key;
+        if (typeof pem !== 'string' || pem.length === 0) {
+          addDebugTrace('crypto', 'public key payload invalid', { attempt });
+          lastFailure = 'server';
+        } else {
+          const publicKey = forge.pki.publicKeyFromPem(pem);
+          return { ok: true, publicKey };
+        }
+      }
+    } catch (error) {
+      addDebugTrace('crypto', 'public key fetch failed', { error: String(error), attempt });
+      lastFailure = 'network';
+    }
+    if (attempt < PUBLIC_KEY_MAX_ATTEMPTS) {
+      await delay(PUBLIC_KEY_RETRY_DELAY_MS);
+    }
+  }
+  return { ok: false, reason: lastFailure };
+}
 
+/**
+ * 获取并转换公钥（失败时自动重试，全部失败返回 null）
+ */
+export async function getPublicKey(): Promise<forge.pki.rsa.PublicKey | null> {
+  if (cachedForgeKey) return cachedForgeKey;
+
+  const outcome = await fetchPublicKeyWithRetry();
+  if (outcome.ok) {
+    cachedForgeKey = outcome.publicKey;
+    return outcome.publicKey;
+  }
+  return null;
+}
+
+export type EncryptPasswordResult =
+  | { ok: true; encrypted: string }
+  | { ok: false; reason: PublicKeyFailureReason | 'crypto' };
+
+/**
+ * 核心加密函数：对接 Python 后端的 RSA-OAEP + SHA-256
+ * 公钥获取失败时自动重试；返回结构化结果以便上层区分失败原因并给出明确提示。
+ */
+export async function encryptPassword(password: string): Promise<EncryptPasswordResult> {
+  // 优先使用已缓存的公钥，未缓存时才发起网络请求
+  let publicKey = cachedForgeKey;
+  if (!publicKey) {
+    const outcome = await fetchPublicKeyWithRetry();
+    if (!outcome.ok) {
+      addDebugTrace('crypto', 'encrypt failed: public key unavailable', { reason: outcome.reason });
+      return { ok: false, reason: outcome.reason };
+    }
+    publicKey = outcome.publicKey;
+    cachedForgeKey = publicKey;
+  }
+
+  try {
     // 1. 将字符串转为 UTF-8 字节编码
     const bytes = forge.util.encodeUtf8(password);
 
@@ -48,10 +121,10 @@ export async function encryptPassword(
     });
 
     // 3. 将加密后的二进制转为 Base64 字符串
-    return forge.util.encode64(encrypted);
+    return { ok: true, encrypted: forge.util.encode64(encrypted) };
   } catch (error) {
     addDebugTrace('crypto', 'encrypt failed', { error: String(error) });
-    return null;
+    return { ok: false, reason: 'crypto' };
   }
 }
 

--- a/app/utils/dynamics.ts
+++ b/app/utils/dynamics.ts
@@ -100,7 +100,7 @@ export async function getDynamics(
   limit = 20,
   cursor?: string | null,
 ): Promise<DynamicListResponse> {
-  const query = buildQuery({ username, token, limit, cursor: cursor || undefined });
+  const query = buildQuery({ username, limit, cursor: cursor || undefined });
   const url = `${server_config.BASE_URL}/dynamics?${query}`;
   addDebugTrace('dynamics', 'fetch list', { limit, hasCursor: Boolean(cursor) });
   const response = await fetch(url, {
@@ -134,7 +134,7 @@ export async function getDynamicComments(
   limit = 50,
   cursor?: string | null,
 ): Promise<DynamicCommentListResponse> {
-  const query = buildQuery({ username, token, limit, cursor: cursor || undefined });
+  const query = buildQuery({ username, limit, cursor: cursor || undefined });
   addDebugTrace('dynamics', 'fetch comments', { dynamicId, hasCursor: Boolean(cursor) });
   const response = await fetch(`${server_config.BASE_URL}/dynamics/${encodeURIComponent(dynamicId)}/comments?${query}`, {
     method: 'GET',
@@ -171,7 +171,7 @@ export async function getDynamicUnreadStatus(
   username: string,
   token: string,
 ): Promise<DynamicUnreadStatus> {
-  const query = buildQuery({ username, token });
+  const query = buildQuery({ username });
   const response = await fetch(`${server_config.BASE_URL}/dynamics/unread?${query}`, {
     method: 'GET',
     headers: {

--- a/app/utils/message_processor.ts
+++ b/app/utils/message_processor.ts
@@ -6,7 +6,16 @@ import { AgentBinder } from './binder';
 import { addDebugTrace } from './debug_trace';
 import { NetworkClient } from './network_client';
 
-type SendItem = { clientMsgId: string } & (
+type SendKind =
+  | 'text'
+  | 'proactive'
+  | 'image'
+  | 'typing'
+  | 'touch'
+  | 'image_selecting'
+  | 'image_selecting_cancel';
+
+type SendItem = { clientMsgId: string; retryAttempt: number; enqueuedAtMs: number } & (
   | { kind: 'text'; uuid: string; text: string }
   | { kind: 'proactive'; uuid: string; text: string }
   | { kind: 'image'; uuid: string; imageUri: string; mimeType: string }
@@ -16,6 +25,25 @@ type SendItem = { clientMsgId: string } & (
   | { kind: 'image_selecting_cancel' }
 );
 
+export const MAX_DURABLE_RETRY_ATTEMPTS = 8;
+export const MAX_DURABLE_MESSAGE_AGE_MS = 4 * 60 * 1000;
+
+export function isDurableSendKind(kind: SendKind) {
+  return kind === 'text' || kind === 'image' || kind === 'proactive';
+}
+
+export function canRetryDurableMessage(
+  retryAttempt: number,
+  enqueuedAtMs: number,
+  retryDelayMs: number,
+  nowMs = Date.now(),
+) {
+  return (
+    retryAttempt < MAX_DURABLE_RETRY_ATTEMPTS
+    && nowMs - enqueuedAtMs + retryDelayMs < MAX_DURABLE_MESSAGE_AGE_MS
+  );
+}
+
 interface SendResult {
   ok: boolean;
   error?: string;
@@ -24,7 +52,11 @@ interface SendResult {
 
 function isTerminalSendError(errorText?: string) {
   const text = (errorText || '').toLowerCase();
-  return text.includes('not logged in') || text.includes('failed to read image file');
+  return text.includes('failed to read image file');
+}
+
+export function getSendRetryDelayMs(retryAttempt: number) {
+  return Math.min(2 ** Math.max(0, retryAttempt), 30) * 1000;
 }
 
 function getErrorMessage(error: unknown) {
@@ -120,20 +152,26 @@ export class MessageProcessor {
   }
 
   async sendText(uuid: string, text: string) {
-    this.sendQueue.push({ kind: 'text', uuid, text, clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'text', uuid, text, clientMsgId: this.nextClientMsgId(), retryAttempt: 0, enqueuedAtMs: Date.now(),
+    });
     addDebugTrace('send', 'enqueue text', { uuid, queueLength: this.sendQueue.length, textLength: text.length });
     this.binder.emitMessageStatus(uuid, 'waiting');
     this.startSendLoop();
   }
 
   async sendProactiveText(uuid: string, text: string) {
-    this.sendQueue.push({ kind: 'proactive', uuid, text, clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'proactive', uuid, text, clientMsgId: this.nextClientMsgId(), retryAttempt: 0, enqueuedAtMs: Date.now(),
+    });
     addDebugTrace('send', 'enqueue proactive text', { uuid, queueLength: this.sendQueue.length, textLength: text.length });
     this.startSendLoop();
   }
 
   async sendImage(uuid: string, imageUri: string, mimeType: string) {
-    this.sendQueue.push({ kind: 'image', uuid, imageUri, mimeType, clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'image', uuid, imageUri, mimeType, clientMsgId: this.nextClientMsgId(), retryAttempt: 0, enqueuedAtMs: Date.now(),
+    });
     addDebugTrace('send', 'enqueue image', { uuid, queueLength: this.sendQueue.length, mimeType });
     this.binder.emitMessageStatus(uuid, 'waiting');
     this.startSendLoop();
@@ -141,7 +179,10 @@ export class MessageProcessor {
 
   async sendTouch(touchArea: string | string[], clickFrequency?: Record<string, number>, touchMeta?: Record<string, unknown>) {
     addDebugTrace('send', 'enqueue touch', { touchArea, queueLength: this.sendQueue.length });
-    this.sendQueue.push({ kind: 'touch', touchArea, clickFrequency, touchMeta, clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'touch', touchArea, clickFrequency, touchMeta, clientMsgId: this.nextClientMsgId(), retryAttempt: 0,
+      enqueuedAtMs: Date.now(),
+    });
     this.startSendLoop();
   }
 
@@ -154,20 +195,26 @@ export class MessageProcessor {
       return;
     }
     this.lastTypingSentAt = now;
-    this.sendQueue.push({ kind: 'typing', textLength, clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'typing', textLength, clientMsgId: this.nextClientMsgId(), retryAttempt: 0, enqueuedAtMs: Date.now(),
+    });
     addDebugTrace('send', 'enqueue typing', { queueLength: this.sendQueue.length, textLength });
     this.startSendLoop();
   }
 
   async sendImageSelecting() {
     addDebugTrace('send', 'enqueue image_selecting');
-    this.sendQueue.push({ kind: 'image_selecting', clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'image_selecting', clientMsgId: this.nextClientMsgId(), retryAttempt: 0, enqueuedAtMs: Date.now(),
+    });
     this.startSendLoop();
   }
 
   async sendImageSelectingCancel() {
     addDebugTrace('send', 'enqueue image_selecting_cancel');
-    this.sendQueue.push({ kind: 'image_selecting_cancel', clientMsgId: this.nextClientMsgId() });
+    this.sendQueue.push({
+      kind: 'image_selecting_cancel', clientMsgId: this.nextClientMsgId(), retryAttempt: 0, enqueuedAtMs: Date.now(),
+    });
     this.startSendLoop();
   }
 
@@ -323,6 +370,8 @@ export class MessageProcessor {
         text: payload.text,
         expression: payload.expression || undefined,
         is_final_package: payload.is_final_package,
+        audio_error: payload.audio_error,
+        error_code: payload.error_code,
         display_in_chat: payload.display_in_chat,
         is_ephemeral: payload.is_ephemeral,
       });
@@ -331,6 +380,8 @@ export class MessageProcessor {
         uuid: convUuid,
         expression: payload.expression || undefined,
         is_final_package: payload.is_final_package,
+        audio_error: payload.audio_error,
+        error_code: payload.error_code,
         display_in_chat: payload.display_in_chat,
         is_ephemeral: payload.is_ephemeral,
       });
@@ -348,7 +399,16 @@ export class MessageProcessor {
     if (payload.is_final_package) {
       this.feedServerAudioChunk('', true);
       await this.waitForServerAudioFinished();
-      await this.saveAudioToLocal(convUuid);
+      if (payload.audio_error) {
+        this.audioChunksByUuid.delete(convUuid);
+        this.transientMessageUuids.delete(convUuid);
+        addDebugTrace('audio', 'server audio stream ended with error', {
+          convUuid,
+          errorCode: payload.error_code || 'UNKNOWN',
+        });
+      } else {
+        await this.saveAudioToLocal(convUuid);
+      }
     }
   }
 
@@ -379,7 +439,7 @@ export class MessageProcessor {
         addDebugTrace('audio', 'waitForServerAudioFinished timeout', {
           timeoutMs,
         });
-        onFinished();
+        this.onServerAudioFinished();
       }, timeoutMs);
 
       this.serverAudioFinishWaiters.push(onFinished);
@@ -408,43 +468,82 @@ export class MessageProcessor {
       }
 
       const item = this.sendQueue[0];
-      const result = await this.sendOne(item);
-
-      if (item.kind === 'typing' || item.kind === 'proactive' || item.kind === 'touch' || item.kind === 'image_selecting' || item.kind === 'image_selecting_cancel') {
-        addDebugTrace('send', `${item.kind} sent`, { ok: result.ok, error: result.error });
+      const durable = isDurableSendKind(item.kind);
+      if (durable && Date.now() - item.enqueuedAtMs >= MAX_DURABLE_MESSAGE_AGE_MS) {
+        this.failDeliveryUncertain(item, 'message exceeded the automatic delivery window');
         this.sendQueue.shift();
         continue;
       }
 
+      const result = await this.sendOne(item);
+      const tracksMessageStatus = durable && 'uuid' in item;
+
       if (result.ok) {
-        addDebugTrace('send', 'send success', { uuid: item.uuid, kind: item.kind, queueLength: this.sendQueue.length });
-        this.binder.emitMessageStatus(item.uuid, 'submitted');
+        addDebugTrace('send', 'send success', { kind: item.kind, queueLength: this.sendQueue.length });
+        if (tracksMessageStatus) {
+          this.binder.emitMessageStatus(item.uuid, 'submitted');
+        }
+        this.sendQueue.shift();
+        continue;
+      }
+
+      if (!durable) {
+        addDebugTrace('send', 'transient event dropped after send failure', {
+          kind: item.kind,
+          error: result.error,
+        });
         this.sendQueue.shift();
         continue;
       }
 
       if (result.drop || isTerminalSendError(result.error)) {
         addDebugTrace('send', 'send failed terminal', {
-          uuid: item.uuid,
           kind: item.kind,
           error: result.error,
           drop: result.drop,
         });
-        this.binder.emitMessageStatus(item.uuid, 'failed');
+        if (tracksMessageStatus) {
+          this.binder.emitMessageStatus(item.uuid, 'failed');
+        }
         this.sendQueue.shift();
         continue;
       }
 
+      const retryDelayMs = getSendRetryDelayMs(item.retryAttempt);
+      if (!canRetryDurableMessage(item.retryAttempt, item.enqueuedAtMs, retryDelayMs)) {
+        this.failDeliveryUncertain(item, result.error || 'delivery acknowledgement was not received');
+        this.sendQueue.shift();
+        continue;
+      }
+      item.retryAttempt += 1;
       addDebugTrace('send', 'send failed retry', {
-        uuid: item.uuid,
         kind: item.kind,
         error: result.error,
+        retryAttempt: item.retryAttempt,
+        retryDelayMs,
       });
-      this.binder.emitMessageStatus(item.uuid, 'waiting');
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      if (tracksMessageStatus) {
+        this.binder.emitMessageStatus(item.uuid, 'waiting');
+      }
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
 
     this.sendLoopRunning = false;
+  }
+
+  private failDeliveryUncertain(item: SendItem, reason: string) {
+    addDebugTrace('send', 'durable message delivery is uncertain', {
+      kind: item.kind,
+      clientMsgId: item.clientMsgId,
+      retryAttempt: item.retryAttempt,
+      ageMs: Date.now() - item.enqueuedAtMs,
+      code: 'DELIVERY_UNCERTAIN',
+      reason,
+    });
+    if ('uuid' in item) {
+      this.binder.emitMessageStatus(item.uuid, 'failed');
+    }
+    this.binder.emitErrorText('[DELIVERY_UNCERTAIN] 消息发送结果无法确认，请检查会话后再重试。');
   }
 
   private async sendOne(item: SendItem): Promise<SendResult> {

--- a/app/utils/message_processor.ts
+++ b/app/utils/message_processor.ts
@@ -114,6 +114,7 @@ export class MessageProcessor {
   private readonly networkClient: NetworkClient;
   private readonly binder: AgentBinder;
   private readonly feedServerAudioChunk: (base64Audio: string, isFinal: boolean) => void;
+  private readonly stopServerAudio: () => void;
   private sendQueue: SendItem[] = [];
   private sendLoopRunning = false;
   private stopRequested = false;
@@ -131,15 +132,18 @@ export class MessageProcessor {
     networkClient: NetworkClient,
     binder: AgentBinder,
     feedServerAudioChunk: (base64Audio: string, isFinal: boolean) => void,
+    stopServerAudio?: () => void,
   ) {
     this.networkClient = networkClient;
     this.binder = binder;
     this.feedServerAudioChunk = feedServerAudioChunk;
+    this.stopServerAudio = stopServerAudio || (() => {});
   }
 
   stop() {
     this.stopRequested = true;
     this.sendQueue = [];
+    this.stopServerAudio();
     void this.stopLocalTts();
   }
 
@@ -224,6 +228,10 @@ export class MessageProcessor {
       addDebugTrace('audio', 'play blocked by server audio playing', { convUuid });
       return false;
     }
+
+    // 防御性清空 WebView 音频队列：即使 serverAudioPlaying 标志因异常未同步，
+    // 也保证本地播放开始时没有服务端音频在播（单播放器互斥）。
+    this.stopServerAudio();
 
     const localUri = this.audioPathByUuid.get(convUuid);
     if (!localUri) {
@@ -392,7 +400,7 @@ export class MessageProcessor {
     const convUuid = payload.uuid || `agent-${Date.now()}`;
 
     if (this.localPlayingUuid) {
-      void this.stopLocalTts();
+      await this.stopLocalTts();
     }
 
     const audioChunk = payload.audio || '';

--- a/app/utils/message_processor.ts
+++ b/app/utils/message_processor.ts
@@ -343,25 +343,25 @@ export class MessageProcessor {
   }
 
   onAgentMessage(payload: AgentMessagePayload) {
+    // 文本与表情展示即时执行，不被上一句的音频完成/落盘阻塞，
+    // 保证多句回复可以流式渲染出全部句子（而不是只显示第一句）。
+    this.handleAgentMessageDisplay(payload);
+    // 音频链路保持串行：分片累积、播放、落盘按到达顺序执行。
     this.incomingMessageChain = this.incomingMessageChain
-      .then(() => this.handleAgentMessage(payload))
+      .then(() => this.handleAgentMessageAudio(payload))
       .catch((error) => {
-        addDebugTrace('agent', 'handleAgentMessage failed', {
+        addDebugTrace('agent', 'handleAgentMessageAudio failed', {
           error: getErrorMessage(error),
         });
       });
   }
 
-  private async handleAgentMessage(payload: AgentMessagePayload) {
+  private handleAgentMessageDisplay(payload: AgentMessagePayload) {
     const convUuid = payload.uuid || `agent-${Date.now()}`;
     const displayInChat = payload.display_in_chat !== false;
 
     if (!displayInChat) {
       this.transientMessageUuids.add(convUuid);
-    }
-
-    if (this.localPlayingUuid) {
-      void this.stopLocalTts();
     }
 
     if (displayInChat && payload.text && payload.text.trim().length > 0) {
@@ -385,6 +385,14 @@ export class MessageProcessor {
         display_in_chat: payload.display_in_chat,
         is_ephemeral: payload.is_ephemeral,
       });
+    }
+  }
+
+  private async handleAgentMessageAudio(payload: AgentMessagePayload) {
+    const convUuid = payload.uuid || `agent-${Date.now()}`;
+
+    if (this.localPlayingUuid) {
+      void this.stopLocalTts();
     }
 
     const audioChunk = payload.audio || '';

--- a/app/utils/ws_ack.ts
+++ b/app/utils/ws_ack.ts
@@ -1,0 +1,27 @@
+export interface AckResult {
+  ok: boolean;
+  request_id: string;
+  error?: string;
+  drop?: boolean;
+  code?: string;
+  retryable?: boolean;
+}
+
+export function normalizeServerAck(payload: Record<string, unknown>, requestId: string): AckResult {
+  // Older servers did not send `ok`; preserve their positive-ACK behavior.
+  if (payload.ok !== false) {
+    return { ok: true, request_id: requestId };
+  }
+
+  const code = typeof payload.code === 'string' ? payload.code : 'REJECTED';
+  const retryable = payload.retryable === true;
+  const message = typeof payload.message === 'string' ? payload.message : code;
+  return {
+    ok: false,
+    request_id: requestId,
+    error: `[${code}] ${message}`,
+    code,
+    retryable,
+    drop: !retryable,
+  };
+}

--- a/app/utils/ws_transport.ts
+++ b/app/utils/ws_transport.ts
@@ -3,13 +3,12 @@ import { server_config } from '../config';
 import { AgentMessagePayload } from '../types/chat';
 import { WSEventType } from '../types/ws_events';
 import { addDebugTrace } from './debug_trace';
+import { AckResult, normalizeServerAck } from './ws_ack';
 
-interface AckResult {
-  ok: boolean;
-  request_id: string;
-  error?: string;
-  drop?: boolean;
-}
+export type { AckResult } from './ws_ack';
+export { normalizeServerAck } from './ws_ack';
+
+export const WS_CLIENT_CAPABILITIES = ['negative_ack_v1'] as const;
 
 interface ServerEnvelope {
   type?: string;
@@ -46,6 +45,7 @@ export class WebSocketTransport {
   private isStopped = true;
   private isConnected = false;
   private isAuthed = false;
+  private authRejected = false;
 
   constructor(username: string, token: string, callbacks: WsCallbacks) {
     this.username = username;
@@ -99,6 +99,7 @@ export class WebSocketTransport {
 
   start() {
     this.isStopped = false;
+    this.authRejected = false;
     addDebugTrace('ws', 'start transport', { username: this.username });
     if (!this.appStateSubscription) {
       this.appStateSubscription = AppState.addEventListener('change', this.handleAppStateChange);
@@ -113,7 +114,11 @@ export class WebSocketTransport {
     addDebugTrace('ws', 'stop transport');
     this.clearReconnectTimer();
     this.stopHeartbeat();
-    this.rejectAllWaiters('websocket stopped');
+    this.rejectAllWaiters('websocket stopped', {
+      code: 'TRANSPORT_STOPPED',
+      retryable: false,
+      drop: true,
+    });
     this.reconnectPausedForBackground = false;
     this.reconnectDueAt = null;
     this.reconnectDelayMs = null;
@@ -207,7 +212,6 @@ export class WebSocketTransport {
 
     this.ws.onopen = () => {
       this.isConnected = true;
-      this.reconnectAttempts = 0;
       this.sendAuth();
       this.startHeartbeat();
     };
@@ -232,7 +236,16 @@ export class WebSocketTransport {
       this.isConnected = false;
       this.isAuthed = false;
       this.stopHeartbeat();
+      this.rejectAllWaiters('websocket disconnected', {
+        code: 'DISCONNECTED',
+        retryable: true,
+        drop: false,
+      });
       if (this.isStopped) {
+        return;
+      }
+      if (!this.canReconnectAfterClose()) {
+        addDebugTrace('ws', 'reconnect suppressed after authentication rejection');
         return;
       }
 
@@ -334,6 +347,7 @@ export class WebSocketTransport {
       payload: {
         username: this.username,
         token: this.token,
+        capabilities: [...WS_CLIENT_CAPABILITIES],
       },
     });
   }
@@ -361,19 +375,35 @@ export class WebSocketTransport {
     }
   }
 
-  private async waitUntilReady(timeoutMs = 10000) {
+  private async waitUntilReady(
+    timeoutMs = 10000,
+  ): Promise<'ready' | 'auth_rejected' | 'stopped' | 'timeout'> {
     const start = Date.now();
     while (!this.isStopped && (!this.isConnected || !this.isAuthed)) {
+      if (this.authRejected) {
+        return 'auth_rejected';
+      }
       if (Date.now() - start > timeoutMs) {
         addDebugTrace('ws', 'waitUntilReady timeout', {
           waitedMs: Date.now() - start,
           isConnected: this.isConnected,
           isAuthed: this.isAuthed,
         });
-        throw new Error('websocket not ready');
+        return 'timeout';
       }
       await new Promise((resolve) => setTimeout(resolve, 80));
     }
+    if (this.authRejected) {
+      return 'auth_rejected';
+    }
+    if (this.isStopped) {
+      return 'stopped';
+    }
+    return 'ready';
+  }
+
+  private canReconnectAfterClose() {
+    return !this.authRejected;
   }
 
   private async sendWithAck(
@@ -384,15 +414,17 @@ export class WebSocketTransport {
   ): Promise<AckResult> {
     const requestId = clientMsgId || `c-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-    try {
-      await this.waitUntilReady();
-    } catch {
+    const readiness = await this.waitUntilReady();
+    if (readiness !== 'ready') {
+      const permanent = readiness === 'auth_rejected' || readiness === 'stopped';
       addDebugTrace('ack', 'sendWithAck blocked: websocket not ready', { eventType, requestId });
       return {
         ok: false,
         request_id: requestId,
-        error: 'not logged in',
-        drop: true,
+        error: readiness === 'auth_rejected' ? 'authentication rejected' : 'websocket not ready',
+        code: readiness === 'auth_rejected' ? 'AUTH_REJECTED' : 'NOT_READY',
+        retryable: !permanent,
+        drop: permanent,
       };
     }
 
@@ -408,24 +440,42 @@ export class WebSocketTransport {
       }, timeoutMs);
 
       this.ackWaiters.set(requestId, { resolve, timer });
-      this.sendRaw({
+      const sent = this.sendRaw({
         type: eventType,
         client_msg_id: requestId,
         ts: Date.now(),
         payload,
       });
+      if (!sent) {
+        clearTimeout(timer);
+        this.ackWaiters.delete(requestId);
+        resolve({
+          ok: false,
+          request_id: requestId,
+          error: 'websocket disconnected before send',
+          code: 'DISCONNECTED',
+          retryable: true,
+          drop: false,
+        });
+      }
     });
   }
 
-  private sendRaw(message: Record<string, unknown>) {
+  private sendRaw(message: Record<string, unknown>): boolean {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       addDebugTrace('ws', 'sendRaw skipped: socket not open', {
         readyState: this.ws?.readyState,
         type: String(message.type || ''),
       });
-      return;
+      return false;
     }
-    this.ws.send(JSON.stringify(message));
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      addDebugTrace('ws', 'sendRaw failed', { type: String(message.type || '') });
+      return false;
+    }
   }
 
   private handleServerMessage(raw: unknown) {
@@ -440,14 +490,29 @@ export class WebSocketTransport {
       }
 
       if (eventType === WSEventType.AUTH_OK) {
+        this.authRejected = false;
         this.isAuthed = true;
+        this.reconnectAttempts = 0;
         return;
       }
 
       if (eventType === WSEventType.AUTH_ERROR) {
         this.isAuthed = false;
+        this.authRejected = true;
+        this.rejectAllWaiters(String(payload.message || 'authentication rejected'), {
+          code: 'AUTH_REJECTED',
+          retryable: false,
+          drop: true,
+        });
         addDebugTrace('ws', 'recv auth_error', { message: String(payload.message || '鉴权失败') });
         this.callbacks.onError(String(payload.message || '鉴权失败'));
+        this.clearReconnectTimer();
+        this.stopHeartbeat();
+        try {
+          this.ws?.close();
+        } catch {
+          // The close path already suppresses reconnect for rejected credentials.
+        }
         return;
       }
 
@@ -457,7 +522,7 @@ export class WebSocketTransport {
           const waiter = this.ackWaiters.get(replyTo)!;
           clearTimeout(waiter.timer);
           this.ackWaiters.delete(replyTo);
-          waiter.resolve({ ok: true, request_id: replyTo });
+          waiter.resolve(normalizeServerAck(payload, replyTo));
         }
         return;
       }
@@ -482,7 +547,10 @@ export class WebSocketTransport {
     }
   }
 
-  private rejectAllWaiters(errorText: string) {
+  private rejectAllWaiters(
+    errorText: string,
+    options: Pick<AckResult, 'code' | 'retryable' | 'drop'> = {},
+  ) {
     addDebugTrace('ack', 'reject all waiters', { count: this.ackWaiters.size, errorText });
     for (const [requestId, waiter] of this.ackWaiters.entries()) {
       clearTimeout(waiter.timer);
@@ -490,6 +558,7 @@ export class WebSocketTransport {
         ok: false,
         request_id: requestId,
         error: errorText,
+        ...options,
       });
     }
     this.ackWaiters.clear();

--- a/client/docs/dev/统一事件协议.md
+++ b/client/docs/dev/统一事件协议.md
@@ -78,6 +78,7 @@ S -> C: agent_message
 `payload` 字段：
 1. `username`: 字符串，必填
 2. `token`: 字符串，必填（即 `message_token`）
+3. `capabilities`: 字符串数组，可选；当前客户端声明 `negative_ack_v1`
 
 示例：
 
@@ -87,7 +88,8 @@ S -> C: agent_message
   "client_msg_id": "auth-1",
   "payload": {
     "username": "dpon",
-    "token": "<message_token>"
+    "token": "<message_token>",
+    "capabilities": ["negative_ack_v1"]
   }
 }
 ```
@@ -236,6 +238,10 @@ S -> C: agent_message
 3. `audio`: 字符串或 `null`（通常为 Base64 音频数据，当前简化链路可能为空字符串）
 4. `expression`: 字符串或 `null`
 5. `is_final_package`: 布尔
+6. `audio_error`: 可选布尔；为 `true` 时音频生成失败，但该包仍是终止包
+7. `error_code`: 可选字符串；例如 `TTS_EMPTY`、`TTS_STREAM_ERROR`
+
+每个回复 UUID 必须以一个 `is_final_package=true` 包结束。即使 `audio_error=true`，客户端也必须结束 loading/playing 状态、保留已收到的文本，并且不得保存失败流的部分音频。
 
 示例：
 
@@ -268,7 +274,10 @@ S -> C: agent_message
 
 ### 5.8 server_ack
 
-用途：确认服务端已接收并入队一个客户端聊天输入事件。
+用途：报告服务端是否已接纳一个客户端聊天输入事件。
+
+`payload.ok=true` 只表示事件已进入当前服务端进程的内存队列，不表示业务处理完成或已持久化。
+声明 `negative_ack_v1` 的客户端可以收到 `payload.ok=false`。未声明该能力的旧客户端不能把负 ACK 识别为失败，服务端不得向其发送负 ACK。
 
 当前会发送 ACK 的客户端事件类型：
 1. `user_text`
@@ -276,7 +285,12 @@ S -> C: agent_message
 3. `user_typing`
 
 `payload` 字段：
-1. `received_event_type`: 字符串，表示被确认接收的事件类型
+1. `ok`: 布尔；`true` 表示已接纳，`false` 表示未接纳
+2. `received_event_type`: 字符串，表示对应事件类型
+3. `duplicate`: 可选布尔；表示该 ID 已经接纳，本次没有重复入队
+4. `code`: 负 ACK 错误码，例如 `OVERLOADED`、`BAD_MESSAGE`
+5. `message`: 负 ACK 说明
+6. `retryable`: 负 ACK 是否允许客户端自动重试
 
 通常会带 `reply_to`，值为对应客户端事件的 `client_msg_id`。
 
@@ -288,6 +302,7 @@ S -> C: agent_message
   "ts": 1773474001000,
   "reply_to": "msg-1",
   "payload": {
+    "ok": true,
     "received_event_type": "user_text"
   }
 }
@@ -297,6 +312,10 @@ S -> C: agent_message
 
 1. 鉴权前发送聊天消息不会进入聊天流程；必须先 `auth` 成功。
 2. 非 JSON、非对象、缺少 `type` 的消息会收到 `error`。
-3. 当前已实现接收确认事件 `server_ack`，但未实现重传与 `done` 事件；客户端应以 `agent_message` 和 `agent_state_changed` 作为主要渲染依据。
+3. `text`、`image`、`proactive` 在可重试失败时复用原 `client_msg_id`，按 1、2、4 秒指数退避（最大 30 秒）；最多自动重试 8 次，且下一次尝试必须发生在入队后 4 分钟内。
 4. 断线后可重连，同一用户会复用对应 chat_stream（服务端侧管理）。
 5. 心跳建议每 5 到 30 秒发送一次，避免连接被服务端清理任务回收。
+6. 重试次数或总龄期超限时，客户端将消息标为 `failed`，错误码为 `DELIVERY_UNCERTAIN`；这表示无法确认是否送达，不能自动换新 ID 再发。
+7. `typing`、`touch`、`image_selecting`、`image_selecting_cancel` 是瞬时事件，发送失败后直接丢弃或被新状态合并，不得阻塞业务消息队列。
+8. 收到明确 `auth_error` 后，客户端停止以相同凭据自动重连；凭据变化后才能重新开始鉴权。
+9. 尚未实现业务完成 `done` 事件；渲染仍以 `agent_message` 和 `agent_state_changed` 为准。

--- a/client/src/delivery_policy.py
+++ b/client/src/delivery_policy.py
@@ -1,0 +1,39 @@
+import time
+
+
+MAX_DURABLE_RETRY_ATTEMPTS = 8
+MAX_DURABLE_MESSAGE_AGE_SECONDS = 4 * 60
+DURABLE_SEND_KINDS = frozenset({"text", "image", "proactive"})
+
+
+def get_send_retry_delay_seconds(retry_attempt: int) -> float:
+    return float(min(2 ** max(0, retry_attempt), 30))
+
+
+def is_durable_send_kind(kind: str) -> bool:
+    return kind in DURABLE_SEND_KINDS
+
+
+def can_retry_durable_message(
+    retry_attempt: int,
+    enqueued_monotonic: float,
+    retry_delay: float,
+    *,
+    now: float | None = None,
+) -> bool:
+    current = time.monotonic() if now is None else now
+    return (
+        retry_attempt < MAX_DURABLE_RETRY_ATTEMPTS
+        and current - enqueued_monotonic + retry_delay < MAX_DURABLE_MESSAGE_AGE_SECONDS
+    )
+
+
+def delivery_uncertain_result(request_id: str, reason: str) -> dict:
+    return {
+        "ok": False,
+        "request_id": request_id,
+        "error": f"[DELIVERY_UNCERTAIN] {reason}",
+        "code": "DELIVERY_UNCERTAIN",
+        "retryable": False,
+        "drop": True,
+    }

--- a/client/src/message_process/message_processor.py
+++ b/client/src/message_process/message_processor.py
@@ -8,11 +8,18 @@ import re
 import base64
 import datetime
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from collections import deque
 from typing import Callable, TYPE_CHECKING
-from ..network.event_types import AgentMessage
+from ..network.event_types import AgentMessage, is_audio_terminal
 from ..utils.logger import get_logger
+from ..delivery_policy import (
+    MAX_DURABLE_MESSAGE_AGE_SECONDS,
+    can_retry_durable_message,
+    delivery_uncertain_result,
+    get_send_retry_delay_seconds,
+    is_durable_send_kind,
+)
 
 if TYPE_CHECKING:
     from ..network.network_client import NetworkClient
@@ -25,6 +32,9 @@ class OutgoingMessage:
     payload: dict
     done_event: threading.Event
     result: dict | None = None
+    retry_attempt: int = 0
+    enqueued_monotonic: float = field(default_factory=time.monotonic)
+
 
 class MessageProcessor:
     def __init__(self,
@@ -223,11 +233,17 @@ class MessageProcessor:
             except Exception as exc:
                 self.logger.error(f"Failed to decode audio chunk (uuid={response.uuid}): {exc}")
 
-        if response.is_final_package:
+        if is_audio_terminal(response):
             self.multimedia_stream.finish_one_sentense()
             # 将最终的音频结果保存到本地
             saved_uuid = self.processing_uuid
-            ret = self._save_audio_to_temp(self.processing_audio, saved_uuid, ".wav")
+            ret = ""
+            if self.processing_audio and not response.audio_error:
+                ret = self._save_audio_to_temp(self.processing_audio, saved_uuid, ".wav")
+            if response.audio_error:
+                self.logger.warning(
+                    f"Audio stream ended with error (uuid={saved_uuid}, code={response.error_code or 'UNKNOWN'})"
+                )
             self.processing_audio = bytearray()
             self.processing_uuid = None
             if display_in_chat and ret and self.update_bubble_signal:
@@ -246,7 +262,13 @@ class MessageProcessor:
                     return
                 item = self._send_queue[0]
 
-            self.update_bubble_signal(item.local_id, "waiting")
+            durable = is_durable_send_kind(item.kind)
+            if durable and time.monotonic() - item.enqueued_monotonic >= MAX_DURABLE_MESSAGE_AGE_SECONDS:
+                self._fail_delivery_uncertain(item, "message exceeded the automatic delivery window")
+                continue
+
+            if durable:
+                self.update_bubble_signal(item.local_id, "waiting")
             ack = self._send_one(item)
             if ack.get("ok", False):
                 with self._send_cond:
@@ -254,11 +276,23 @@ class MessageProcessor:
                         self._send_queue.popleft()
                 item.result = ack
                 item.done_event.set()
-                self.update_bubble_signal(item.local_id, "submitted")
+                if durable:
+                    self.update_bubble_signal(item.local_id, "submitted")
                 continue
 
             error_text = str(ack.get("error") or "")
             self.logger.error(f"Failed to send message (local_id={item.local_id}): {error_text}")
+            if not durable:
+                with self._send_cond:
+                    if self._send_queue and self._send_queue[0] is item:
+                        self._send_queue.popleft()
+                item.result = ack
+                item.done_event.set()
+                self.logger.debug(
+                    f"Dropped transient event after send failure (kind={item.kind}, local_id={item.local_id})"
+                )
+                continue
+
             if self._is_terminal_send_error(error_text) or ack.get("drop", False):
                 with self._send_cond:
                     if self._send_queue and self._send_queue[0] is item:
@@ -267,9 +301,31 @@ class MessageProcessor:
                 item.done_event.set()
                 self.update_bubble_signal(item.local_id, "failed")
                 continue
+            retry_delay = get_send_retry_delay_seconds(item.retry_attempt)
+            if not can_retry_durable_message(
+                item.retry_attempt,
+                item.enqueued_monotonic,
+                retry_delay,
+            ):
+                self._fail_delivery_uncertain(item, error_text or "delivery acknowledgement was not received")
+                continue
+            item.retry_attempt += 1
             self.update_bubble_signal(item.local_id, "waiting")
-            # Retransmit head item after 1s when ack timeout/disconnect occurs.
-            time.sleep(1.0)
+            time.sleep(retry_delay)
+
+    def _fail_delivery_uncertain(self, item: OutgoingMessage, reason: str) -> None:
+        result = delivery_uncertain_result(item.client_msg_id, reason)
+        with self._send_cond:
+            if self._send_queue and self._send_queue[0] is item:
+                self._send_queue.popleft()
+        item.result = result
+        item.done_event.set()
+        self.update_bubble_signal(item.local_id, "failed")
+        self.logger.error(
+            "Durable message delivery is uncertain "
+            f"(local_id={item.local_id}, client_msg_id={item.client_msg_id}, "
+            f"retry_attempt={item.retry_attempt}): {reason}"
+        )
 
     def feed_agent_msg(self, payload: AgentMessage): # 接收WS传来的消息，放入队列等待处理
         self._event_queue.put(payload)
@@ -413,8 +469,6 @@ class MessageProcessor:
     @staticmethod
     def _is_terminal_send_error(error_text: str) -> bool:
         text = error_text.lower()
-        if "not logged in" in text:
-            return True
         if "failed to read image file" in text:
             return True
         return False

--- a/client/src/network/event_types.py
+++ b/client/src/network/event_types.py
@@ -55,6 +55,8 @@ class AgentMessage:
     is_final_package: bool
     uuid: str | None
     reply_to: str | None
+    audio_error: bool = False
+    error_code: str | None = None
     display_in_chat: bool = True
     is_ephemeral: bool = False
 
@@ -114,9 +116,16 @@ def normalize_agent_message(message: WSMessage) -> AgentMessage:
         is_final_package=bool(payload.get("is_final_package", True)),
         uuid=payload.get("uuid"),
         reply_to=message.reply_to,
+        audio_error=bool(payload.get("audio_error", False)),
+        error_code=payload.get("error_code"),
         display_in_chat=bool(payload.get("display_in_chat", True)),
         is_ephemeral=bool(payload.get("is_ephemeral", False)),
     )
+
+
+def is_audio_terminal(message: AgentMessage) -> bool:
+    """All final packages, including audio failures, end client playback."""
+    return message.is_final_package
 
 
 def normalize_error_message(message: WSMessage) -> ErrorMessage:

--- a/client/src/network/network_client.py
+++ b/client/src/network/network_client.py
@@ -551,5 +551,4 @@ class NetworkClient:
                 )
         except Exception as exc:
             self.logger.error(f"Failed to retrieve image for history item {item.uuid}: {exc}")
-        finally:
-            return item
+        return item

--- a/client/src/network/ws_transport.py
+++ b/client/src/network/ws_transport.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import ssl
 import threading
+import time
 from typing import Callable
 
 import websockets
@@ -10,7 +11,30 @@ from .event_types import build_event, normalize_agent_message, normalize_error_m
 from ..utils.logger import get_logger
 from ..utils.tls import create_default_ssl_context
 
+
+WS_CLIENT_CAPABILITIES = ("negative_ack_v1",)
+
+
+def normalize_server_ack(payload: dict) -> dict:
+    """Normalize positive and negative ACK payloads, including legacy ACKs."""
+    if payload.get("ok") is not False:
+        return {"ok": True, "error": None}
+
+    code = payload.get("code") if isinstance(payload.get("code"), str) else "REJECTED"
+    retryable = payload.get("retryable") is True
+    message = payload.get("message") if isinstance(payload.get("message"), str) else code
+    return {
+        "ok": False,
+        "error": f"[{code}] {message}",
+        "code": code,
+        "retryable": retryable,
+        "drop": not retryable,
+    }
+
+
 class WsTransport:
+    READY_TIMEOUT_SECONDS = 8.0
+
     def __init__(
         self,
         base_url: str,
@@ -40,6 +64,7 @@ class WsTransport:
         self._stop_event = threading.Event()
         self._ready_event = threading.Event()
         self._connected_event = threading.Event()
+        self._auth_rejected_credentials: tuple[str | None, str | None] | None = None
 
     def set_base_url(self, base_url: str, verify_ssl: bool) -> None:
         """更新服务器地址，断开当前连接以便自动重连到新地址。"""
@@ -62,7 +87,12 @@ class WsTransport:
         self._stop_event.set()
         self._ready_event.clear()
         self._connected_event.clear()
-        self._notify_ack_failure("WebSocket disconnected")
+        self._notify_ack_failure(
+            "WebSocket stopped",
+            drop=True,
+            code="TRANSPORT_STOPPED",
+            retryable=False,
+        )
         self.logger.debug("WebSocket disconnected")
         if self._loop and self._ws:
             try:
@@ -162,12 +192,30 @@ class WsTransport:
         request_id = event.client_msg_id
 
         self.start()
-        if not self._ready_event.wait(timeout=8): # 验证是否登录，从而完整地建立WS连接，避免登录后立即发消息导致的鉴权失败问题
+        deadline = time.monotonic() + self.READY_TIMEOUT_SECONDS
+        while not self._ready_event.is_set():
+            if self._is_auth_rejected():
+                return {
+                    "ok": False,
+                    "request_id": request_id,
+                    "error": "WebSocket authentication rejected",
+                    "code": "AUTH_REJECTED",
+                    "retryable": False,
+                    "drop": True,
+                }
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            self._ready_event.wait(timeout=min(0.1, remaining))
+
+        if not self._ready_event.is_set():
             return {
                 "ok": False,
                 "request_id": request_id,
                 "error": "WebSocket auth timeout",
-                "drop": True,
+                "code": "NOT_READY",
+                "retryable": True,
+                "drop": False,
             }
 
         with self._submit_lock:
@@ -187,7 +235,7 @@ class WsTransport:
                     "ok": False,
                     "request_id": request_id,
                     "error": "Send failed",
-                    "drop": True,
+                    "drop": False,
                 }
 
             if not waiter["event"].wait(timeout=max(0.1, ack_timeout)):
@@ -199,7 +247,7 @@ class WsTransport:
                     "ok": False,
                     "request_id": request_id,
                     "error": "Wait server ack timeout",
-                    "drop": True,
+                    "drop": False,
                 }
 
             result = waiter["result"] or {
@@ -248,6 +296,9 @@ class WsTransport:
                     self._ready_event.clear()
 
                     await self._authenticate(ws)
+                    if self._is_auth_rejected():
+                        await ws.close()
+                        return
                     recv_task = asyncio.create_task(self._recv_loop(ws))
                     hb_task = asyncio.create_task(self._heartbeat_loop(ws))
                     reconnect_delay = 2
@@ -264,7 +315,12 @@ class WsTransport:
                             self.logger.error(f"WebSocket inner task exited with error: {exc}")
             except Exception as e:
                 self.logger.error(f"WebSocket connection error: {e}")
-                self._notify_ack_failure("WebSocket disconnected")
+                self._notify_ack_failure(
+                    "WebSocket disconnected",
+                    drop=False,
+                    code="DISCONNECTED",
+                    retryable=True,
+                )
                 self.logger.debug("WebSocket connection closed, retrying...")
                 await asyncio.sleep(reconnect_delay)
                 reconnect_delay = min(reconnect_delay * 2, 30) # 指数退避，最大30秒
@@ -280,7 +336,11 @@ class WsTransport:
             raw = await asyncio.wait_for(ws.recv(), timeout=5)
             msg = parse_server_message(raw)
             if msg and msg.event_type == WSEventType.AUTH_OK:
+                self._auth_rejected_credentials = None
                 self._ready_event.set()
+                return
+            if msg and msg.event_type == WSEventType.AUTH_ERROR:
+                self._mark_auth_rejected()
                 return
         except Exception as e:
             self.logger.error(f"Error occurred while waiting for auth response: {e}")
@@ -290,9 +350,17 @@ class WsTransport:
         token = self.token_getter()
         if not username or not token:
             self.logger.error("WebSocket auth failed: missing username or token")
+            self._mark_auth_rejected()
             return
 
-        auth_event = build_event(WSEventType.USER_AUTH, payload={"username": username, "token": token})
+        auth_event = build_event(
+            WSEventType.USER_AUTH,
+            payload={
+                "username": username,
+                "token": token,
+                "capabilities": list(WS_CLIENT_CAPABILITIES),
+            },
+        )
         await ws.send(json.dumps(auth_event.__dict__(), ensure_ascii=False))
 
         # 等待 auth_ok
@@ -303,9 +371,14 @@ class WsTransport:
                 continue
             if msg.event_type == WSEventType.AUTH_OK:
                 self.logger.debug("WebSocket auth successful")
+                self._auth_rejected_credentials = None
                 self._ready_event.set()
                 return
-            if msg.event_type in (WSEventType.AUTH_ERROR, WSEventType.SERVER_ERROR):
+            if msg.event_type == WSEventType.AUTH_ERROR:
+                self._mark_auth_rejected()
+                self.logger.error(f"WebSocket auth failed: {msg.payload.get('message')}")
+                return
+            if msg.event_type == WSEventType.SERVER_ERROR:
                 self.logger.error(f"WebSocket auth failed: {msg.payload.get('message')}")
                 return
 
@@ -319,7 +392,15 @@ class WsTransport:
 
             if event_type == WSEventType.SERVER_ACK:
                 self.logger.debug(f"Received ack for request_id {msg.reply_to}")
-                self._complete_ack_waiter(ok=True, error=None, reply_to=msg.reply_to)
+                ack = normalize_server_ack(msg.payload)
+                self._complete_ack_waiter(
+                    ok=ack["ok"],
+                    error=ack["error"],
+                    reply_to=msg.reply_to,
+                    drop=ack.get("drop"),
+                    code=ack.get("code"),
+                    retryable=ack.get("retryable"),
+                )
                 continue
 
             if event_type == WSEventType.AGENT_MESSAGE:
@@ -339,10 +420,17 @@ class WsTransport:
 
             if event_type in (WSEventType.SERVER_ERROR, WSEventType.AUTH_ERROR):
                 error_msg = normalize_error_message(msg)
+                is_auth_rejection = event_type == WSEventType.AUTH_ERROR
+                if is_auth_rejection:
+                    self._mark_auth_rejected()
+                    self._ready_event.clear()
                 consumed = self._complete_ack_waiter(
                     ok=False,
                     error=f"[{error_msg.code}] {error_msg.message}",
                     reply_to=error_msg.reply_to,
+                    drop=True if is_auth_rejection else None,
+                    code="AUTH_REJECTED" if is_auth_rejection else None,
+                    retryable=False if is_auth_rejection else None,
                 )
                 if not consumed:
                     self._emit_agent_message(
@@ -369,7 +457,16 @@ class WsTransport:
             await asyncio.sleep(self.heartbeat_interval)
         self.logger.debug("WebSocket heartbeat loop exited")
 
-    def _complete_ack_waiter(self, ok: bool, error: str | None, reply_to: str | None) -> bool:
+    def _complete_ack_waiter(
+        self,
+        ok: bool,
+        error: str | None,
+        reply_to: str | None,
+        *,
+        drop: bool | None = None,
+        code: str | None = None,
+        retryable: bool | None = None,
+    ) -> bool:
         with self._lock:
             waiter = self._ack_waiter
             if not waiter:
@@ -386,11 +483,24 @@ class WsTransport:
                 "request_id": expected,
                 "error": error,
             }
+            if drop is not None:
+                waiter["result"]["drop"] = drop
+            if code is not None:
+                waiter["result"]["code"] = code
+            if retryable is not None:
+                waiter["result"]["retryable"] = retryable
             waiter["event"].set()
             self.logger.debug(f"ACK waiter completed for request_id {expected}")
             return True
 
-    def _notify_ack_failure(self, error_text: str) -> None:
+    def _notify_ack_failure(
+        self,
+        error_text: str,
+        *,
+        drop: bool = False,
+        code: str = "DISCONNECTED",
+        retryable: bool = True,
+    ) -> None:
         with self._lock:
             waiter = self._ack_waiter
             if not waiter:
@@ -399,8 +509,27 @@ class WsTransport:
                 "ok": False,
                 "request_id": waiter.get("request_id"),
                 "error": error_text,
+                "drop": drop,
+                "code": code,
+                "retryable": retryable,
             }
             waiter["event"].set()
+
+    def _mark_auth_rejected(self) -> None:
+        self._auth_rejected_credentials = (
+            self.username_getter(),
+            self.token_getter(),
+        )
+
+    def _is_auth_rejected(self) -> bool:
+        rejected = self._auth_rejected_credentials
+        if rejected is None:
+            return False
+        current = (self.username_getter(), self.token_getter())
+        if current != rejected:
+            self._auth_rejected_credentials = None
+            return False
+        return True
 
     def _emit_agent_message(self, agent_msg: AgentMessage) -> None:
         if not self._agent_message_listener:

--- a/client/test/test_message_delivery_policy.py
+++ b/client/test/test_message_delivery_policy.py
@@ -1,0 +1,54 @@
+from src.delivery_policy import (
+    MAX_DURABLE_MESSAGE_AGE_SECONDS,
+    MAX_DURABLE_RETRY_ATTEMPTS,
+    can_retry_durable_message,
+    delivery_uncertain_result,
+    get_send_retry_delay_seconds,
+    is_durable_send_kind,
+)
+
+
+def test_retry_delay_is_exponential_and_capped():
+    assert [get_send_retry_delay_seconds(value) for value in (0, 1, 2, 3, 4, 5, 8)] == [
+        1.0,
+        2.0,
+        4.0,
+        8.0,
+        16.0,
+        30.0,
+        30.0,
+    ]
+
+
+def test_only_business_messages_are_durable():
+    assert all(is_durable_send_kind(kind) for kind in ("text", "image", "proactive"))
+    assert not any(
+        is_durable_send_kind(kind)
+        for kind in ("typing", "touch", "image_selecting", "image_selecting_cancel")
+    )
+
+
+def test_retry_policy_has_attempt_and_total_age_limits():
+    enqueued_at = 100.0
+    assert can_retry_durable_message(0, enqueued_at, 1.0, now=enqueued_at)
+    assert not can_retry_durable_message(
+        MAX_DURABLE_RETRY_ATTEMPTS,
+        enqueued_at,
+        1.0,
+        now=enqueued_at,
+    )
+    assert not can_retry_durable_message(
+        0,
+        enqueued_at,
+        1.0,
+        now=enqueued_at + MAX_DURABLE_MESSAGE_AGE_SECONDS - 1.0,
+    )
+
+
+def test_delivery_uncertain_is_terminal_and_keeps_request_id():
+    result = delivery_uncertain_result("msg-1", "ack timeout")
+
+    assert result["request_id"] == "msg-1"
+    assert result["code"] == "DELIVERY_UNCERTAIN"
+    assert result["retryable"] is False
+    assert result["drop"] is True

--- a/client/test/test_network_client_images.py
+++ b/client/test/test_network_client_images.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+client_root = str(Path(__file__).resolve().parent.parent)
+if client_root not in sys.path:
+    sys.path.insert(0, client_root)
+
+from src.network.network_client import NetworkClient
+from src.types import ConversationItem
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.errors = []
+
+    def error(self, message):
+        self.errors.append(message)
+
+
+class RaisingSession:
+    def __init__(self, error):
+        self.error = error
+
+    def post(self, *args, **kwargs):
+        raise self.error
+
+
+class FatalImageDownload(BaseException):
+    pass
+
+
+def make_client(error):
+    client = NetworkClient.__new__(NetworkClient)
+    client.base_url = "https://example.invalid"
+    client.verify_ssl = True
+    client.user_id = "user-1"
+    client.message_token = "token"
+    client.logger = RecordingLogger()
+    client.session = RaisingSession(error)
+    return client
+
+
+def make_item():
+    return ConversationItem(
+        timestamp="2026-08-01 00:00:00",
+        source="agent",
+        type="image",
+        content="missing.png",
+        uuid="image-1",
+    )
+
+
+def test_image_download_error_returns_original_item_and_logs_error():
+    client = make_client(RuntimeError("network failed"))
+    item = make_item()
+
+    result = client._get_image_from_server(item)
+
+    assert result is item
+    assert len(client.logger.errors) == 1
+    assert "network failed" in client.logger.errors[0]
+
+
+def test_image_download_does_not_swallow_base_exception():
+    client = make_client(FatalImageDownload("stop now"))
+
+    with pytest.raises(FatalImageDownload, match="stop now"):
+        client._get_image_from_server(make_item())

--- a/client/test/test_tts_terminal_event.py
+++ b/client/test/test_tts_terminal_event.py
@@ -1,0 +1,41 @@
+from src.network.event_types import (
+    WSMessage,
+    WSEventType,
+    is_audio_terminal,
+    normalize_agent_message,
+)
+
+
+def test_audio_error_final_package_is_a_terminal_event():
+    message = WSMessage(
+        event_type=WSEventType.AGENT_MESSAGE,
+        payload={
+            "uuid": "reply-1",
+            "text": "已经生成的文本",
+            "audio": "",
+            "is_final_package": True,
+            "audio_error": True,
+            "error_code": "TTS_EMPTY",
+        },
+    )
+
+    normalized = normalize_agent_message(message)
+
+    assert normalized.text == "已经生成的文本"
+    assert normalized.audio_error is True
+    assert normalized.error_code == "TTS_EMPTY"
+    assert is_audio_terminal(normalized) is True
+
+
+def test_non_final_audio_error_flag_does_not_end_playback_by_itself():
+    message = WSMessage(
+        event_type=WSEventType.AGENT_MESSAGE,
+        payload={
+            "uuid": "reply-1",
+            "is_final_package": False,
+            "audio_error": True,
+            "error_code": "TTS_STREAM_ERROR",
+        },
+    )
+
+    assert is_audio_terminal(normalize_agent_message(message)) is False

--- a/client/test/test_ws_transport_ack.py
+++ b/client/test/test_ws_transport_ack.py
@@ -1,0 +1,136 @@
+import asyncio
+import json
+
+from src.network.event_types import WSEventType
+from src.network.ws_transport import WsTransport, normalize_server_ack
+
+
+def test_legacy_ack_is_successful():
+    assert normalize_server_ack({"received_event_type": "user_text"}) == {
+        "ok": True,
+        "error": None,
+    }
+
+
+def test_overload_ack_is_retryable():
+    assert normalize_server_ack(
+        {
+            "ok": False,
+            "code": "OVERLOADED",
+            "message": "ingress queue is full",
+            "retryable": True,
+        }
+    ) == {
+        "ok": False,
+        "error": "[OVERLOADED] ingress queue is full",
+        "code": "OVERLOADED",
+        "retryable": True,
+        "drop": False,
+    }
+
+
+def test_permanent_rejection_is_terminal():
+    ack = normalize_server_ack({"ok": False, "code": "BAD_MESSAGE"})
+
+    assert ack["ok"] is False
+    assert ack["retryable"] is False
+    assert ack["drop"] is True
+
+
+def _ready_transport():
+    transport = WsTransport("http://localhost:60030", lambda: "alice", lambda: "token")
+    transport.start = lambda: None
+    transport._ready_event.set()
+    return transport
+
+
+def test_send_race_keeps_message_retryable():
+    transport = _ready_transport()
+    transport._send_event = lambda _event: False
+
+    result = transport._submit_user_event(
+        WSEventType.USER_TEXT,
+        {"message": "hello"},
+        ack_timeout=0.1,
+        client_msg_id="msg-1",
+    )
+
+    assert result["ok"] is False
+    assert result["drop"] is False
+
+
+def test_ack_timeout_keeps_same_message_retryable():
+    transport = _ready_transport()
+    transport._send_event = lambda _event: True
+
+    result = transport._submit_user_event(
+        WSEventType.USER_TEXT,
+        {"message": "hello"},
+        ack_timeout=0.01,
+        client_msg_id="msg-1",
+    )
+
+    assert result["request_id"] == "msg-1"
+    assert result["drop"] is False
+
+
+def test_temporary_not_ready_keeps_same_message_retryable():
+    transport = WsTransport("http://localhost:60030", lambda: "alice", lambda: "token")
+    transport.start = lambda: None
+    transport.READY_TIMEOUT_SECONDS = 0.01
+
+    result = transport._submit_user_event(
+        WSEventType.USER_TEXT,
+        {"message": "hello"},
+        ack_timeout=0.01,
+        client_msg_id="msg-not-ready",
+    )
+
+    assert result["request_id"] == "msg-not-ready"
+    assert result["retryable"] is True
+    assert result["drop"] is False
+
+
+def test_explicit_auth_rejection_is_terminal():
+    transport = WsTransport("http://localhost:60030", lambda: "alice", lambda: "bad-token")
+    transport.start = lambda: None
+    transport._mark_auth_rejected()
+
+    result = transport._submit_user_event(
+        WSEventType.USER_TEXT,
+        {"message": "hello"},
+        ack_timeout=0.01,
+        client_msg_id="msg-auth-rejected",
+    )
+
+    assert result["request_id"] == "msg-auth-rejected"
+    assert result["code"] == "AUTH_REJECTED"
+    assert result["retryable"] is False
+    assert result["drop"] is True
+
+
+def test_auth_payload_advertises_negative_ack_support():
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent = []
+            self.responses = [
+                json.dumps({"type": "system_ready", "payload": {}}),
+                json.dumps({"type": "auth_ok", "payload": {}}),
+            ]
+
+        async def recv(self):
+            return self.responses.pop(0)
+
+        async def send(self, raw):
+            self.sent.append(json.loads(raw))
+
+    transport = WsTransport("http://localhost:60030", lambda: "alice", lambda: "token")
+    websocket = FakeWebSocket()
+
+    asyncio.run(transport._authenticate(websocket))
+
+    assert websocket.sent[0]["payload"] == {
+        "username": "alice",
+        "token": "token",
+        "capabilities": ["negative_ack_v1"],
+    }

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -64,6 +64,7 @@
     "database": {
         "sql_db_folder": "data/database",
         "sql_db_file": "luotianyi.db",
+        "message_token_ttl_seconds": 3600,
         "redis": {},
         "event_store": {
             "llm_module": {
@@ -158,11 +159,30 @@
     "chat_session_manager": {
         "chat_stream_manager": {
             "default_expiration_seconds": 3600,
-            "heartbeat_timeout_seconds": 60
+            "heartbeat_timeout_seconds": 60,
+            "chat_stream": {
+                "response_queue_maxsize": 256,
+                "ingress_helper": {
+                    "queue_maxsize": 128
+                },
+                "topic_planner": {
+                    "unread_store": {
+                        "maxsize": 128
+                    }
+                },
+                "topic_replier": {
+                    "queue_maxsize": 64
+                },
+                "reflection_worker": {
+                    "queue_maxsize": 64
+                }
+            }
         },
         "global_speaking_worker": {
-            "tts_job_timeout_seconds": 120,
-            "max_retries": 2
+            "queue_maxsize": 512,
+            "terminal_send_max_attempts": 3,
+            "terminal_send_retry_delay_seconds": 0.05,
+            "shutdown_timeout_seconds": 30
         },
         "conversation_service": {
             "raw_conversation_context_limit": 60,

--- a/server/config/config.json.template
+++ b/server/config/config.json.template
@@ -38,6 +38,7 @@
     "database": {
         "sql_db_folder": "data/database",
         "sql_db_file": "luotianyi.db",
+        "message_token_ttl_seconds": 3600,
         "redis": {},
         "event_store": {
             "llm_module": {
@@ -127,11 +128,30 @@
     "chat_session_manager": {
         "chat_stream_manager": {
             "default_expiration_seconds": 3600,
-            "heartbeat_timeout_seconds": 60
+            "heartbeat_timeout_seconds": 60,
+            "chat_stream": {
+                "response_queue_maxsize": 256,
+                "ingress_helper": {
+                    "queue_maxsize": 128
+                },
+                "topic_planner": {
+                    "unread_store": {
+                        "maxsize": 128
+                    }
+                },
+                "topic_replier": {
+                    "queue_maxsize": 64
+                },
+                "reflection_worker": {
+                    "queue_maxsize": 64
+                }
+            }
         },
         "global_speaking_worker": {
-            "tts_job_timeout_seconds": 120,
-            "max_retries": 2
+            "queue_maxsize": 512,
+            "terminal_send_max_attempts": 3,
+            "terminal_send_retry_delay_seconds": 0.05,
+            "shutdown_timeout_seconds": 30
         },
         "conversation_service": {
             "raw_conversation_context_limit": 60,

--- a/server/docs/dev/统一事件协议.md
+++ b/server/docs/dev/统一事件协议.md
@@ -32,7 +32,7 @@ WebSocket 鉴权使用 `message_token`，不是 `login_token`。
 
 1. `type`: 事件类型，字符串，必填
 2. `payload`: 事件体，对象，建议必填（服务端会兜底为空对象）
-3. `client_msg_id`: 客户端消息 ID，字符串，建议传
+3. `client_msg_id`: 客户端消息 ID，字符串，聊天输入必填，长度 1-128
 4. `ts`: 客户端毫秒时间戳，数字，可选
 5. `reply_to`: 仅服务端事件可能携带，关联到客户端 `client_msg_id`
 
@@ -78,6 +78,7 @@ S -> C: agent_message
 `payload` 字段：
 1. `username`: 字符串，必填
 2. `token`: 字符串，必填（即 `message_token`）
+3. `capabilities`: 字符串数组，可选；支持负 ACK 的客户端声明 `negative_ack_v1`
 
 示例：
 
@@ -87,7 +88,8 @@ S -> C: agent_message
   "client_msg_id": "auth-1",
   "payload": {
     "username": "dpon",
-    "token": "<message_token>"
+    "token": "<message_token>",
+    "capabilities": ["negative_ack_v1"]
   }
 }
 ```
@@ -142,17 +144,17 @@ S -> C: agent_message
 
 用途：发送图片语义输入（当前实现会转成“用户发送了一张图片”的事件语义）。
 
-`payload` 字段：当前服务端未强校验具体字段，建议包含：
-1. `image_base64`: 字符串
-2. `mime_type`: 字符串
+`payload` 字段：
+1. `image_base64`: 非空 Base64 字符串，必填；解码后最大 6 MiB
+2. `mime_type`: 字符串，必填；支持 JPEG、PNG、GIF、BMP、WebP
 3. `image_client_path`: 字符串，可选
 
 ### 4.5 user_typing
 
 用途：告知“正在输入”，用于延长 listening 阶段等待时间。当输入框内消息更改时，前端可以持续发送 `user_typing` 事件。发送间隔建议为0.5s到1s之间。
 
-`payload` 字段：当前服务端不读取具体字段，可传：
-1. `is_typing`: 布尔
+`payload` 字段：
+1. `text_length`: 非负整数，必填
 
 注意：事件名必须是 `user_typing`，不是 `typing`。
 
@@ -189,11 +191,13 @@ S -> C: agent_message
 
 ```json
 {
-  "message": "authentication successful for user dpon"
+  "message": "authentication successful for user dpon",
+  "capabilities": ["negative_ack_v1"]
 }
 ```
 
 通常会带 `reply_to`，值为对应 `auth` 的 `client_msg_id`。
+`capabilities` 仅返回服务端已协商的能力。
 
 ### 5.3 auth_error
 
@@ -206,6 +210,8 @@ S -> C: agent_message
 当前错误码：
 1. `MISSING_AUTH_FIELDS`
 2. `INVALID_TOKEN`
+3. `AUTH_TIMEOUT`
+4. `AUTH_ATTEMPTS_EXCEEDED`
 
 ### 5.4 hb_pong
 
@@ -238,6 +244,11 @@ S -> C: agent_message
 3. `audio`: 字符串或 `null`（通常为 Base64 音频数据，当前简化链路可能为空字符串）
 4. `expression`: 字符串或 `null`
 5. `is_final_package`: 布尔
+6. `audio_error`: 可选布尔；为 `true` 时表示音频生成失败，但该包仍是本条回复的终止包
+7. `error_code`: 可选字符串；当前可能为 `TTS_EMPTY` 或 `TTS_STREAM_ERROR`
+
+无论音频成功、零产出还是中途失败，每个回复 UUID 都必须恰好收到一个
+`is_final_package=true` 的终止包。音频失败不会丢弃已经生成的文本；客户端收到终止包后必须结束 loading/playing 状态。
 
 示例：
 
@@ -270,15 +281,26 @@ S -> C: agent_message
 
 ### 5.8 server_ack
 
-用途：确认服务端已接收并入队一个客户端聊天输入事件。
+用途：报告服务端是否已接纳一个客户端聊天输入事件。
+
+成功 ACK 只表示事件已经进入当前进程的有界 ingress 内存队列，并已登记短期幂等；不表示业务处理完成，也不保证服务端进程崩溃后仍可恢复。
 
 当前会发送 ACK 的客户端事件类型：
 1. `user_text`
 2. `user_image`
 3. `user_typing`
+4. `user_touch`
+5. `user_image_selecting`
+6. `user_image_selecting_cancel`
+7. 兼容文本别名事件
 
 `payload` 字段：
-1. `received_event_type`: 字符串，表示被确认接收的事件类型
+1. `ok`: 布尔值；`true` 表示已接纳；协商 `negative_ack_v1` 后，`false` 表示未接纳
+2. `received_event_type`: 字符串，表示对应的客户端事件类型
+3. `duplicate`: 可选布尔值；为 `true` 时表示该 ID 此前已接纳，本次未重复入队
+4. `code`: NACK 错误码，例如 `OVERLOADED`、`BAD_MESSAGE`
+5. `message`: NACK 的稳定说明
+6. `retryable`: NACK 是否允许客户端重试
 
 通常会带 `reply_to`，值为对应客户端事件的 `client_msg_id`。
 
@@ -290,16 +312,37 @@ S -> C: agent_message
   "ts": 1773474001000,
   "reply_to": "msg-1",
   "payload": {
+    "ok": true,
     "received_event_type": "user_text"
   }
 }
 ```
 
+队列满时返回：
+
+```json
+{
+  "type": "server_ack",
+  "reply_to": "msg-1",
+  "payload": {
+    "ok": false,
+    "received_event_type": "user_text",
+    "code": "OVERLOADED",
+    "message": "chat ingress queue is full",
+    "retryable": true
+  }
+}
+```
+
+为兼容旧客户端，服务端只向已协商 `negative_ack_v1` 的连接发送负 ACK；未声明该能力的连接会收到相同 `reply_to` 的 `error`，避免旧客户端把拒绝误判为成功。
+
+客户端收到可重试 NACK 或等待 ACK 超时后，应递增退避并复用原 `client_msg_id`。当前客户端最多自动尝试 8 次，且消息总龄期必须小于 4 分钟；超限后标记 `DELIVERY_UNCERTAIN`，不得为同一业务消息生成新 ID。typing、touch 和图片选择状态属于瞬时事件，发送失败后直接丢弃，不阻塞持久消息队列。
+
 ## 6. 关键行为约束（按当前实现）
 
 1. 鉴权前发送聊天消息不会进入聊天流程；必须先 `auth` 成功。
 2. 非 JSON、非对象、缺少 `type` 的消息会收到 `error`。
-3. 当前已实现接收确认事件 `server_ack`，但未实现重传与 `done` 事件；客户端应以 `agent_message` 和 `agent_state_changed` 作为主要渲染依据。
+3. `server_ack.payload.ok=true` 只表示内存接纳；客户端内置超时/可重试 NACK 重传，但未实现业务完成 `done` 事件。渲染仍以 `agent_message` 和 `agent_state_changed` 为准。
 4. 断线后可重连，同一用户会复用对应 chat_stream（服务端侧管理）。
 5. 心跳建议每 5 到 30 秒发送一次，避免连接被服务端清理任务回收。
 

--- a/server/server_main.py
+++ b/server/server_main.py
@@ -16,20 +16,23 @@ from src.system.user_interface.types import (
     RegisterRequest,
     LoginRequest,
     AutoLoginRequest,
-    HistoryRequest,
+    HistoryQuery,
     ImageRequest,
     ResetAccountRequest,
     WSEventType,
     PreferenceGetRequest,
     PreferenceOverwriteRequest,
     DynamicListRequest,
+    DynamicListQuery,
     DynamicCreateRequest,
     DynamicCommentListRequest,
+    DynamicCommentListQuery,
     DynamicCommentCreateRequest,
     DynamicUnreadRequest,
+    DynamicUnreadQuery,
     DynamicReadMarkRequest,
 )
-from src.system.user_interface.websocket_service import WebSocketConnection
+from src.system.user_interface.websocket_service import ChatEventAcceptance, WebSocketConnection
 from src.system.admin.admin_interface import router as admin_router
 from src.system.admin import get_admin_shell, init_admin_shell, shutdown_admin_shell
 
@@ -58,7 +61,7 @@ async def startup_event(app: FastAPI):
 
 
 def runtime_not_ready_detail() -> dict:
-    status = get_admin_shell().runtime_supervisor.status()
+    status = get_admin_shell().runtime_supervisor.public_status()
     return {
         "ok": False,
         "code": "SYSTEM_RUNTIME_NOT_READY",
@@ -72,6 +75,20 @@ def get_runtime():
     if runtime is None:
         raise HTTPException(status_code=503, detail=runtime_not_ready_detail())
     return runtime
+
+
+def require_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="消息令牌缺失")
+    scheme, separator, token = authorization.partition(" ")
+    if (
+        separator != " "
+        or scheme.lower() != "bearer"
+        or not token
+        or any(character.isspace() for character in token)
+    ):
+        raise HTTPException(status_code=401, detail="无效的 Authorization 请求头")
+    return token
 
 
 app = FastAPI(lifespan=startup_event)
@@ -130,7 +147,12 @@ async def chat_ws(websocket: WebSocket):
 
     ws_connection = WebSocketConnection(websocket=websocket, user_uuid=None, user_name=None)
     try:
-        await ws_connection.auth(websocket_service, system_runtime.database_manager)  # 等待认证，认证成功之后将ws和用户信息绑定
+        authenticated = await ws_connection.auth(
+            websocket_service,
+            system_runtime.database_manager,
+        )
+        if not authenticated:
+            return
         chat_stream = await gcsm.get_or_register_chat_stream(
             ws_connection, system_runtime=system_runtime
         )  # 根据ws连接获取对应的聊天流实例，内部会根据用户UUID进行管理
@@ -144,18 +166,42 @@ async def chat_ws(websocket: WebSocket):
                 continue
 
             if websocket_service.is_chat_related_event(event):
-                if websocket_service.is_duplicate_client_message(ws_connection, event):
+                acceptance = websocket_service.try_accept_chat_event(
+                    ws_connection,
+                    event,
+                    chat_stream,
+                )
+                if acceptance == ChatEventAcceptance.DUPLICATE:
                     await websocket_service.send_duplicate_ack_event(ws_connection, event)
                     continue
-                await websocket_service.send_ack_event(ws_connection, event)  # 先确认收到，避免图片预处理拖慢 ACK
-
-            chat_event = websocket_service.convert_to_chat_input_event(
-                event,
-                sender_user_id=ws_connection.user_uuid,
-            )
-            if chat_event is None:
-                continue
-            await chat_stream.feed_event(chat_event)
+                if acceptance == ChatEventAcceptance.BAD_MESSAGE:
+                    await websocket_service.send_nack_event(
+                        ws_connection,
+                        event,
+                        code="BAD_MESSAGE",
+                        message="chat event payload is invalid",
+                        retryable=False,
+                    )
+                    continue
+                if acceptance == ChatEventAcceptance.UNSUPPORTED:
+                    await websocket_service.send_nack_event(
+                        ws_connection,
+                        event,
+                        code="UNSUPPORTED_EVENT",
+                        message="chat event type is not supported",
+                        retryable=False,
+                    )
+                    continue
+                if acceptance == ChatEventAcceptance.OVERLOADED:
+                    await websocket_service.send_nack_event(
+                        ws_connection,
+                        event,
+                        code="OVERLOADED",
+                        message="chat ingress queue is full",
+                        retryable=True,
+                    )
+                    continue
+                await websocket_service.send_ack_event(ws_connection, event)
     except WebSocketDisconnect:
         gcsm.ws_lost_connection(ws_connection)
         logger.info("WebSocket client disconnected from /chat_ws")
@@ -212,7 +258,7 @@ async def register(
     - 成功：{"message": "注册成功", "user_id": req.username}
     - 失败：HTTP 400 错误，{"detail": "注册失败，失败原因"}
     """
-    logger.info(f"Register request: {req.username} with code {req.invite_code}")
+    logger.info("Register request for username=%s", req.username)
     return await system_runtime.user_interface.register(
         req, system_runtime, request
     )
@@ -234,7 +280,7 @@ async def reset_account(
     - 成功：{"message": "重置成功"}
     - 失败：HTTP 400 错误，{"detail": "失败原因"}
     """
-    logger.info(f"Reset account request for invite_code: {req.invite_code[:4]}****")
+    logger.info("Reset account request for username=%s", req.new_username)
     return await system_runtime.user_interface.reset_account(
         req, system_runtime, request
     )
@@ -283,19 +329,13 @@ async def overwrite_preference(
 
 @app.get("/history")
 async def get_history(
-    request: HistoryRequest = Depends(),
+    request: HistoryQuery = Depends(),
     authorization: str | None = Header(default=None),
     system_runtime: "SystemRuntime" = Depends(get_runtime),
 ):
     """获取聊天历史：委托到 UserInterface。"""
     logger.info(f"Server received: Get history request from {request.username}")
-    token = request.token
-    if not token and authorization:
-        parts = authorization.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            token = parts[1]
-    if not token:
-        raise HTTPException(status_code=401, detail="消息令牌缺失")
+    token = require_bearer_token(authorization)
     return await system_runtime.user_interface.get_history(
         request.username, token, request.count, request.end_index, system_runtime
     )
@@ -303,17 +343,11 @@ async def get_history(
 
 @app.get("/dynamics")
 async def list_dynamics(
-    request: DynamicListRequest = Depends(),
+    request: DynamicListQuery = Depends(),
     authorization: str | None = Header(default=None),
     system_runtime: "SystemRuntime" = Depends(get_runtime),
 ):
-    token = request.token
-    if not token and authorization:
-        parts = authorization.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            token = parts[1]
-    if not token:
-        raise HTTPException(status_code=401, detail="消息令牌缺失")
+    token = require_bearer_token(authorization)
     req = DynamicListRequest(
         username=request.username,
         token=token,
@@ -333,17 +367,11 @@ async def create_dynamic(
 
 @app.get("/dynamics/unread")
 async def get_dynamic_unread(
-    request: DynamicUnreadRequest = Depends(),
+    request: DynamicUnreadQuery = Depends(),
     authorization: str | None = Header(default=None),
     system_runtime: "SystemRuntime" = Depends(get_runtime),
 ):
-    token = request.token
-    if not token and authorization:
-        parts = authorization.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            token = parts[1]
-    if not token:
-        raise HTTPException(status_code=401, detail="消息令牌缺失")
+    token = require_bearer_token(authorization)
     req = DynamicUnreadRequest(username=request.username, token=token)
     return await system_runtime.user_interface.get_dynamic_unread(req, system_runtime)
 
@@ -359,17 +387,11 @@ async def mark_dynamic_read(
 @app.get("/dynamics/{dynamic_id}/comments")
 async def list_dynamic_comments(
     dynamic_id: str,
-    request: DynamicCommentListRequest = Depends(),
+    request: DynamicCommentListQuery = Depends(),
     authorization: str | None = Header(default=None),
     system_runtime: "SystemRuntime" = Depends(get_runtime),
 ):
-    token = request.token
-    if not token and authorization:
-        parts = authorization.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            token = parts[1]
-    if not token:
-        raise HTTPException(status_code=401, detail="消息令牌缺失")
+    token = require_bearer_token(authorization)
     req = DynamicCommentListRequest(
         username=request.username,
         token=token,

--- a/server/src/agent/main_chat.py
+++ b/server/src/agent/main_chat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
@@ -19,6 +20,11 @@ from src.utils.logger import get_logger
 DEFAULT_LLM_TONE = "中性"
 DEFAULT_TTS_TONE = "normal"
 DEFAULT_EXPRESSION = "微笑脸"
+DEFAULT_LLM_FAILURE_RESPONSE = "[中性]抱歉，我刚刚没能组织好回复，请再说一次吧"
+DEFAULT_LLM_FAILURE_MAX_ATTEMPTS = 2
+MAX_LLM_FAILURE_ATTEMPTS = 3
+DEFAULT_LLM_FAILURE_RETRY_DELAY_SECONDS = 0.2
+MAX_LLM_FAILURE_RETRY_DELAY_SECONDS = 2.0
 
 
 @dataclass
@@ -68,6 +74,20 @@ class MainChat:
         self.config = config
         self.character_profile = character_profile
         self.llm = llm_module
+        self.llm_failure_max_attempts = self._bounded_int(
+            config.get("llm_failure_max_attempts"),
+            default=DEFAULT_LLM_FAILURE_MAX_ATTEMPTS,
+            minimum=1,
+            maximum=MAX_LLM_FAILURE_ATTEMPTS,
+        )
+        self.llm_failure_retry_delay_seconds = self._bounded_float(
+            config.get("llm_failure_retry_delay_seconds"),
+            default=DEFAULT_LLM_FAILURE_RETRY_DELAY_SECONDS,
+            minimum=0.0,
+            maximum=MAX_LLM_FAILURE_RETRY_DELAY_SECONDS,
+        )
+        configured_fallback = str(config.get("llm_failure_response") or "").strip()
+        self.llm_failure_response = self._structured_failure_response(configured_fallback)
         self.variables: List[str] = self.llm.prompt_template.get_variables()
         self._init_static_variables_sync()
         self._init_llm_tone_mapping()
@@ -108,60 +128,154 @@ class MainChat:
         return self._parse_response(response, sing_plan)
 
     async def _call_llm(self, **kwargs) -> str:
-        try:
-            return await self.llm.generate_response(**kwargs)
-        except LLMContentInspectionError as e:
-            self.logger.warning(f"MainChat LLM 内容审查失败，返回话题切换回复: {e}")
-            return "[中性]这个话题不太合适，我们聊点别的吧"
-        except Exception as e:
-            import traceback
+        max_attempts = getattr(
+            self,
+            "llm_failure_max_attempts",
+            DEFAULT_LLM_FAILURE_MAX_ATTEMPTS,
+        )
+        retry_delay = getattr(
+            self,
+            "llm_failure_retry_delay_seconds",
+            DEFAULT_LLM_FAILURE_RETRY_DELAY_SECONDS,
+        )
+        failure_response = getattr(
+            self,
+            "llm_failure_response",
+            DEFAULT_LLM_FAILURE_RESPONSE,
+        )
 
-            self.logger.error(f"Error during topic reply generation: {e}\n{traceback.format_exc()}")
-            return ""
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = await self.llm.generate_response(**kwargs)
+                if isinstance(response, str) and response.strip():
+                    return response
+                raise RuntimeError("LLM returned an empty response")
+            except LLMContentInspectionError as e:
+                self.logger.warning(f"MainChat LLM 内容审查失败，返回话题切换回复: {e}")
+                return "[中性]这个话题不太合适，我们聊点别的吧"
+            except Exception as e:
+                if attempt >= max_attempts:
+                    self.logger.error(
+                        "MainChat LLM failed after "
+                        f"{attempt} attempts ({type(e).__name__}): {e}"
+                    )
+                    break
+                self.logger.warning(
+                    "MainChat LLM request failed "
+                    f"({attempt}/{max_attempts}), retrying: "
+                    f"{type(e).__name__}: {e}"
+                )
+                if retry_delay > 0:
+                    await asyncio.sleep(retry_delay)
+
+        return failure_response
 
     def _parse_response(self, response: str, sing_plan: Optional[Tuple[str, str]]) -> List[OneResponseLine]:
         return self.response_parser.parse(response, sing_plan)
 
+    @staticmethod
+    def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            parsed = default
+        return max(minimum, min(maximum, parsed))
+
+    @staticmethod
+    def _bounded_float(value: Any, *, default: float, minimum: float, maximum: float) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            parsed = default
+        return max(minimum, min(maximum, parsed))
+
+    @staticmethod
+    def _structured_failure_response(value: str) -> str:
+        if not value:
+            return DEFAULT_LLM_FAILURE_RESPONSE
+        if value.startswith("[") and "]" in value:
+            _tone, content = value.split("]", 1)
+            if content.strip():
+                return value
+            return DEFAULT_LLM_FAILURE_RESPONSE
+        return f"[{DEFAULT_LLM_TONE}]{value}"
+
     def _init_static_variables_sync(self) -> None:
         static_variables_file = self.character_profile.static_variables_file
+        character_id = self.character_profile.character_id
         if not static_variables_file:
-            raise ValueError(f"No static_variables_file configured for character {self.character_profile.character_id}")
+            raise ValueError(f"No static_variables_file configured for character '{character_id}'.")
 
         path = Path(static_variables_file)
-        if not path.exists():
-            self.logger.warning(f"MainChat static_variables_file not found: {static_variables_file}")
-            return
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"Static variables file for character '{character_id}' was not found: {path}"
+            )
 
         try:
             with path.open("r", encoding="utf-8") as f:
                 static_vars: Dict[str, Any] = json.load(f)
-        except Exception as e:
-            self.logger.warning(f"Failed to load MainChat static variables: {e}")
-            return
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Static variables file for character '{character_id}' contains invalid JSON: {path}"
+            ) from exc
+        except OSError as exc:
+            raise OSError(
+                f"Failed to read static variables file for character '{character_id}': {path}"
+            ) from exc
 
-        character_name = static_vars.get("character_name", "").strip()
-        if character_name:
-            self.character_name = character_name
+        if not isinstance(static_vars, dict):
+            raise ValueError(
+                f"Static variables file for character '{character_id}' must contain a JSON object: {path}"
+            )
 
-        persona = static_vars.get("character_persona", "")
-        if isinstance(persona, list):
-            persona = "".join(str(x) for x in persona if str(x).strip())
-        if persona:
-            self.character_persona = str(persona).strip()
+        character_name = self._required_static_text(
+            static_vars,
+            "character_name",
+            character_id=character_id,
+            path=path,
+            allow_list=False,
+        )
+        character_persona = self._required_static_text(
+            static_vars,
+            "character_persona",
+            character_id=character_id,
+            path=path,
+        )
+        speaking_style = self._required_static_text(
+            static_vars,
+            "speaking_style",
+            character_id=character_id,
+            path=path,
+        )
 
-        style = static_vars.get("speaking_style", "")
-        if isinstance(style, list):
-            style = "".join(str(x) for x in style if str(x).strip())
-        if not style:
-            requirements = static_vars.get("response_requirements", [])
-            if isinstance(requirements, list):
-                style = "".join(str(x).lstrip("- ").strip() for x in requirements[:3] if str(x).strip())
-        if style:
-            self.speaking_style = str(style).strip()
+        self.character_name = character_name
+        self.character_persona = character_persona
+        self.speaking_style = speaking_style
 
-        assert hasattr(self, "character_name"), "character_name is required in static variables"
-        assert hasattr(self, "character_persona"), "character_persona is required in static variables"
-        assert hasattr(self, "speaking_style"), "speaking_style is required in static variables"
+    @staticmethod
+    def _required_static_text(
+        static_vars: Dict[str, Any],
+        field_name: str,
+        *,
+        character_id: str,
+        path: Path,
+        allow_list: bool = True,
+    ) -> str:
+        value = static_vars.get(field_name)
+        if isinstance(value, str):
+            normalized = value.strip()
+        elif allow_list and isinstance(value, list) and all(isinstance(item, str) for item in value):
+            normalized = "".join(item.strip() for item in value if item.strip())
+        else:
+            normalized = ""
+
+        if not normalized:
+            raise ValueError(
+                f"Static variables file for character '{character_id}' has an invalid or missing "
+                f"'{field_name}' field: {path}"
+            )
+        return normalized
 
     def _init_llm_tone_mapping(self) -> None:
         self.llm_tone_mapping_file = self.character_profile.llm_tone_mapping_file

--- a/server/src/agent_runtime/agent_runtime.py
+++ b/server/src/agent_runtime/agent_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict, TYPE_CHECKING
 
 from src.agent.luotianyi_agent import LuoTianyiAgent
@@ -10,7 +11,12 @@ from src.agent_runtime.character_runtime import CharacterRuntime
 from src.subconscious.character_mind import CharacterSubconscious
 from src.subconscious.memory import SubconsciousMemory
 from src.subconscious.preprocessing import ChatPreprocessor
-from src.system.database.vector_store import get_vector_store, init_vector_store
+from src.system.database.vector_store import clear_vector_store, get_vector_store, init_vector_store
+from src.utils.asyncio_helpers import (
+    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+    run_sync_owned,
+    wait_for_owned_tasks,
+)
 from src.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -35,31 +41,99 @@ class AgentRuntime:
         self.llm_service = llm_service
         self.capability_manager = capability_manager
         self.database_manager = database_manager
+        self._shutdown_lock = asyncio.Lock()
+        self._shutdown_complete = False
+        self._shutdown_task: asyncio.Task | None = None
+        self.shutdown_timeout_seconds = DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS
         self.vector_store = self._initialize_vector_store(self.config["agent"])
-        
-        # 公用的预处理器，用于处理用户输入事件，例如图片理解、歌曲实体抽取和日期线索抽取
-        self.preprocessor = ChatPreprocessor(
-            self.config.get("agent", {}).get("preprocessing", {}),
-            capability_manager
-        )
+        try:
+            # 公用的预处理器，用于处理用户输入事件，例如图片理解、歌曲实体抽取和日期线索抽取
+            self.preprocessor = ChatPreprocessor(
+                self.config.get("agent", {}).get("preprocessing", {}),
+                capability_manager
+            )
 
-        self.character_registry = CharacterRegistry(config.get("character_registry", {}))
-        self.character_runtimes = self._build_character_runtimes(
-            agent_config=self.config["agent"],
-            llm_service=llm_service,
-            capability_manager=capability_manager,
-            database_manager=database_manager,
-        )
+            self.character_registry = CharacterRegistry(config.get("character_registry", {}))
+            self.character_runtimes = self._build_character_runtimes(
+                agent_config=self.config["agent"],
+                llm_service=llm_service,
+                capability_manager=capability_manager,
+                database_manager=database_manager,
+            )
 
-        self.agent_registry = AgentRegistry(
-            self.config.get("agent_registry", {}),
-            self.character_registry,
-            self.character_runtimes,
-        )
+            self.agent_registry = AgentRegistry(
+                self.config.get("agent_registry", {}),
+                self.character_registry,
+                self.character_runtimes,
+            )
 
-        self.default_character_id = self.character_registry.default_character_id
-        global _agent_runtime
-        _agent_runtime = self
+            self.default_character_id = self.character_registry.default_character_id
+            set_agent_runtime(self)
+        except BaseException:
+            try:
+                self._abort_initialization()
+            except Exception as cleanup_error:
+                self.logger.error(
+                    f"AgentRuntime initialization rollback failed: {cleanup_error}"
+                )
+            raise
+
+    def _abort_initialization(self) -> None:
+        vector_store = getattr(self, "vector_store", None)
+        try:
+            close = getattr(vector_store, "close", None)
+            if close is not None:
+                close()
+        finally:
+            if vector_store is not None:
+                clear_vector_store(vector_store)
+            clear_agent_runtime(self)
+
+    async def shutdown(self) -> None:
+        """Release AgentRuntime-owned resources exactly once after success."""
+        async with self._shutdown_lock:
+            if self._shutdown_complete:
+                return
+            close = getattr(self.vector_store, "close", None)
+            if close is not None:
+                shutdown_task = getattr(self, "_shutdown_task", None)
+                if shutdown_task is None:
+                    shutdown_task = asyncio.create_task(run_sync_owned(close))
+                    self._shutdown_task = shutdown_task
+                cancellation: asyncio.CancelledError | None = None
+                try:
+                    done, pending = await wait_for_owned_tasks(
+                        (shutdown_task,),
+                        timeout_seconds=getattr(
+                            self,
+                            "shutdown_timeout_seconds",
+                            DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+                        ),
+                    )
+                except asyncio.CancelledError as error:
+                    cancellation = error
+                    done, pending = await asyncio.shield(
+                        wait_for_owned_tasks(
+                            (shutdown_task,),
+                            timeout_seconds=getattr(
+                                self,
+                                "shutdown_timeout_seconds",
+                                DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+                            ),
+                        )
+                    )
+                if pending:
+                    raise RuntimeError("Vector store close task is still running")
+                try:
+                    shutdown_task.result()
+                except BaseException:
+                    self._shutdown_task = None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
+            clear_vector_store(self.vector_store)
+            clear_agent_runtime(self)
+            self._shutdown_complete = True
 
     def wire_dependencies(
         self,
@@ -302,6 +376,19 @@ class AgentRuntime:
 
 
 _agent_runtime: AgentRuntime | None = None
+
+
+def set_agent_runtime(runtime: AgentRuntime | None) -> None:
+    global _agent_runtime
+    _agent_runtime = runtime
+
+
+def clear_agent_runtime(expected: AgentRuntime | None = None) -> bool:
+    global _agent_runtime
+    if expected is not None and _agent_runtime is not expected:
+        return False
+    _agent_runtime = None
+    return True
 
 
 def get_agent_runtime() -> AgentRuntime:

--- a/server/src/agent_runtime/character_registry.py
+++ b/server/src/agent_runtime/character_registry.py
@@ -15,9 +15,11 @@ class CharacterRegistry:
         self.characters: dict[str, CharacterProfile] = {}
         self.default_character_id: str = DEFAULT_CHARACTER_ID
         self._build_character_profiles()
+        self._validate_default_character()
 
     def _build_character_profiles(self) -> None:
         characters_cfg = self.config.get("characters", self.config)
+        default_targets: list[str] = []
         for character_id, profile_cfg in characters_cfg.items():
             profile = CharacterProfile(
                 character_id=character_id,
@@ -36,11 +38,30 @@ class CharacterRegistry:
             )
             self.characters[character_id] = profile
             if profile.default_target:
-                self.default_character_id = character_id
+                default_targets.append(character_id)
+        if len(default_targets) > 1:
+            raise ValueError(
+                "Multiple default characters are configured: "
+                + ", ".join(default_targets)
+            )
+        if default_targets:
+            self.default_character_id = default_targets[0]
         if not self.characters:
             profile = self._default_profile()
             self.characters[profile.character_id] = profile
             self.default_character_id = profile.character_id
+
+    def _validate_default_character(self) -> None:
+        try:
+            default_profile = self.characters[self.default_character_id]
+        except KeyError as exc:
+            raise ValueError(
+                f"Default character '{self.default_character_id}' is not configured."
+            ) from exc
+        if not default_profile.enabled:
+            raise ValueError(
+                f"Default character '{self.default_character_id}' must be enabled."
+            )
 
     def get(self, character_id: str | None = None) -> CharacterProfile:
         resolved_id = character_id or self.default_character_id
@@ -50,11 +71,12 @@ class CharacterRegistry:
             raise KeyError(f"Unknown character_id: {resolved_id}") from exc
 
     def resolve_targets(self, target_character_ids: tuple[str, ...] | None = None) -> tuple[str, ...]:
-        if target_character_ids:
-            for character_id in target_character_ids:
-                self.get(character_id)
-            return target_character_ids
-        return (self.default_character_id,)
+        resolved = target_character_ids or (self.default_character_id,)
+        for character_id in resolved:
+            profile = self.get(character_id)
+            if not profile.enabled:
+                raise ValueError(f"Target character '{character_id}' is disabled.")
+        return resolved
 
     @staticmethod
     def _default_profile() -> CharacterProfile:

--- a/server/src/capabilities/capability_manager.py
+++ b/server/src/capabilities/capability_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 from typing import Any, Dict, TYPE_CHECKING
 
 from src.capabilities.dynamic import DynamicCapability
@@ -18,27 +19,40 @@ class CapabilityManager:
         self.config: Dict[str, Any] = config
         self.logger = get_logger(__name__)
         self.llm_service: "LLMService | None" = llm_service
+        self._stop_lock = asyncio.Lock()
+        self._stopped = False
 
-        # TTS合成能力
-        self.logger.info("Start initializing Speech Capability...")
-        self.speech: SpeechCapability = SpeechCapability(self.config.get("tts", {}))
+        try:
+            # TTS合成能力
+            self.logger.info("Start initializing Speech Capability...")
+            self.speech: SpeechCapability = SpeechCapability(self.config.get("tts", {}))
 
-        # 歌唱能力
-        self.logger.info("Start initializing Singing Capability...")
-        self.singing: SingingCapability = SingingCapability(
-            self.config.get("sing", {}),
-            llm_service=llm_service,
-        )
+            # 歌唱能力
+            self.logger.info("Start initializing Singing Capability...")
+            self.singing: SingingCapability = SingingCapability(
+                self.config.get("sing", {}),
+                llm_service=llm_service,
+            )
 
-        # 动态能力
-        self.logger.info("Start initializing Dynamic Capability...")
-        self.dynamics: DynamicCapability = DynamicCapability(self.config.get("dynamic", {}))
-        self.dynamics.create_dynamic_composer_module(llm_service)
+            # 动态能力
+            self.logger.info("Start initializing Dynamic Capability...")
+            self.dynamics: DynamicCapability = DynamicCapability(self.config.get("dynamic", {}))
+            self.dynamics.create_dynamic_composer_module(llm_service)
 
-        # 图像理解能力
-        self.logger.info("Start initializing Image Understanding Capability...")
-        self.image_understanding: ImageUnderstanding = ImageUnderstanding(self.config.get("image_understanding", {}))
-        self.image_understanding.create_vlm_module(llm_service)
+            # 图像理解能力
+            self.logger.info("Start initializing Image Understanding Capability...")
+            self.image_understanding: ImageUnderstanding = ImageUnderstanding(
+                self.config.get("image_understanding", {})
+            )
+            self.image_understanding.create_vlm_module(llm_service)
+        except BaseException:
+            speech = getattr(self, "speech", None)
+            if speech is not None:
+                try:
+                    speech._abort_initialization()
+                except Exception as error:
+                    self.logger.error(f"Capability initialization rollback failed: {error}")
+            raise
 
     def wire_dependencies(self, *, database_manager: "DatabaseManager", llm_service: "LLMService | None" = None) -> None:
         """向能力子模块派发外部依赖。"""
@@ -64,3 +78,11 @@ class CapabilityManager:
         self.singing.ensure_dependencies()
         self.dynamics.ensure_dependencies()
         self.image_understanding.ensure_dependencies()
+
+    async def stop(self) -> None:
+        """Stop owned capability resources exactly once after a successful attempt."""
+        async with self._stop_lock:
+            if self._stopped:
+                return
+            await self.speech.stop()
+            self._stopped = True

--- a/server/src/capabilities/speech/speech.py
+++ b/server/src/capabilities/speech/speech.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Generator, Dict
 
 from src.capabilities.speech.tts_module import init_tts_module, TTSModule
+from src.utils.asyncio_helpers import (
+    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+    run_sync_owned,
+    wait_for_owned_tasks,
+)
+from src.utils.logger import get_logger
 
 
 class SpeechCapability:
     """Action capability for saying text through TTS."""
 
     def __init__(self, config: Dict) -> None:
+        self.logger = get_logger(__name__)
         self.tts_config = config
         self.tts_module: Dict[str, TTSModule] = {}
-        for character, tts_config in self.tts_config.items():
-            self.tts_module[character] = init_tts_module(tts_config)
+        self._stop_lock = asyncio.Lock()
+        self._stopped_server_ids: set[int] = set()
+        self._stop_signaled_server_ids: set[int] = set()
+        self._stop_tasks: dict[int, asyncio.Task] = {}
+        self.stop_timeout_seconds = DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS
+        try:
+            for character, tts_config in self.tts_config.items():
+                self.tts_module[character] = init_tts_module(tts_config)
+        except BaseException:
+            self._abort_initialization()
+            raise
 
     def ensure_dependencies(self) -> None:
         """检查语音能力依赖已经初始化。"""
@@ -51,3 +68,120 @@ class SpeechCapability:
         character_tts_module: TTSModule = self.tts_module[character]
         for chunk in character_tts_module.stream_synthesize_speech_with_tone(text, tone):
             yield character_tts_module.encode_audio_to_base64(chunk)
+
+    def request_stop(self) -> None:
+        """Synchronously wake active TTS requests before awaiting their workers."""
+        errors: list[str] = []
+        for server_id, server in self._distinct_servers().items():
+            if server_id in self._stop_signaled_server_ids:
+                continue
+            request_stop = getattr(server, "request_stop", None)
+            if request_stop is None:
+                self._stop_signaled_server_ids.add(server_id)
+                continue
+            try:
+                request_stop()
+            except Exception as error:
+                errors.append(f"{type(error).__name__}: {error}")
+            else:
+                self._stop_signaled_server_ids.add(server_id)
+        if errors:
+            raise RuntimeError("Failed to signal TTS shutdown: " + "; ".join(errors))
+
+    def _distinct_servers(self) -> dict[int, object]:
+        return {
+            id(server): server
+            for module in self.tts_module.values()
+            if (server := getattr(module, "tts_server", None)) is not None
+        }
+
+    def _abort_initialization(self) -> None:
+        """Synchronously release TTS workers when construction cannot complete."""
+        errors: list[str] = []
+        try:
+            self.request_stop()
+        except Exception as error:
+            errors.append(str(error))
+
+        for server_id, server in self._distinct_servers().items():
+            if server_id in self._stopped_server_ids:
+                continue
+            try:
+                server.stop()
+            except Exception as error:
+                errors.append(f"{type(error).__name__}: {error}")
+            else:
+                self._stopped_server_ids.add(server_id)
+
+        if errors:
+            self.logger.error("TTS initialization rollback had errors: " + "; ".join(errors))
+
+    async def stop(self) -> None:
+        """Stop each distinct TTS backend once, retrying only prior failures."""
+        async with self._stop_lock:
+            errors: list[str] = []
+            try:
+                self.request_stop()
+            except Exception as error:
+                errors.append(str(error))
+            servers = self._distinct_servers()
+
+            pending = [
+                (server_id, server)
+                for server_id, server in servers.items()
+                if server_id not in self._stopped_server_ids
+            ]
+            if not pending:
+                if errors:
+                    raise RuntimeError("TTS shutdown failed: " + "; ".join(errors))
+                return
+
+            stop_tasks = getattr(self, "_stop_tasks", None)
+            if stop_tasks is None:
+                stop_tasks = self._stop_tasks = {}
+            for server_id, server in pending:
+                if server_id not in stop_tasks:
+                    stop_tasks[server_id] = asyncio.create_task(run_sync_owned(server.stop))
+            tasks = [stop_tasks[server_id] for server_id, _ in pending]
+            cancellation: asyncio.CancelledError | None = None
+            try:
+                done, still_running = await wait_for_owned_tasks(
+                    tasks,
+                    timeout_seconds=getattr(
+                        self,
+                        "stop_timeout_seconds",
+                        DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+                    ),
+                )
+            except asyncio.CancelledError as error:
+                cancellation = error
+                done, still_running = await asyncio.shield(
+                    wait_for_owned_tasks(
+                        tasks,
+                        timeout_seconds=getattr(
+                            self,
+                            "stop_timeout_seconds",
+                            DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+                        ),
+                    )
+                )
+            for server_id, _server in pending:
+                task = stop_tasks[server_id]
+                if task not in done:
+                    continue
+                try:
+                    task.result()
+                except BaseException as error:
+                    errors.append(f"{type(error).__name__}: {error}")
+                else:
+                    self._stopped_server_ids.add(server_id)
+                finally:
+                    stop_tasks.pop(server_id, None)
+
+            if still_running:
+                errors.append(f"{len(still_running)} TTS backend stop task(s) still running")
+
+            if errors:
+                raise RuntimeError("TTS shutdown failed: " + "; ".join(errors))
+            if cancellation is not None:
+                raise cancellation

--- a/server/src/capabilities/speech/tts_module.py
+++ b/server/src/capabilities/speech/tts_module.py
@@ -1,8 +1,8 @@
 import os
 import json
-import asyncio
 from typing import Dict, Any, Generator
 from src.utils.logger import get_logger
+from src.utils.asyncio_helpers import run_sync_owned
 from src.capabilities.speech.tts_server import TTSServer
 
 class ReferenceAudio:
@@ -136,8 +136,8 @@ class TTSModule:
         self._debug(f"Sending TTS request for text: {text[:20]}...")
         
         try:
-            # Use asyncio.to_thread to keep this method async-friendly.
-            audio_bytes = await asyncio.to_thread(
+            # Keep the event loop responsive while retaining shutdown ownership.
+            audio_bytes = await run_sync_owned(
                 self.tts_server.synthesize,
                 payload["text"],
                 payload["ref_audio_path"],
@@ -205,6 +205,12 @@ def init_tts_module(tts_config: Dict[str, Any]) -> TTSModule:
         suppress_worker_output=tts_config.get("suppress_worker_output", True),
         trim_startup_memory=tts_config.get("trim_startup_memory", True),
     )
-    tts_server.start()
-    tts_module = TTSModule(tts_config=tts_config, tts_server=tts_server)
-    return tts_module
+    try:
+        tts_server.start()
+        return TTSModule(tts_config=tts_config, tts_server=tts_server)
+    except BaseException:
+        try:
+            tts_server.stop()
+        except Exception as error:
+            get_logger(__name__).error(f"TTS module initialization rollback failed: {error}")
+        raise

--- a/server/src/capabilities/speech/tts_server.py
+++ b/server/src/capabilities/speech/tts_server.py
@@ -5,6 +5,7 @@ import atexit
 import gc
 import logging
 import sys
+import threading
 import traceback
 import multiprocessing
 from queue import Empty
@@ -212,6 +213,8 @@ def _run_gsv_worker(
                             prompt_audio_text=prompt_audio_text,
                             text=text,
                         ):
+                            if stop_event.is_set():
+                                break
                             chunk_bytes = _audio_to_wav_bytes(clip.audio_data, clip.samplerate)
                             if not is_first_chunk:
                                 chunk_bytes = _strip_wav_header(chunk_bytes)
@@ -331,6 +334,11 @@ class TTSServer:
         self.stop_event: Optional[MPEvent] = None
         self._request_counter = 0
         self._synthesize_lock = multiprocessing.Lock()
+        self._lifecycle_lock = threading.RLock()
+        self._lifecycle_condition = threading.Condition()
+        self._active_requests = 0
+        self._stopping = False
+        self._atexit_registered = False
 
     def _info(self, message: str) -> None:
         if not self.quiet_logs:
@@ -338,9 +346,29 @@ class TTSServer:
 
     def start(self):
         """Starts the gsv_tts worker process if not already running."""
+        with self._lifecycle_lock:
+            try:
+                self._start()
+            except BaseException:
+                try:
+                    self._stop(force=True)
+                except Exception as cleanup_error:
+                    self.logger.error(
+                        f"Failed to roll back gsv_tts startup: {cleanup_error}"
+                    )
+                raise
+
+    def _start(self) -> None:
         if self.server_process and self.server_process.is_alive():
+            if self._stopping:
+                raise RuntimeError("gsv_tts worker is still stopping")
             self._info("gsv_tts worker is already running")
             return
+
+        with self._lifecycle_condition:
+            if self._active_requests:
+                raise RuntimeError("Cannot restart gsv_tts while synthesis requests are still active")
+            self._stopping = False
 
         if not os.path.exists(self.config_path):
             self.logger.error(f"Config file not found at {self.config_path}")
@@ -375,49 +403,107 @@ class TTSServer:
 
         self._info("gsv_tts worker started successfully")
 
-        # Ensure cleanup on main process exit
-        atexit.register(self.stop)
+        # Ensure cleanup on main process exit without retaining stopped servers.
+        if not self._atexit_registered:
+            atexit.register(self.stop)
+            self._atexit_registered = True
+
+    def request_stop(self) -> None:
+        """Reject new requests and wake in-flight response waiters."""
+        with self._lifecycle_condition:
+            self._stopping = True
+        if self.stop_event is not None:
+            self.stop_event.set()
+
+    def _begin_request(self) -> None:
+        with self._lifecycle_condition:
+            if self._stopping:
+                raise RuntimeError("gsv_tts worker is stopping")
+            self._active_requests += 1
+
+    def _end_request(self) -> None:
+        with self._lifecycle_condition:
+            self._active_requests -= 1
+            if self._active_requests == 0:
+                self._lifecycle_condition.notify_all()
+
+    def _wait_for_active_requests(self, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._lifecycle_condition:
+            while self._active_requests:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._lifecycle_condition.wait(remaining)
+            return True
 
     def stop(self, force: bool = False):
         """Stops the gsv_tts worker process."""
-        if not self.server_process:
-            return
+        with self._lifecycle_lock:
+            self._stop(force=force)
 
-        self._info("Stopping gsv_tts worker...")
-        if self.stop_event:
-            self.stop_event.set()
-        try:
-            if self.request_queue and not force:
-                self.request_queue.put({"command": "shutdown", "request_id": "__shutdown__"})
-        except Exception:
-            pass
+    def _stop(self, force: bool = False) -> None:
+        self.request_stop()
+        process = self.server_process
 
-        if self.server_process.is_alive():
-            self.server_process.join(timeout=10)
-            if self.server_process.is_alive():
+        if process is not None:
+            if not force and not self._wait_for_active_requests(timeout=10.0):
+                self.logger.warning(
+                    "Timed out waiting for active gsv_tts requests; forcing worker shutdown"
+                )
+                force = True
+
+            self._info("Stopping gsv_tts worker...")
+            try:
+                if self.request_queue is not None and not force:
+                    self.request_queue.put({"command": "shutdown", "request_id": "__shutdown__"})
+            except Exception:
+                pass
+
+            if process.is_alive():
+                process.join(timeout=10)
+            if process.is_alive():
                 self.logger.warning("gsv_tts worker did not exit gracefully, terminating...")
-                self.server_process.terminate()
-                self.server_process.join(timeout=5)
+                process.terminate()
+                process.join(timeout=5)
+            if process.is_alive():
+                kill = getattr(process, "kill", None)
+                if kill is not None:
+                    self.logger.warning("gsv_tts worker survived terminate(), killing...")
+                    kill()
+                    process.join(timeout=5)
+            if process.is_alive():
+                raise RuntimeError("gsv_tts worker is still alive after forced shutdown")
 
-        self.server_process = None
+            close_process = getattr(process, "close", None)
+            if close_process is not None:
+                close_process()
+            self.server_process = None
 
-        if self.request_queue is not None:
+        cleanup_errors: list[str] = []
+        for attribute in ("request_queue", "response_queue"):
+            queue = getattr(self, attribute)
+            if queue is None:
+                continue
             try:
-                self.request_queue.close()
-                self.request_queue.cancel_join_thread()
-            except Exception:
-                pass
-        if self.response_queue is not None:
-            try:
-                self.response_queue.close()
-                self.response_queue.cancel_join_thread()
-            except Exception:
-                pass
+                queue.close()
+                queue.cancel_join_thread()
+            except ValueError:
+                # multiprocessing.Queue raises ValueError when already closed.
+                setattr(self, attribute, None)
+            except Exception as error:
+                cleanup_errors.append(f"{attribute}: {type(error).__name__}: {error}")
+            else:
+                setattr(self, attribute, None)
 
-        self.request_queue = None
-        self.response_queue = None
+        if cleanup_errors:
+            raise RuntimeError("Failed to close gsv_tts queues: " + "; ".join(cleanup_errors))
+
         self.ready_event = None
         self.stop_event = None
+        if self._atexit_registered:
+            atexit.unregister(self.stop)
+            self._atexit_registered = False
         self._info("gsv_tts worker stopped")
 
     def synthesize(
@@ -428,35 +514,39 @@ class TTSServer:
         prompt_audio_text: str,
         timeout: int = 600,
     ) -> bytes:
-        if not self.server_process or not self.server_process.is_alive():
-            raise RuntimeError("gsv_tts worker is not running")
+        self._begin_request()
+        try:
+            if not self.server_process or not self.server_process.is_alive():
+                raise RuntimeError("gsv_tts worker is not running")
 
-        if not self.request_queue or not self.response_queue:
-            raise RuntimeError("gsv_tts worker queues are not initialized")
+            if not self.request_queue or not self.response_queue:
+                raise RuntimeError("gsv_tts worker queues are not initialized")
 
-        with self._synthesize_lock:
-            self._request_counter += 1
-            request_id = f"req-{self._request_counter}"
+            with self._synthesize_lock:
+                self._request_counter += 1
+                request_id = f"req-{self._request_counter}"
 
-            self.request_queue.put(
-                {
-                    "command": "synthesize",
-                    "request_id": request_id,
-                    "text": text,
-                    "spk_audio_path": spk_audio_path,
-                    "prompt_audio_path": prompt_audio_path,
-                    "prompt_audio_text": prompt_audio_text,
-                }
-            )
+                self.request_queue.put(
+                    {
+                        "command": "synthesize",
+                        "request_id": request_id,
+                        "text": text,
+                        "spk_audio_path": spk_audio_path,
+                        "prompt_audio_path": prompt_audio_path,
+                        "prompt_audio_text": prompt_audio_text,
+                    }
+                )
 
-            response = self._wait_for_response(request_id=request_id, timeout=timeout)
-            if not response.get("ok"):
-                error = response.get("error", "unknown error")
-                tb = response.get("traceback")
-                if tb:
-                    self.logger.error(f"gsv_tts synthesize failed: {error}\n{tb}")
-                raise RuntimeError(f"gsv_tts synthesize failed: {error}")
-            return response.get("audio_bytes", b"")
+                response = self._wait_for_response(request_id=request_id, timeout=timeout)
+                if not response.get("ok"):
+                    error = response.get("error", "unknown error")
+                    tb = response.get("traceback")
+                    if tb:
+                        self.logger.error(f"gsv_tts synthesize failed: {error}\n{tb}")
+                    raise RuntimeError(f"gsv_tts synthesize failed: {error}")
+                return response.get("audio_bytes", b"")
+        finally:
+            self._end_request()
 
     def stream_synthesize(
         self,
@@ -466,42 +556,46 @@ class TTSServer:
         prompt_audio_text: str,
         timeout: int = 600,
     ) -> Generator[bytes, None, None]:
-        if not self.server_process or not self.server_process.is_alive():
-            raise RuntimeError("gsv_tts worker is not running")
+        self._begin_request()
+        try:
+            if not self.server_process or not self.server_process.is_alive():
+                raise RuntimeError("gsv_tts worker is not running")
 
-        if not self.request_queue or not self.response_queue:
-            raise RuntimeError("gsv_tts worker queues are not initialized")
+            if not self.request_queue or not self.response_queue:
+                raise RuntimeError("gsv_tts worker queues are not initialized")
 
-        with self._synthesize_lock:
-            self._request_counter += 1
-            request_id = f"req-{self._request_counter}"
+            with self._synthesize_lock:
+                self._request_counter += 1
+                request_id = f"req-{self._request_counter}"
 
-            self.request_queue.put(
-                {
-                    "command": "stream_synthesize",
-                    "request_id": request_id,
-                    "text": text,
-                    "spk_audio_path": spk_audio_path,
-                    "prompt_audio_path": prompt_audio_path,
-                    "prompt_audio_text": prompt_audio_text,
-                }
-            )
+                self.request_queue.put(
+                    {
+                        "command": "stream_synthesize",
+                        "request_id": request_id,
+                        "text": text,
+                        "spk_audio_path": spk_audio_path,
+                        "prompt_audio_path": prompt_audio_path,
+                        "prompt_audio_text": prompt_audio_text,
+                    }
+                )
 
-            while True:
-                response = self._wait_for_response(request_id=request_id, timeout=timeout)
-                if not response.get("ok"):
-                    error = response.get("error", "unknown error")
-                    tb = response.get("traceback")
-                    if tb:
-                        self.logger.error(f"gsv_tts stream synthesize failed: {error}\n{tb}")
-                    raise RuntimeError(f"gsv_tts stream synthesize failed: {error}")
+                while True:
+                    response = self._wait_for_response(request_id=request_id, timeout=timeout)
+                    if not response.get("ok"):
+                        error = response.get("error", "unknown error")
+                        tb = response.get("traceback")
+                        if tb:
+                            self.logger.error(f"gsv_tts stream synthesize failed: {error}\n{tb}")
+                        raise RuntimeError(f"gsv_tts stream synthesize failed: {error}")
 
-                chunk = response.get("audio_bytes")
-                if chunk:
-                    yield chunk
+                    chunk = response.get("audio_bytes")
+                    if chunk:
+                        yield chunk
 
-                if response.get("is_final"):
-                    break
+                    if response.get("is_final"):
+                        break
+        finally:
+            self._end_request()
 
     def _wait_for_worker_ready(self, timeout: int) -> bool:
         if not self.ready_event:
@@ -528,6 +622,8 @@ class TTSServer:
     def _wait_for_response(self, request_id: str, timeout: int) -> Dict[str, Any]:
         start_time = time.time()
         while (time.time() - start_time) < timeout:
+            if self._stopping or (self.stop_event is not None and self.stop_event.is_set()):
+                raise RuntimeError("gsv_tts worker is stopping")
             if self.server_process and not self.server_process.is_alive():
                 raise RuntimeError("gsv_tts worker exited unexpectedly")
 

--- a/server/src/chat_session/chat_pipeline/chat_stream.py
+++ b/server/src/chat_session/chat_pipeline/chat_stream.py
@@ -7,6 +7,11 @@ from typing import Any, List, Optional, TYPE_CHECKING
 
 
 from src.utils.logger import get_logger
+from src.utils.asyncio_helpers import (
+    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+    cancel_task_once,
+    wait_for_owned_tasks,
+)
 from src.domain.chat import ChatInputEvent, ChatInputEventType
 from src.system.user_interface.types import WSEventType
 
@@ -74,7 +79,13 @@ class ChatStream:
         self.topic_replier.set_change_state_callback(self.change_state)
         self.topic_replier.set_send_reply_callback(self.feed_response)
 
-        self.response_queue: asyncio.Queue[ChatResponse] = asyncio.Queue()
+        self.response_queue_maxsize = max(
+            1,
+            int(config.get("response_queue_maxsize", 256)),
+        )
+        self.response_queue: asyncio.Queue[ChatResponse] = asyncio.Queue(
+            maxsize=self.response_queue_maxsize,
+        )
         self.response_sender_task: asyncio.Task | None = None
         self.context_snapshot: "ConversationContextSnapshot | None" = None
         self.context_snapshot_ts_type: str = "elapsed"
@@ -83,6 +94,18 @@ class ChatStream:
         self.state = self.STATE_WAITING
         self.state_lock = asyncio.Lock()
         self.last_response_active_ts: float | None = None
+        self._stop_lock = asyncio.Lock()
+        self._closing = False
+        self._stopped = False
+        self.shutdown_timeout_seconds = max(
+            0.001,
+            float(
+                config.get(
+                    "shutdown_timeout_seconds",
+                    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+                )
+            ),
+        )
 
     def record_sung_segment(self, song_name: str, segment: str) -> None:
         self.recent_sung_segments.append((song_name, segment))
@@ -128,6 +151,8 @@ class ChatStream:
 
     async def start_if_needed(self):
         """启动常驻消息处理协程（仅启动一次）。"""
+        if self._closing:
+            raise RuntimeError("Chat stream is stopping and cannot be started")
         self.ensure_dependencies()
         await self.initialize_context()
         self.ingress_helper.start_processing()
@@ -138,10 +163,20 @@ class ChatStream:
 
     async def feed_event(self, event: ChatInputEvent):
         """接收 service 层转换后的聊天事件，并交给 ingress worker。"""
+        if self._closing:
+            raise RuntimeError("Chat stream is stopping and cannot accept events")
         await self.ingress_helper.put(event)
+
+    def try_feed_event(self, event: ChatInputEvent) -> bool:
+        """Try to accept a WebSocket event without waiting for queue capacity."""
+        if self._closing:
+            return False
+        return self.ingress_helper.put_nowait(event)
     
     async def feed_response(self, response: ChatResponse):
         """接收 topic replier 生成的回复，并发送给用户。"""
+        if self._closing:
+            raise RuntimeError("Chat stream is stopping and cannot accept responses")
         await self.response_queue.put(response)
 
     async def get_conversation_context(
@@ -281,10 +316,19 @@ class ChatStream:
 
     ####### 下方为连接管理相关方法 #######
 
-    def lost_connection(self):
-        """连接丢失时的清理逻辑"""
+    def owns_connection(self, ws_connection: "WebSocketConnection") -> bool:
+        """Return whether ``ws_connection`` is still the stream's active connection."""
+        return self.ws_connection is ws_connection
+
+    def lost_connection(self, ws_connection: "WebSocketConnection | None" = None) -> bool:
+        """Mark the stream offline only when the active connection was lost."""
+        if ws_connection is not None and not self.owns_connection(ws_connection):
+            return False
+        if self.ws_connection is None:
+            return False
         self.ws_connection = None
         self.connection_lost_time = time.time()
+        return True
 
     def is_connection_lost(self):
         """检查连接是否丢失"""
@@ -292,6 +336,8 @@ class ChatStream:
 
     async def reconnect(self, new_ws_connection: "WebSocketConnection"):
         """用户重连时调用，更新 WebSocket 连接"""
+        if self._closing:
+            raise RuntimeError("Chat stream is stopping and cannot reconnect")
         self.logger.info(f"User {self.user_name} reconnected")
         self.ws_connection = new_ws_connection
         self.user_name = new_ws_connection.user_name if new_ws_connection else self.user_name
@@ -299,15 +345,72 @@ class ChatStream:
         self.state = self.STATE_WAITING
         await self.start_if_needed()
 
+    def _worker_task_bindings(self):
+        return (
+            (self.ingress_helper, "ingress_worker_task"),
+            (self.topic_planner, "processor_task"),
+            (self.topic_replier, "processor_task"),
+            (self.reflection_worker, "processor_task"),
+            (self, "response_sender_task"),
+        )
+
     def clean_up(self):
-        """清理资源的逻辑，比如关闭文件、数据库连接等"""
-        if self.ingress_helper.ingress_worker_task and not self.ingress_helper.ingress_worker_task.done():
-            self.ingress_helper.ingress_worker_task.cancel()
-        if self.topic_planner.processor_task and not self.topic_planner.processor_task.done():
-            self.topic_planner.processor_task.cancel()
-        if self.topic_replier.processor_task and not self.topic_replier.processor_task.done():
-            self.topic_replier.processor_task.cancel()
-        if self.reflection_worker.processor_task and not self.reflection_worker.processor_task.done():
-            self.reflection_worker.processor_task.cancel()
-        if self.response_sender_task and not self.response_sender_task.done():
-            self.response_sender_task.cancel()
+        """Request cancellation of all stream workers without waiting for completion."""
+        for owner, attribute in self._worker_task_bindings():
+            task = getattr(owner, attribute, None)
+            if task is not None and not task.done():
+                task.cancel()
+
+    async def stop(self, *, close_connection: bool = True) -> None:
+        """Stop the stream completely; failed steps remain retryable."""
+        async with self._stop_lock:
+            if self._stopped:
+                return
+
+            self._closing = True
+            errors: list[str] = []
+            connection = self.ws_connection
+            if close_connection and connection is not None and connection.websocket is not None:
+                try:
+                    await connection.websocket.close()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    errors.append(f"websocket close failed: {error}")
+                else:
+                    self.lost_connection(connection)
+
+            bindings = self._worker_task_bindings()
+            tasks = []
+            for owner, attribute in bindings:
+                task = getattr(owner, attribute, None)
+                if task is not None:
+                    cancel_task_once(task)
+                    tasks.append(task)
+
+            if tasks:
+                done, pending = await wait_for_owned_tasks(
+                    tasks,
+                    timeout_seconds=self.shutdown_timeout_seconds,
+                )
+                for task in done:
+                    try:
+                        task.result()
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception as error:
+                        errors.append(f"worker stop failed: {error}")
+                if pending:
+                    errors.append(f"{len(pending)} worker task(s) still stopping")
+
+            for owner, attribute in bindings:
+                task = getattr(owner, attribute, None)
+                if task is not None and task.done():
+                    setattr(owner, attribute, None)
+
+            if errors:
+                raise RuntimeError("; ".join(errors))
+
+            if connection is not None and self.ws_connection is connection:
+                self.lost_connection(connection)
+            self._stopped = True

--- a/server/src/chat_session/chat_pipeline/ingress_helper.py
+++ b/server/src/chat_session/chat_pipeline/ingress_helper.py
@@ -22,7 +22,10 @@ class IngressHelper:
         self.user_uuid = user_id
         self.character_id = character_id or "luotianyi"
         self.logger = get_logger(f"{self.username}IngressHelper")
-        self.ingress_queue: asyncio.Queue[ChatInputEvent] = asyncio.Queue()
+        self.queue_maxsize = max(1, int(config.get("queue_maxsize", 128)))
+        self.ingress_queue: asyncio.Queue[ChatInputEvent] = asyncio.Queue(
+            maxsize=self.queue_maxsize,
+        )
         self.ingress_worker_task: asyncio.Task | None = None
         self.system_runtime: "SystemRuntime" | None = None
         self.send_reply_callback: Callable[["ChatResponse"], Awaitable[None]] = send_reply_callback
@@ -35,6 +38,14 @@ class IngressHelper:
     async def put(self, event: ChatInputEvent):
         """将事件放入 ingress 队列，供 ingress worker 处理。"""
         await self.ingress_queue.put(event)
+
+    def put_nowait(self, event: ChatInputEvent) -> bool:
+        """Try to accept an event without blocking the WebSocket receive loop."""
+        try:
+            self.ingress_queue.put_nowait(event)
+        except asyncio.QueueFull:
+            return False
+        return True
 
     # ————————————————————设置依赖————————————————————————
 

--- a/server/src/chat_session/chat_pipeline/reflection_worker.py
+++ b/server/src/chat_session/chat_pipeline/reflection_worker.py
@@ -42,7 +42,10 @@ class ReflectionWorker:
         self.reply_topic_callback = reply_topic_callback
         self.system_runtime: "SystemRuntime | None" = None
         self.logger = get_logger(f"{username}ReflectionWorker")
-        self.reflection_queue: asyncio.Queue[CompletedTurn] = asyncio.Queue()
+        self.queue_maxsize = max(1, int(config.get("queue_maxsize", 64)))
+        self.reflection_queue: asyncio.Queue[CompletedTurn] = asyncio.Queue(
+            maxsize=self.queue_maxsize,
+        )
         self.processor_task: asyncio.Task | None = None
 
     def set_system_runtime(self, system_runtime: "SystemRuntime") -> None:
@@ -102,7 +105,7 @@ class ReflectionWorker:
             user_id=turn.user_id,
             topic=turn.topic,
             conversation_history=turn.conversation_history,
-            reply_topic_callback=lambda t: self._safe_reply_topic(t),
+            reply_topic_callback=self._safe_reply_topic,
         )
 
         if result is True:
@@ -112,12 +115,14 @@ class ReflectionWorker:
         else:
             self.logger.info(f"Date confirmation topic created from topic {turn.topic.topic_id}")
 
-    def _safe_reply_topic(self, topic: "ExtractedTopic") -> None:
+    async def _safe_reply_topic(self, topic: "ExtractedTopic") -> None:
         if self.reply_topic_callback is None:
             self.logger.warning("No reply topic callback set, cannot enqueue reflection topic")
             return
         try:
-            asyncio.create_task(self.reply_topic_callback(topic))
+            await self.reply_topic_callback(topic)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             self.logger.warning(f"Failed to add reflection topic: {e}")
 

--- a/server/src/chat_session/chat_pipeline/topic_replier.py
+++ b/server/src/chat_session/chat_pipeline/topic_replier.py
@@ -34,7 +34,8 @@ class TopicReplier:
         self.character_id = character_id
         self.send_reply_callback: Optional[Callable[["ChatResponse"], Awaitable[None]]] = None
         self.logger = get_logger(f"{username}TopicReplier")
-        self.topic_queue = asyncio.Queue()
+        self.queue_maxsize = max(1, int(config.get("queue_maxsize", 64)))
+        self.topic_queue = asyncio.Queue(maxsize=self.queue_maxsize)
         self.processor_task: asyncio.Task | None = None
         self.system_runtime: "SystemRuntime" | None = None
         self.is_processing: bool = False

--- a/server/src/chat_session/chat_pipeline/unread_store.py
+++ b/server/src/chat_session/chat_pipeline/unread_store.py
@@ -13,12 +13,16 @@ class UnreadStore:
     def __init__(self, config: dict, username: str, user_id: str):
         self.config = config
         self.logger = get_logger(f"{username}UnreadStore")
+        self.maxsize = max(1, int(config.get("maxsize", 128)))
         self.unread_messages: List[UnreadMessage] = []
         self.username: str = username
         self.user_id: str = user_id
         self._snapshot_version: int = 0  # 用于跟踪消息版本，确保一致性
         self._snapshot: UnreadMessageSnapshot | None = None
         self._message_lock = asyncio.Lock()  # 用于保护unread_messages的并发访问
+        self._capacity_changed = asyncio.Condition(self._message_lock)
+        # A snapshot still owns its messages until update_unread_message commits.
+        self._occupied_count = 0
 
     @staticmethod
     def trans_ChatInputEvent_to_UnreadMessage(event: ChatInputEvent) -> UnreadMessage:
@@ -37,32 +41,49 @@ class UnreadStore:
         )
 
     async def append(self, message: UnreadMessage):
-        async with self._message_lock:
+        async with self._capacity_changed:
+            while self._occupied_count >= self.maxsize:
+                await self._capacity_changed.wait()
             self.unread_messages.append(message)
+            self._occupied_count += 1
 
     async def snapshot(self) -> UnreadMessageSnapshot:
-        if self._snapshot is not None:
-            self.logger.error("在snapshot被销毁之前不应该重新建立snapshot，可能存在并发问题")
-            return self._snapshot
         async with self._message_lock:
+            if self._snapshot is not None:
+                self.logger.error("在snapshot被销毁之前不应该重新建立snapshot，可能存在并发问题")
+                return self._snapshot
             self._snapshot_version += 1
             self._snapshot = UnreadMessageSnapshot(messages=self.unread_messages.copy(), version=self._snapshot_version)
             self.unread_messages.clear()  # 清空当前未读消息列表
             return self._snapshot
 
     async def update_unread_message(self, snapshot: UnreadMessageSnapshot, remained_messages: List[UnreadMessage]):
-        if self._snapshot is None or snapshot.version != self._snapshot.version:
-            self.logger.error("更新未读消息失败，版本不匹配，可能存在并发问题")
-            return
-        async with self._message_lock:
+        async with self._capacity_changed:
+            if self._snapshot is None or snapshot.version != self._snapshot.version:
+                self.logger.error("更新未读消息失败，版本不匹配，可能存在并发问题")
+                return
+            if len(remained_messages) > len(snapshot.messages):
+                raise ValueError("remained_messages cannot exceed the active snapshot")
+
+            released = len(snapshot.messages) - len(remained_messages)
             self._snapshot = None  # 销毁当前snapshot
             self.unread_messages = remained_messages + self.unread_messages  # 将未处理的消息重新加入未读消息列表
+            self._occupied_count -= released
+            if released:
+                self._capacity_changed.notify_all()
 
     async def has_unread(self) -> bool:
         async with self._message_lock:
             return len(self.unread_messages) > 0
+
+    async def pending_count(self) -> int:
+        """Return all capacity-owned messages, including the active snapshot."""
+        async with self._message_lock:
+            return self._occupied_count
         
     async def clear(self):
-        async with self._message_lock:
+        async with self._capacity_changed:
             self.unread_messages.clear()
             self._snapshot = None
+            self._occupied_count = 0
+            self._capacity_changed.notify_all()

--- a/server/src/chat_session/chat_session_manager.py
+++ b/server/src/chat_session/chat_session_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from .dependency.activity_context_provider import ActivityContextProvider
@@ -47,18 +48,23 @@ class ChatSessionManager:
             activity_context_provider = self.activity_context_provider,
         )
         chat_stream_manager_module.chat_stream_manager = self.chat_stream_manager
-        self.proactive_topic_maker.configure(
-            conversation_service=self.conversation_service,
-            database_manager=self.database_manager,
-            chat_stream_manager=self.chat_stream_manager,
-        )
-        self.call_stream_manager = CallStreamManager(
-            config.get("call_stream_manager", {}),
-            conversation_service = self.conversation_service,
-            global_speaking_worker = self.global_speaking_worker,
-            proactive_topic_maker = self.proactive_topic_maker,
-            activity_context_provider = self.activity_context_provider,
+        try:
+            self.proactive_topic_maker.configure(
+                conversation_service=self.conversation_service,
+                database_manager=self.database_manager,
+                chat_stream_manager=self.chat_stream_manager,
             )
+            self.call_stream_manager = CallStreamManager(
+                config.get("call_stream_manager", {}),
+                conversation_service = self.conversation_service,
+                global_speaking_worker = self.global_speaking_worker,
+                proactive_topic_maker = self.proactive_topic_maker,
+                activity_context_provider = self.activity_context_provider,
+                )
+        except BaseException:
+            if chat_stream_manager_module.chat_stream_manager is self.chat_stream_manager:
+                chat_stream_manager_module.chat_stream_manager = None
+            raise
 
     def wire_dependencies(
         self,
@@ -124,9 +130,21 @@ class ChatSessionManager:
 
     async def stop_background_services(self) -> None:
         """停止聊天、通话和 speaking worker 后台服务。"""
-        await self.chat_stream_manager.stop_cleanup_task()
-        await self.call_stream_manager.stop_background_services()
-        await self.global_speaking_worker.stop()
+        errors: list[str] = []
+        shutdown_steps = (
+            ("chat streams", self.chat_stream_manager.stop_all_streams),
+            ("call streams", self.call_stream_manager.stop_background_services),
+            ("speaking worker", self.global_speaking_worker.stop),
+        )
+        for name, stop in shutdown_steps:
+            try:
+                await stop()
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                errors.append(f"{name}: {error}")
+        if errors:
+            raise RuntimeError("Chat session shutdown failed: " + "; ".join(errors))
 
     async def on_user_login(self, user_uuid: str, elapsed_from_last_login: Optional[float]) -> None:
         """用户登录时，记录主动话题所需的登录活动。"""

--- a/server/src/chat_session/chat_stream_manager.py
+++ b/server/src/chat_session/chat_stream_manager.py
@@ -39,6 +39,10 @@ class ChatStreamManager:
 
         self.user_streams: Dict[Tuple[str, str], ChatStream] = {}
         self.cleanup_task: asyncio.Task | None = None
+        lock_stripes = max(1, int(config.get("stream_lock_stripes", 64)))
+        self._stream_locks = tuple(asyncio.Lock() for _ in range(lock_stripes))
+        self._background_tasks: set[asyncio.Task] = set()
+        self._closing = False
         self.default_expiration_seconds = config.get("default_expiration_seconds", 3600)
         self.heartbeat_timeout_seconds = config.get("heartbeat_timeout_seconds", 60)
 
@@ -69,10 +73,29 @@ class ChatStreamManager:
         if missing:
             raise RuntimeError(f"ChatStreamManager dependencies are missing: {', '.join(missing)}")
 
+    def _stream_lock_for(self, stream_key: Tuple[str, str]) -> asyncio.Lock:
+        """Return a bounded lock stripe that serializes mutations for one stream key."""
+        return self._stream_locks[hash(stream_key) % len(self._stream_locks)]
+
+    def _track_background_task(self, task: asyncio.Task) -> None:
+        self._background_tasks.add(task)
+        task.add_done_callback(self._on_background_task_done)
+
+    def _on_background_task_done(self, task: asyncio.Task) -> None:
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        try:
+            error = task.exception()
+        except asyncio.CancelledError:
+            return
+        if error is not None:
+            self.logger.error(f"Chat stream background task failed: {error}")
+
     async def get_or_register_chat_stream(
         self,
         ws_connection: WebSocketConnection,
-        character: Optional[str] = "luotianyi",
+        character: Optional[str] = None,
         system_runtime: Optional["SystemRuntime"] = None,
     ) -> ChatStream:
         """
@@ -82,19 +105,62 @@ class ChatStreamManager:
         user_uuid = ws_connection.user_uuid
         if user_uuid is None:
             raise ValueError("WebSocketConnection must have a user_uuid for chat stream management.")
+        if self._closing:
+            raise RuntimeError("Chat stream manager is stopping and cannot accept connections")
 
-        if (user_uuid, character) not in self.user_streams:  # 创建新的聊天流实例并注册
-            chat_stream = ChatStream(self.config.get("chat_stream", {}), ws_connection, character_id=character)
-            chat_stream.set_system_runtime(system_runtime)
-            await chat_stream.start_if_needed()
-            self.user_streams[(user_uuid, character)] = chat_stream
-        else: # 如果已经存在聊天流实例，则更新 WebSocket 连接
-            chat_stream = self.user_streams[(user_uuid, character)]
-            chat_stream.set_system_runtime(system_runtime)
-            await chat_stream.reconnect(ws_connection)
-        if self.proactive_topic_maker is not None:
-            asyncio.create_task(self.proactive_topic_maker.on_user_login(user_uuid, chat_stream=chat_stream))
+        character_id = self._resolve_character_id(character, system_runtime)
+        stream_key = (user_uuid, character_id)
+        async with self._stream_lock_for(stream_key):
+            if self._closing:
+                raise RuntimeError("Chat stream manager is stopping and cannot accept connections")
+            chat_stream = self.user_streams.get(stream_key)
+            if chat_stream is None:
+                candidate = ChatStream(
+                    self.config.get("chat_stream", {}),
+                    ws_connection,
+                    character_id=character_id,
+                )
+                candidate.set_system_runtime(system_runtime)
+                try:
+                    await candidate.start_if_needed()
+                except BaseException:
+                    try:
+                        await self._stop_stream(candidate, close_connection=False)
+                    except Exception as cleanup_error:
+                        self.logger.error(
+                            f"Failed to clean up partially started chat stream "
+                            f"for user_uuid={user_uuid}, character={character_id}: {cleanup_error}"
+                        )
+                    raise
+                self.user_streams[stream_key] = candidate
+                chat_stream = candidate
+            else:
+                chat_stream.set_system_runtime(system_runtime)
+                await chat_stream.reconnect(ws_connection)
+        if self.proactive_topic_maker is not None and not self._closing:
+            login_task = asyncio.create_task(
+                self.proactive_topic_maker.on_user_login(user_uuid, chat_stream=chat_stream),
+                name=f"chat-stream-login:{user_uuid}:{character_id}",
+            )
+            self._track_background_task(login_task)
         return chat_stream
+
+    @staticmethod
+    def _resolve_character_id(
+        character: str | None,
+        system_runtime: Optional["SystemRuntime"],
+    ) -> str:
+        agent_runtime = getattr(system_runtime, "agent_runtime", None)
+        registry = getattr(agent_runtime, "character_registry", None)
+        default_character_id = (
+            getattr(agent_runtime, "default_character_id", None)
+            or getattr(registry, "default_character_id", None)
+            or "luotianyi"
+        )
+        resolved = character or default_character_id
+        if registry is not None:
+            registry.resolve_targets((resolved,))
+        return resolved
 
     def get_stream_by_user_uuid(self, user_uuid: str, character: str = "luotianyi") -> ChatStream | None:
         return self.user_streams.get((user_uuid, character))
@@ -116,59 +182,153 @@ class ChatStreamManager:
         user_uuid = ws_connection.user_uuid
         if not user_uuid:
             return
-        for (stream_user_uuid, _character), chat_stream in self.user_streams.items():
+        for (stream_user_uuid, _character), chat_stream in list(self.user_streams.items()):
             if stream_user_uuid == user_uuid:
-                chat_stream.lost_connection()
+                chat_stream.lost_connection(ws_connection)
 
-    async def cleanup_expired_streams(self, expiration_seconds: int = 3600):
-        """
-        定期清理过期的聊天流实例。
-        """
-        while True:
+    async def _cleanup_once(self, expiration_seconds: int, current_time: float | None = None) -> None:
+        """Run one cleanup pass while isolating failures to the affected stream."""
+        if current_time is None:
             current_time = time.time()
-            current_time_ms = int(current_time * 1000)
+        current_time_ms = int(current_time * 1000)
 
-            for stream_key in list(self.user_streams.keys()):
-                stream = self.user_streams[stream_key]
+        for stream_key, stream in list(self.user_streams.items()):
+            try:
                 ws_connection = stream.ws_connection
                 if (
                     ws_connection
                     and ws_connection.last_ping_time
                     and (current_time_ms - ws_connection.last_ping_time > self.heartbeat_timeout_seconds * 1000)
                 ):
-                    await ws_connection.websocket.close()
-                    self.ws_lost_connection(ws_connection)
+                    try:
+                        await ws_connection.websocket.close()
+                    finally:
+                        stream.lost_connection(ws_connection)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                self.logger.error(f"Failed to close stale chat stream {stream_key}: {error}")
 
-            expired_stream_keys = []
-            for stream_key, chat_stream in list(self.user_streams.items()):
-                if chat_stream.connection_lost_time and (current_time - chat_stream.connection_lost_time > expiration_seconds):
-                    expired_stream_keys.append(stream_key)
+        for stream_key, snapshot_stream in list(self.user_streams.items()):
+            try:
+                async with self._stream_lock_for(stream_key):
+                    chat_stream = self.user_streams.get(stream_key)
+                    if chat_stream is not snapshot_stream:
+                        continue
+                    lost_at = chat_stream.connection_lost_time
+                    if lost_at is None or current_time - lost_at <= expiration_seconds:
+                        continue
+                    await self._stop_stream(chat_stream, close_connection=False)
+                    if self.user_streams.get(stream_key) is chat_stream:
+                        del self.user_streams[stream_key]
+                    user_uuid, character_id = stream_key
+                    self.logger.info(
+                        f"Cleaned up expired chat stream for user_uuid={user_uuid}, "
+                        f"character={character_id}"
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                self.logger.error(f"Failed to clean up expired chat stream {stream_key}: {error}")
 
-            for stream_key in expired_stream_keys:
-                user_uuid, _character = stream_key
-                chat_stream = self.user_streams[stream_key]
-                chat_stream.clean_up()
-                del self.user_streams[stream_key]
-                self.logger.info(f"Cleaned up expired chat stream for user_uuid={user_uuid}")
-
+    async def cleanup_expired_streams(self, expiration_seconds: int = 3600):
+        """
+        定期清理过期的聊天流实例。
+        """
+        while True:
+            try:
+                await self._cleanup_once(expiration_seconds)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                self.logger.error(f"Unexpected chat stream cleanup failure: {error}")
             await asyncio.sleep(60)
 
     def start_cleanup_task(self, expiration_seconds: Optional[int] = None):
         self.ensure_dependencies()
+        if self._closing:
+            raise RuntimeError("Chat stream manager is stopping and cannot start cleanup")
         if self.cleanup_task is not None and not self.cleanup_task.done():
             return
         if expiration_seconds is None:
             expiration_seconds = self.default_expiration_seconds
-        self.cleanup_task = asyncio.create_task(self.cleanup_expired_streams(expiration_seconds))
+        self.cleanup_task = asyncio.create_task(
+            self.cleanup_expired_streams(expiration_seconds),
+            name="chat-stream-cleanup",
+        )
+        self.cleanup_task.add_done_callback(self._on_cleanup_task_done)
+
+    def _on_cleanup_task_done(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        try:
+            error = task.exception()
+        except asyncio.CancelledError:
+            return
+        if error is not None:
+            self.logger.error(f"Chat stream cleanup task stopped unexpectedly: {error}")
 
     async def stop_cleanup_task(self):
-        if self.cleanup_task:
-            self.cleanup_task.cancel()
+        task = self.cleanup_task
+        if task:
+            task.cancel()
             try:
-                await self.cleanup_task
+                await task
             except asyncio.CancelledError:
                 self.logger.info("ChatStreamManager cleanup task cancelled")
-        self.cleanup_task = None
+            finally:
+                if self.cleanup_task is task:
+                    self.cleanup_task = None
+
+    async def _stop_stream(self, chat_stream: ChatStream, *, close_connection: bool) -> None:
+        stop = getattr(chat_stream, "stop", None)
+        if stop is not None:
+            await stop(close_connection=close_connection)
+            return
+        chat_stream.clean_up()
+
+    async def stop_all_streams(self) -> None:
+        """Reject new streams and fully stop every registered stream."""
+        self._closing = True
+        errors: list[str] = []
+
+        try:
+            await self.stop_cleanup_task()
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            errors.append(f"cleanup task: {error}")
+
+        background_tasks = list(self._background_tasks)
+        for task in background_tasks:
+            if not task.done():
+                task.cancel()
+        if background_tasks:
+            await asyncio.gather(*background_tasks, return_exceptions=True)
+            self._background_tasks.difference_update(background_tasks)
+
+        acquired_locks: list[asyncio.Lock] = []
+        try:
+            for lock in self._stream_locks:
+                await lock.acquire()
+                acquired_locks.append(lock)
+
+            for stream_key, chat_stream in list(self.user_streams.items()):
+                try:
+                    await self._stop_stream(chat_stream, close_connection=True)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    errors.append(f"stream {stream_key}: {error}")
+                    continue
+                if self.user_streams.get(stream_key) is chat_stream:
+                    del self.user_streams[stream_key]
+        finally:
+            for lock in reversed(acquired_locks):
+                lock.release()
+
+        if errors:
+            raise RuntimeError("Chat stream shutdown failed: " + "; ".join(errors))
 
 
 chat_stream_manager: ChatStreamManager | None = None

--- a/server/src/chat_session/dependency/conversation_service.py
+++ b/server/src/chat_session/dependency/conversation_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime
 import time
@@ -13,6 +12,7 @@ from src.domain.chat import ChatInputEvent, ChatInputEventType
 from src.domain.conversation_type import ConversationItem, timestamp_to_date, timestamp_to_elapsed_time
 from src.utils.enum_type import ContextType, ConversationSource
 from src.utils.logger import get_logger
+from src.utils.asyncio_helpers import run_sync_owned
 
 if TYPE_CHECKING:
     from src.system.database.database_service import DatabaseManager
@@ -127,7 +127,13 @@ class ConversationService:
             content=content,
             data=data,
         )
-        uuid_list = await asyncio.to_thread(self.database.add_conversations, user_id, [item], True, character_id)
+        uuid_list = await run_sync_owned(
+            self.database.add_conversations,
+            user_id,
+            [item],
+            True,
+            character_id,
+        )
         return uuid_list[0] if uuid_list else None
 
     async def initialize_context_snapshot(
@@ -147,7 +153,7 @@ class ConversationService:
         :param ts_type: 时间戳类型，'elapsed'表示相对时间，'date'表示绝对时间
         :return: ConversationContextSnapshot对象
         '''
-        await asyncio.to_thread(
+        await run_sync_owned(
             self.database.reset_conversation_context_if_stale,
             user_id,
             character_id,
@@ -206,7 +212,13 @@ class ConversationService:
         if not conversation_items:
             return [None] * len(reply_items)
 
-        uuid_list = await asyncio.to_thread(self.database.add_conversations, user_id, conversation_items, True, character_id)
+        uuid_list = await run_sync_owned(
+            self.database.add_conversations,
+            user_id,
+            conversation_items,
+            True,
+            character_id,
+        )
         result: list[Optional[str]] = [None] * len(reply_items)
         for index, uuid in zip(persisted_indices, uuid_list):
             result[index] = uuid
@@ -222,7 +234,11 @@ class ConversationService:
         '''
         获取快照形式的对话上下文状态，包含summary、conversations、context_count等信息
         '''
-        context_data = await asyncio.to_thread(self.database.get_conversation_context_state, user_id, character_id)
+        context_data = await run_sync_owned(
+            self.database.get_conversation_context_state,
+            user_id,
+            character_id,
+        )
         return self._build_snapshot(user_id, character_id, context_data, ts_type=ts_type)
 
     async def get_context(
@@ -255,7 +271,11 @@ class ConversationService:
         '''
         根据需要压缩对话上下文
         '''
-        context_count = await asyncio.to_thread(self.database.get_context_count, user_id, character_id)
+        context_count = await run_sync_owned(
+            self.database.get_context_count,
+            user_id,
+            character_id,
+        )
         if context_count <= self.raw_conversation_context_limit:
             return None
 
@@ -275,7 +295,7 @@ class ConversationService:
             recent_conversation="\n".join(recent_conversation),
         )
 
-        updated = await asyncio.to_thread(
+        updated = await run_sync_owned(
             self.database.compact_conversation_context,
             user_id,
             new_summary.strip(),

--- a/server/src/chat_session/dependency/global_speaking_worker.py
+++ b/server/src/chat_session/dependency/global_speaking_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import aclosing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, AsyncGenerator
 from datetime import datetime, timezone
@@ -11,6 +12,12 @@ import base64
 from src.agent.main_chat import OneSentenceChat, SongSegmentChat
 from typing import Callable, Awaitable, Dict, Any
 from src.system.observability import get_observability_service
+from src.utils.asyncio_helpers import (
+    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+    cancel_task_once,
+    run_sync_owned,
+    wait_for_owned_tasks,
+)
 
 if TYPE_CHECKING:
     from src.capabilities import CapabilityManager
@@ -20,14 +27,23 @@ if TYPE_CHECKING:
 _sentinel = object()
 
 
+async def _run_sync_in_executor(call, *args, executor=None):
+    """Await a sync call without abandoning its thread when cancellation arrives."""
+    return await run_sync_owned(call, *args, executor=executor)
+
+
 async def _iter_sync_gen_in_executor(gen, executor=None):
     """Wrap a sync generator as an async generator by driving it in a thread."""
-    loop = asyncio.get_event_loop()
-    while True:
-        chunk = await loop.run_in_executor(executor, next, gen, _sentinel)
-        if chunk is _sentinel:
-            break
-        yield chunk
+    try:
+        while True:
+            chunk = await _run_sync_in_executor(next, gen, _sentinel, executor=executor)
+            if chunk is _sentinel:
+                break
+            yield chunk
+    finally:
+        close = getattr(gen, "close", None)
+        if close is not None:
+            await _run_sync_in_executor(close, executor=executor)
 
 
 @dataclass
@@ -52,11 +68,32 @@ class GlobalSpeakingWorker:
     def __init__(self, config: Dict):
         self.config = config
         self.logger = get_logger("GlobalSpeakingWorker")
-        self.queue: asyncio.Queue[SpeakingJob] = asyncio.Queue(maxsize=512)
+        queue_maxsize = max(1, int(config.get("queue_maxsize", 512)))
+        self.queue: asyncio.Queue[SpeakingJob] = asyncio.Queue(maxsize=queue_maxsize)
         self.worker_task: asyncio.Task | None = None
         self.capabilities: "CapabilityManager | None" = None
+        self._stopping = False
+        self.terminal_send_max_attempts = max(
+            1,
+            int(config.get("terminal_send_max_attempts", 3)),
+        )
+        self.terminal_send_retry_delay_seconds = max(
+            0.0,
+            float(config.get("terminal_send_retry_delay_seconds", 0.05)),
+        )
+        self.shutdown_timeout_seconds = max(
+            0.001,
+            float(
+                config.get(
+                    "shutdown_timeout_seconds",
+                    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+                )
+            ),
+        )
 
     def start_if_needed(self):
+        if self._stopping:
+            raise RuntimeError("Global speaking worker is stopping and cannot be restarted")
         if self.worker_task is None or self.worker_task.done():
             self.worker_task = asyncio.create_task(self._run())
             self.logger.info("Global speaking worker started")
@@ -92,20 +129,55 @@ class GlobalSpeakingWorker:
             job_start_monotonic = time.perf_counter()
             job_start_ts = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
             self._record_queue_wait(job, job_start_ts, job_start_monotonic)
+            terminal_sent = False
+
+            async def send_terminal(
+                *,
+                text: str,
+                expression: str,
+                audio: str = "",
+                error_code: str | None = None,
+            ) -> None:
+                nonlocal terminal_sent
+                if terminal_sent:
+                    return
+                response = ChatResponse(
+                    uuid=job.job_content.uuid,
+                    audio=audio,
+                    is_final_package=True,
+                    text=text,
+                    expression=expression,
+                    audio_error=error_code is not None,
+                    error_code=error_code,
+                )
+                for attempt in range(1, self.terminal_send_max_attempts + 1):
+                    try:
+                        await job.send_reply_callback(response)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as error:
+                        if attempt >= self.terminal_send_max_attempts:
+                            raise
+                        self.logger.warning(
+                            "Terminal response was not accepted "
+                            f"({attempt}/{self.terminal_send_max_attempts}): {error}"
+                        )
+                        if self.terminal_send_retry_delay_seconds:
+                            await asyncio.sleep(self.terminal_send_retry_delay_seconds)
+                    else:
+                        terminal_sent = True
+                        return
+
             try:
                 if isinstance(job.job_content, OneSentenceChat):
                     display_text = job.job_content.content
                     sound_text = job.job_content.sound_content
                     expression = job.job_content.expression
                     if not sound_text.strip():
-                        resp = ChatResponse(
-                            uuid=job.job_content.uuid,
-                            audio="",
-                            is_final_package=True,
+                        await send_terminal(
                             text=display_text,
                             expression=expression,
                         )
-                        await job.send_reply_callback(resp)
                         continue
 
                     # Drive the sync TTS generator in a thread so the event loop
@@ -113,35 +185,64 @@ class GlobalSpeakingWorker:
                     sync_gen = self.capabilities.speech.say_stream(
                         job.character_id, sound_text, job.job_content.tone
                     )
-                    is_first = True
-                    async for audio_chunk in _iter_sync_gen_in_executor(sync_gen):
-                        chunk_text = display_text if is_first else ""
-                        if is_first:
-                            self._record_first_packet(job, job_start_ts, job_start_monotonic)
-                        is_first = False
-                        resp = ChatResponse(
-                            uuid=job.job_content.uuid, audio=audio_chunk,
-                            is_final_package=False, text=chunk_text, expression=expression,
+                    audio_sent = False
+                    try:
+                        async with aclosing(_iter_sync_gen_in_executor(sync_gen)) as audio_chunks:
+                            async for audio_chunk in audio_chunks:
+                                if not audio_chunk:
+                                    continue
+                                chunk_text = display_text if not audio_sent else ""
+                                if not audio_sent:
+                                    self._record_first_packet(job, job_start_ts, job_start_monotonic)
+                                audio_sent = True
+                                resp = ChatResponse(
+                                    uuid=job.job_content.uuid, audio=audio_chunk,
+                                    is_final_package=False, text=chunk_text, expression=expression,
+                                )
+                                await job.send_reply_callback(resp)
+                    except Exception as error:
+                        self.logger.error(f"Streaming TTS failed: {error}")
+                        await send_terminal(
+                            text="" if audio_sent else display_text,
+                            expression="" if audio_sent else expression,
+                            error_code="TTS_STREAM_ERROR",
                         )
-                        await job.send_reply_callback(resp)
-                    final_resp = ChatResponse(
-                        uuid=job.job_content.uuid,
-                        audio="", is_final_package=True,
-                        text="", expression="",
-                    )
-                    await job.send_reply_callback(final_resp)
+                        continue
+
+                    if not audio_sent:
+                        await send_terminal(
+                            text=display_text,
+                            expression=expression,
+                            error_code="TTS_EMPTY",
+                        )
+                    else:
+                        await send_terminal(text="", expression="")
 
                 elif isinstance(job.job_content, SongSegmentChat):
                     text = f"(唱了《{job.job_content.song}》)\n{job.job_content.lyrics}"
                     expression = "唱歌"
-                    audio = await asyncio.to_thread(
-                        self.capabilities.singing.sing,
-                        job.character_id,
-                        job.job_content.song,
-                        job.job_content.segment,
-                    )
+                    try:
+                        audio = await _run_sync_in_executor(
+                            self.capabilities.singing.sing,
+                            job.character_id,
+                            job.job_content.song,
+                            job.job_content.segment,
+                        )
+                    except Exception as error:
+                        self.logger.error(f"Singing synthesis failed: {error}")
+                        await send_terminal(
+                            text=text,
+                            expression=expression,
+                            error_code="TTS_STREAM_ERROR",
+                        )
+                        continue
                     if not audio:
                         self.logger.warning(f"No audio generated for song: {job.job_content.song}")
+                        await send_terminal(
+                            text=text,
+                            expression=expression,
+                            error_code="TTS_EMPTY",
+                        )
                         continue
                     if job.song_audio_generated_callback is not None:
                         job.song_audio_generated_callback(job.job_content.song, job.job_content.segment)
@@ -153,12 +254,19 @@ class GlobalSpeakingWorker:
                         if i == 0:
                             self._record_first_packet(job, job_start_ts, job_start_monotonic)
                         is_final_package = (i + CHUNK_SIZE) >= len(audio)
-                        chunk_resp = ChatResponse(
-                            uuid=job.job_content.uuid, audio=chunk_base64,
-                            is_final_package=is_final_package, text=chunk_text,
-                            expression=expression,
-                        )
-                        await job.send_reply_callback(chunk_resp)
+                        if is_final_package:
+                            await send_terminal(
+                                audio=chunk_base64,
+                                text=chunk_text,
+                                expression=expression,
+                            )
+                        else:
+                            chunk_resp = ChatResponse(
+                                uuid=job.job_content.uuid, audio=chunk_base64,
+                                is_final_package=False, text=chunk_text,
+                                expression=expression,
+                            )
+                            await job.send_reply_callback(chunk_resp)
                 else:
                     self.logger.warning(f"Unsupported speaking job type: {type(job.job_content)}")
                     continue
@@ -223,12 +331,35 @@ class GlobalSpeakingWorker:
         )
 
     async def stop(self):
-        if self.worker_task:
-            self.worker_task.cancel()
+        self._stopping = True
+        signal_error: Exception | None = None
+        speech = getattr(self.capabilities, "speech", None)
+        request_stop = getattr(speech, "request_stop", None)
+        if request_stop is not None:
             try:
-                await self.worker_task
+                request_stop()
+            except Exception as error:
+                signal_error = error
+
+        task = self.worker_task
+        if task is not None:
+            cancel_task_once(task)
+            done, pending = await wait_for_owned_tasks(
+                (task,),
+                timeout_seconds=self.shutdown_timeout_seconds,
+            )
+            if pending:
+                raise RuntimeError("Global speaking worker is still stopping")
+            try:
+                task.result()
             except asyncio.CancelledError:
                 self.logger.info("Global speaking worker stopped")
+            finally:
+                if self.worker_task is task:
+                    self.worker_task = None
+
+        if signal_error is not None:
+            raise RuntimeError(f"Failed to signal TTS shutdown: {signal_error}") from signal_error
 
 
 _global_speaking_worker: GlobalSpeakingWorker | None = None

--- a/server/src/chat_session/dependency/proactive_topic_maker.py
+++ b/server/src/chat_session/dependency/proactive_topic_maker.py
@@ -123,97 +123,72 @@ class ProactiveTopicMaker:
 
         if action.activity_type == ActivityType.REGULAR_LOGIN:
             # 当天第一次登录（非首次安装/首次登录，也不是长时未登录）触发
-            topics_to_add: List[ExtractedTopic] = []
+            topics_to_add: List[tuple[ExtractedTopic, str, str]] = []
+            character_id = getattr(chat_stream, "character_id", "luotianyi")
 
             # 1-4) 统一通过 schedule 模块检索：节日 / citywalk / new_song / 用户重要日期
             #      如果已在 schedule 中提醒过，则 login 时不再重复提示
             try:
                 store = self._get_event_store()
-                character_id = getattr(chat_stream, "character_id", "luotianyi")
                 due = store.get_events_due_for_trigger(character=character_id)
-                for event_dict, trigger_key in due:
+                for event_dict, trigger_key in self._filter_events_for_stream(
+                    due,
+                    user_uuid,
+                    character_id,
+                ):
                     event_id = event_dict.get("id")
-                    if event_id and store.is_notified(event_id, user_uuid, trigger_key, character_id):
+                    if not event_id:
+                        continue
+                    if store.is_notified(event_id, user_uuid, trigger_key, character_id):
                         continue
 
-                    evt_type = event_dict.get("event_type", "")
-
-                    if evt_type == "holiday":
-                        holiday_name = event_dict.get("title", "节日")
-                        topics_to_add.append(
-                            ExtractedTopic(
-                                topic_id=str(uuid4()),
-                                source_messages=[],
-                                topic_content=f"今天是{holiday_name}，闲聊几句并询问用户今天是否有安排。",
-                                memory_attempts=[],
-                                fact_constraints=[],
-                                sing_attempts=[],
-                                is_forced_from_incomplete=True,
-                            )
+                    try:
+                        topic = self._build_login_reminder_topic(event_dict)
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Failed to build login reminder for event {event_id}: {e}"
                         )
-
-                    elif evt_type == "travel":
-                        dest_name = event_dict.get("title", "某个地方")
-                        topic_content = f"洛天依昨天独自前往{dest_name}游玩了，和用户分享一下。"
-                        topics_to_add.append(
-                            ExtractedTopic(
-                                topic_id=str(uuid4()),
-                                source_messages=[],
-                                topic_content=topic_content,
-                                memory_attempts=["/YesterdayCityWalk"],
-                                fact_constraints=[],
-                                sing_attempts=[],
-                                is_forced_from_incomplete=True,
-                            )
-                        )
-
-                    elif evt_type == "new_song":
-                        song_title = event_dict.get("title", "洛天依学了一首新歌")
-                        topic_content = f"{song_title}！"
-                        topics_to_add.append(
-                            ExtractedTopic(
-                                topic_id=str(uuid4()),
-                                source_messages=[],
-                                topic_content=topic_content,
-                                memory_attempts=[],
-                                fact_constraints=[],
-                                sing_attempts=[],
-                                is_forced_from_incomplete=True,
-                            )
-                        )
-
-                    elif evt_type in ("birthday", "anniversary"):
-                        # 个人事件：仅当 target_user_id 匹配当前用户时才派发
-                        is_personal = event_dict.get("is_personal", False)
-                        target = event_dict.get("target_user_id", "")
-                        if is_personal and target and target != user_uuid:
-                            continue  # 不是当前用户的，跳过
-                        name = event_dict.get("title", "重要日子")
-                        topic_content = f"今天是{name}！问用户有没有什么安排或计划，并送上祝福。"
-                        topics_to_add.append(
-                            ExtractedTopic(
-                                topic_id=str(uuid4()),
-                                source_messages=[],
-                                topic_content=topic_content,
-                                memory_attempts=[],
-                                fact_constraints=[],
-                                sing_attempts=[],
-                                is_forced_from_incomplete=True,
-                            )
-                        )
-
-                    # Mark notified so the periodic reminder loop does not repeat it.
-                    if event_id:
-                        store.mark_notified(event_id, user_uuid, trigger_key, character_id)
+                        continue
+                    if topic is not None:
+                        topics_to_add.append((topic, event_id, trigger_key))
             except Exception as e:
-                import traceback
-                traceback.print_exc()
                 self.logger.warning(f"Failed to query schedule events for login: {e}")
 
-            # 合并所有话题为单一 ExtractedTopic
-            merged = self._merge_topics(topics_to_add)
+            claimed_topics: List[tuple[ExtractedTopic, str, str]] = []
+            for topic, event_id, trigger_key in topics_to_add:
+                try:
+                    claimed = store.try_claim_notification(
+                        event_id,
+                        user_uuid,
+                        trigger_key,
+                        character_id,
+                    )
+                except Exception as e:
+                    self.logger.warning(f"Failed to claim login reminder {event_id}: {e}")
+                    continue
+                if claimed:
+                    claimed_topics.append((topic, event_id, trigger_key))
+
+            # 合并本次成功 claim 的话题，避免登录与周期任务并发重复派发。
+            merged = self._merge_topics([topic for topic, _, _ in claimed_topics])
             if merged:
-                await chat_stream.topic_replier.add_topic(merged)
+                try:
+                    await chat_stream.topic_replier.add_topic(merged)
+                except BaseException:
+                    self._release_notification_claims(
+                        store,
+                        claimed_topics,
+                        user_uuid,
+                        character_id,
+                    )
+                    raise
+            elif claimed_topics:
+                self._release_notification_claims(
+                    store,
+                    claimed_topics,
+                    user_uuid,
+                    character_id,
+                )
             return
 
         self.logger.warning(f"Unsupported action type: {action.activity_type}")
@@ -235,7 +210,11 @@ class ProactiveTopicMaker:
                 continue
 
             candidates = []
-            for event_dict, trigger_key in self._filter_events_for_stream(due_events, user_id):
+            for event_dict, trigger_key in self._filter_events_for_stream(
+                due_events,
+                user_id,
+                character_id,
+            ):
                 event_id = event_dict.get("id")
                 if not event_id:
                     continue
@@ -247,26 +226,110 @@ class ProactiveTopicMaker:
 
             event_dict, trigger_key = random.choice(candidates)
             event_id = event_dict.get("id")
-            topic = self._build_reminder_topic(event_dict, trigger_key)
-            await chat_stream.topic_replier.add_topic(topic)
-            store.mark_notified(event_id, user_id, trigger_key, character_id)
+            claimed = False
+            try:
+                topic = self._build_reminder_topic(event_dict, trigger_key)
+                claimed = store.try_claim_notification(
+                    event_id,
+                    user_id,
+                    trigger_key,
+                    character_id,
+                )
+                if not claimed:
+                    continue
+                await chat_stream.topic_replier.add_topic(topic)
+            except asyncio.CancelledError:
+                if claimed:
+                    self._release_notification_claims(
+                        store,
+                        [(None, event_id, trigger_key)],
+                        user_id,
+                        character_id,
+                    )
+                raise
+            except Exception as e:
+                if claimed:
+                    self._release_notification_claims(
+                        store,
+                        [(None, event_id, trigger_key)],
+                        user_id,
+                        character_id,
+                    )
+                self.logger.warning(f"Failed to dispatch proactive reminder {event_id}: {e}")
+                continue
             sent += 1
 
         if sent:
             self.logger.info(f"Dispatched {sent} proactive reminder topic(s)")
         return sent
 
+    def _release_notification_claims(
+        self,
+        store,
+        claimed_topics,
+        user_id: str,
+        character_id: str,
+    ) -> None:
+        for _, event_id, trigger_key in claimed_topics:
+            try:
+                store.release_notification_claim(
+                    event_id,
+                    user_id,
+                    trigger_key,
+                    character_id,
+                )
+            except Exception as e:
+                self.logger.error(f"Failed to release notification claim {event_id}: {e}")
+
     def _filter_events_for_stream(
         self,
         due_events: Iterable[tuple[Dict[str, Any], str]],
         user_id: str,
+        character_id: str,
     ) -> Iterable[tuple[Dict[str, Any], str]]:
+        character_id = character_id or "luotianyi"
         for event_dict, trigger_key in due_events:
+            event_character = event_dict.get("character")
+            if event_character and event_character != character_id:
+                continue
             is_personal = event_dict.get("is_personal", False)
             target_user_id = event_dict.get("target_user_id")
-            if is_personal and target_user_id and target_user_id != user_id:
+            if is_personal and target_user_id != user_id:
                 continue
             yield event_dict, trigger_key
+
+    def _build_login_reminder_topic(
+        self,
+        event_dict: Dict[str, Any],
+    ) -> Optional[ExtractedTopic]:
+        evt_type = event_dict.get("event_type", "")
+        memory_attempts: List[str] = []
+
+        if evt_type == "holiday":
+            holiday_name = event_dict.get("title", "节日")
+            topic_content = f"今天是{holiday_name}，闲聊几句并询问用户今天是否有安排。"
+        elif evt_type == "travel":
+            dest_name = event_dict.get("title", "某个地方")
+            topic_content = f"洛天依昨天独自前往{dest_name}游玩了，和用户分享一下。"
+            memory_attempts = ["/YesterdayCityWalk"]
+        elif evt_type == "new_song":
+            song_title = event_dict.get("title", "洛天依学了一首新歌")
+            topic_content = f"{song_title}！"
+        elif evt_type in ("birthday", "anniversary"):
+            name = event_dict.get("title", "重要日子")
+            topic_content = f"今天是{name}！问用户有没有什么安排或计划，并送上祝福。"
+        else:
+            return None
+
+        return ExtractedTopic(
+            topic_id=str(uuid4()),
+            source_messages=[],
+            topic_content=topic_content,
+            memory_attempts=memory_attempts,
+            fact_constraints=[],
+            sing_attempts=[],
+            is_forced_from_incomplete=True,
+        )
 
     def _build_reminder_topic(self, event_dict: Dict[str, Any], trigger_key: str) -> ExtractedTopic:
         event_type = event_dict.get("event_type", "event")

--- a/server/src/legacy/chat_input_adapter.py
+++ b/server/src/legacy/chat_input_adapter.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import binascii
+import re
 from typing import Any
 
 from src.domain.stimulus import PersistPolicy, SourceChannel, Stimulus, StimulusModality
@@ -21,9 +24,142 @@ CHAT_RELATED_EVENT_TYPES = {
     "chat",
 }
 
+MAX_TEXT_LENGTH = 20_000
+MAX_IMAGE_BASE64_CHARS = 8 * 1024 * 1024
+MAX_IMAGE_BYTES = 6 * 1024 * 1024
+MAX_TYPING_TEXT_LENGTH = 100_000
+MAX_TARGET_CHARACTERS = 8
+ALLOWED_IMAGE_MIME_TYPES = {
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/gif",
+    "image/bmp",
+    "image/webp",
+}
+TARGET_CHARACTER_KEYS = (
+    "target_character_ids",
+    "target_characters",
+    "character_ids",
+    "target_character_id",
+    "character_id",
+)
+
 
 def is_chat_related_ws_message(event: WSMessage) -> bool:
     return event.event_type in CHAT_RELATED_EVENT_TYPES
+
+
+def validate_ws_chat_message(event: WSMessage) -> None:
+    """Validate the real client payload before idempotency marking or ACK."""
+    if not is_chat_related_ws_message(event):
+        raise ValueError("unsupported chat event type")
+    if not isinstance(event.payload, dict):
+        raise TypeError("chat event payload must be an object")
+
+    payload = event.payload
+    _validate_target_character_ids(payload)
+
+    if event.event_type == WSEventType.USER_IMAGE.value:
+        _validate_image_payload(payload)
+        return
+    if event.event_type == WSEventType.USER_TYPING.value:
+        text_length = payload.get("text_length")
+        if type(text_length) is not int or not 0 <= text_length <= MAX_TYPING_TEXT_LENGTH:
+            raise ValueError("text_length must be a non-negative integer")
+        return
+    if event.event_type == WSEventType.USER_TOUCH.value:
+        _validate_touch_payload(payload)
+        return
+    if event.event_type in {
+        WSEventType.USER_IMAGE_SELECTING.value,
+        WSEventType.USER_IMAGE_SELECTING_CANCEL.value,
+    }:
+        return
+
+    text = _extract_text(payload)
+    if not text or len(text) > MAX_TEXT_LENGTH:
+        raise ValueError("text message must be non-empty and within the size limit")
+    if "is_proactive" in payload and type(payload["is_proactive"]) is not bool:
+        raise ValueError("is_proactive must be a boolean")
+
+
+def _validate_image_payload(payload: dict[str, Any]) -> None:
+    image_base64 = payload.get("image_base64")
+    mime_type = payload.get("mime_type")
+    if not isinstance(image_base64, str) or not image_base64.strip():
+        raise ValueError("image_base64 is required")
+    if len(image_base64) > MAX_IMAGE_BASE64_CHARS:
+        raise ValueError("image payload exceeds the size limit")
+    if not isinstance(mime_type, str) or mime_type.lower() not in ALLOWED_IMAGE_MIME_TYPES:
+        raise ValueError("mime_type is not supported")
+    if "image_client_path" in payload:
+        path = payload["image_client_path"]
+        if path is not None and (not isinstance(path, str) or len(path) > 4096):
+            raise ValueError("image_client_path must be a string")
+
+    encoded = image_base64.strip()
+    if encoded.startswith("data:"):
+        match = re.fullmatch(r"data:([^;,]+);base64,(.*)", encoded, flags=re.DOTALL)
+        if match is None or match.group(1).lower() != mime_type.lower():
+            raise ValueError("image data URI does not match mime_type")
+        encoded = match.group(2)
+    encoded = "".join(encoded.split())
+    if not encoded:
+        raise ValueError("image_base64 is empty")
+    encoded += "=" * (-len(encoded) % 4)
+    try:
+        decoded = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("image_base64 is invalid") from exc
+    if not decoded or len(decoded) > MAX_IMAGE_BYTES:
+        raise ValueError("decoded image exceeds the size limit")
+
+
+def _validate_touch_payload(payload: dict[str, Any]) -> None:
+    touch_areas = payload.get("touchArea")
+    if touch_areas is None:
+        touch_areas = payload.get("touch_area")
+    if isinstance(touch_areas, str):
+        areas = [touch_areas]
+    elif isinstance(touch_areas, list):
+        areas = touch_areas
+    else:
+        raise ValueError("touch_area or touchArea is required")
+    if not 1 <= len(areas) <= 16:
+        raise ValueError("touch area count is invalid")
+    if any(not isinstance(area, str) or not area.strip() or len(area) > 128 for area in areas):
+        raise ValueError("touch areas must be non-empty strings")
+
+    click_frequency = payload.get("click_frequency")
+    if click_frequency is not None:
+        if not isinstance(click_frequency, dict):
+            raise ValueError("click_frequency must be an object")
+        for value in click_frequency.values():
+            if type(value) is not int or value < 0:
+                raise ValueError("click_frequency values must be non-negative integers")
+
+
+def _validate_target_character_ids(payload: dict[str, Any]) -> None:
+    raw_targets = next(
+        (payload[key] for key in TARGET_CHARACTER_KEYS if key in payload),
+        None,
+    )
+    if raw_targets is None:
+        return
+    if isinstance(raw_targets, str):
+        targets = [raw_targets]
+    elif isinstance(raw_targets, (list, tuple)):
+        targets = list(raw_targets)
+    else:
+        raise ValueError("target character ids must be a string or list")
+    if not 1 <= len(targets) <= MAX_TARGET_CHARACTERS:
+        raise ValueError("target character count is invalid")
+    if any(
+        not isinstance(target, str) or not target.strip() or len(target) > 64
+        for target in targets
+    ):
+        raise ValueError("target character ids must be non-empty strings")
 
 
 def ws_message_to_stimulus(
@@ -134,7 +270,7 @@ def stimulus_to_chat_input_event(stimulus: Stimulus) -> ChatInputEvent | None:
         return None
 
     payload = dict(stimulus.payload or {})
-    payload.setdefault("target_character_ids", list(stimulus.target_character_ids))
+    payload["target_character_ids"] = list(stimulus.target_character_ids)
     payload.setdefault("ephemeral", stimulus.ephemeral)
     payload.setdefault("persist_policy", stimulus.persist_policy.value)
 

--- a/server/src/subconscious/date_processor.py
+++ b/server/src/subconscious/date_processor.py
@@ -152,7 +152,7 @@ async def process_detected_date(
             topic_text += f"描述：{description}\n"
         topic_text += "\n如果正确你就会把它记住。"
 
-        reply_topic_callback(_make_topic(topic_text))
+        await reply_topic_callback(_make_topic(topic_text))
         return None
 
     logger.info(f"Date {name}: confidence {confidence:.2f} in middle range but no callback, discarded")

--- a/server/src/subconscious/memory/memory_write.py
+++ b/server/src/subconscious/memory/memory_write.py
@@ -11,7 +11,7 @@ from src.utils.logger import get_logger
 from src.system.database.vector_store import VectorStore, Document
 from src.utils.llm.llm_module import LLMModule
 import time
-import asyncio
+from src.utils.asyncio_helpers import run_sync_owned
 from src.domain.memory_record import MemoryRecord as DomainMemoryRecord
 from src.domain.memory_record import MemoryType, MemoryVisibility
 
@@ -242,10 +242,10 @@ class MemoryWriter:
                 "user_id": user_id,
             },
         )
-        ids = await asyncio.to_thread(vector_store.add_documents, [doc])
+        ids = await run_sync_owned(vector_store.add_documents, [doc])
         update_cmd = MemoryUpdateCommand(type="write_user_memory", content=text, uuid=ids[0] if ids else None)
-        await asyncio.to_thread(memory_store.write_memory_update, user_id, update_cmd, commit=commit)
-        await asyncio.to_thread(
+        await run_sync_owned(memory_store.write_memory_update, user_id, update_cmd, commit=commit)
+        await run_sync_owned(
             memory_store.write_agent_memory_record,
             DomainMemoryRecord(
                 owner_character_id=owner_character_id,
@@ -293,10 +293,10 @@ class MemoryWriter:
                 "user_id": user_id,
             },
         )
-        ids = await asyncio.to_thread(vector_store.add_documents, [doc])
+        ids = await run_sync_owned(vector_store.add_documents, [doc])
         update_cmd = MemoryUpdateCommand(type="write_event_memory", content=text, uuid=ids[0] if ids else None)
-        await asyncio.to_thread(memory_store.write_memory_update, user_id, update_cmd, commit=commit)
-        await asyncio.to_thread(
+        await run_sync_owned(memory_store.write_memory_update, user_id, update_cmd, commit=commit)
+        await run_sync_owned(
             memory_store.write_agent_memory_record,
             DomainMemoryRecord(
                 owner_character_id=owner_character_id,

--- a/server/src/system/admin/admin_interface.py
+++ b/server/src/system/admin/admin_interface.py
@@ -11,6 +11,7 @@ from fastapi.responses import FileResponse
 from .admin_shell import get_admin_shell
 from .llm_config_editor import apply_llm_config_draft, build_llm_config_view
 from .system_dynamic_publisher import publish_system_dynamic
+from src.system.user_interface.rate_limits import enforce_rate_limit
 from src.utils.helpers import apply_env_variables
 
 if TYPE_CHECKING:
@@ -115,7 +116,7 @@ async def admin_health() -> dict[str, Any]:
     return {
         "status": "ok",
         "admin_auth": shell.auth.status(),
-        "runtime": shell.runtime_supervisor.status(),
+        "runtime": shell.runtime_supervisor.public_status(),
         "observability": shell.observability is not None,
     }
 
@@ -135,10 +136,13 @@ async def admin_auth_setup(payload: dict[str, Any] = Body(default_factory=dict))
 
 @router.post("/admin-auth/login")
 async def admin_auth_login(
+    request: Request,
     response: Response,
     payload: dict[str, Any] = Body(default_factory=dict),
 ) -> dict[str, Any]:
-    return get_admin_shell().auth.login(str(payload.get("password") or ""), response)
+    password = str(payload.get("password") or "")
+    enforce_rate_limit(request, "admin_login", "admin")
+    return await get_admin_shell().auth.login_async(password, response)
 
 
 @protected_router.post("/admin-auth/logout")
@@ -206,8 +210,20 @@ async def secrets_status() -> dict[str, Any]:
 
 @protected_router.put("/secrets")
 async def update_secrets(payload: dict[str, Any] = Body(default_factory=dict)) -> dict[str, Any]:
-    get_admin_shell().secret_store.update(payload)
-    return {"ok": True, "secrets": await secrets_status()}
+    shell = get_admin_shell()
+    before = shell.secret_store.read()
+    after = shell.secret_store.update(payload)
+    changed_keys = sorted(
+        key
+        for key in before.keys() | after.keys()
+        if before.get(key) != after.get(key)
+    )
+    return {
+        "ok": True,
+        "secrets": await secrets_status(),
+        "restart_required": bool(changed_keys and shell.runtime_supervisor.is_running()),
+        "changed_keys": changed_keys,
+    }
 
 
 @protected_router.get("/qq-music/credential/status")

--- a/server/src/system/admin/admin_shell.py
+++ b/server/src/system/admin/admin_shell.py
@@ -63,7 +63,10 @@ class AdminShell:
         )
 
     async def shutdown(self) -> None:
-        await self.runtime_supervisor.stop()
+        status = await self.runtime_supervisor.stop()
+        if status.get("state") != "stopped" or self.runtime_supervisor.has_runtime:
+            error = status.get("last_error") or "runtime cleanup is incomplete"
+            raise RuntimeError(f"Cannot close AdminShell while SystemRuntime is still active: {error}")
         self.observability.close()
         set_observability_service(None)
         uninstall_observability_log_handler()

--- a/server/src/system/admin/auth.py
+++ b/server/src/system/admin/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -23,6 +24,8 @@ class AdminAuthService:
         self.setup_token_file = Path(setup_token_file)
         self.sessions: dict[str, float] = {}
         self.session_ttl_seconds = 12 * 3600
+        self._password_work_slots = asyncio.Semaphore(4)
+        self._password_work_admission_timeout = 1.0
         if not self.is_configured():
             self._ensure_setup_token()
 
@@ -52,6 +55,27 @@ class AdminAuthService:
             raise HTTPException(status_code=403, detail={"code": "ADMIN_SETUP_REQUIRED", "message": "Admin password has not been configured"})
         if not self._verify_password(password):
             raise HTTPException(status_code=401, detail={"code": "BAD_ADMIN_PASSWORD", "message": "Invalid admin password"})
+        return self._create_session(response)
+
+    async def login_async(self, password: str, response: Response) -> dict[str, Any]:
+        if not self.is_configured():
+            raise HTTPException(status_code=403, detail={"code": "ADMIN_SETUP_REQUIRED", "message": "Admin password has not been configured"})
+        try:
+            await asyncio.wait_for(
+                self._password_work_slots.acquire(),
+                timeout=self._password_work_admission_timeout,
+            )
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(status_code=503, detail={"code": "ADMIN_AUTH_BUSY", "message": "Admin authentication is busy"}) from exc
+        try:
+            password_valid = await asyncio.to_thread(self._verify_password, password)
+        finally:
+            self._password_work_slots.release()
+        if not password_valid:
+            raise HTTPException(status_code=401, detail={"code": "BAD_ADMIN_PASSWORD", "message": "Invalid admin password"})
+        return self._create_session(response)
+
+    def _create_session(self, response: Response) -> dict[str, Any]:
         token = secrets.token_urlsafe(32)
         expires_at = time.time() + self.session_ttl_seconds
         self.sessions[token] = expires_at

--- a/server/src/system/admin/config_validator.py
+++ b/server/src/system/admin/config_validator.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from src.system.admin.secret_store import SecretStore
+from src.system.token_config import (
+    DEFAULT_MESSAGE_TOKEN_TTL_SECONDS,
+    MAX_MESSAGE_TOKEN_TTL_SECONDS,
+    MIN_MESSAGE_TOKEN_TTL_SECONDS,
+)
 
 
 @dataclass
@@ -69,6 +74,7 @@ class RuntimeConfigValidator:
     def validate(self, config: dict[str, Any]) -> dict[str, Any]:
         items: list[ValidationItem] = []
         items.extend(self._validate_secrets())
+        items.extend(self._validate_security_config(config))
         items.extend(self._validate_llm_interfaces(config))
         items.extend(self._validate_core_modules(config))
         items.extend(self._validate_core_resources(config))
@@ -114,6 +120,50 @@ class RuntimeConfigValidator:
                 )
             )
         return result
+
+    def _validate_security_config(self, config: dict[str, Any]) -> list[ValidationItem]:
+        name = "config.database.message_token_ttl_seconds"
+        database_config = config.get("database")
+        if (
+            not isinstance(database_config, dict)
+            or "message_token_ttl_seconds" not in database_config
+        ):
+            return [
+                ValidationItem(
+                    "core",
+                    name,
+                    "warning",
+                    (
+                        "未配置 message_token_ttl_seconds，使用安全默认值 "
+                        f"{DEFAULT_MESSAGE_TOKEN_TTL_SECONDS} 秒"
+                    ),
+                    severity="warning",
+                )
+            ]
+        value = database_config["message_token_ttl_seconds"]
+        if type(value) is not int:
+            return [
+                ValidationItem(
+                    "core",
+                    name,
+                    "error",
+                    "message_token_ttl_seconds 必须是整数秒数",
+                )
+            ]
+        if not MIN_MESSAGE_TOKEN_TTL_SECONDS <= value <= MAX_MESSAGE_TOKEN_TTL_SECONDS:
+            return [
+                ValidationItem(
+                    "core",
+                    name,
+                    "error",
+                    (
+                        "message_token_ttl_seconds 必须在 "
+                        f"{MIN_MESSAGE_TOKEN_TTL_SECONDS} 至 "
+                        f"{MAX_MESSAGE_TOKEN_TTL_SECONDS} 秒之间"
+                    ),
+                )
+            ]
+        return [ValidationItem("core", name, "ok", f"消息令牌有效期为 {value} 秒")]
 
     def _validate_llm_interfaces(self, config: dict[str, Any]) -> list[ValidationItem]:
         result: list[ValidationItem] = []

--- a/server/src/system/admin/runtime_supervisor.py
+++ b/server/src/system/admin/runtime_supervisor.py
@@ -9,7 +9,8 @@ from typing import Any, Coroutine
 from src.system.admin.config_store import ConfigStore
 from src.system.admin.config_validator import RuntimeConfigValidator
 from src.system.admin.secret_store import SecretStore
-from src.system.observability import ObservabilityService
+from src.system.observability import ObservabilityService, new_trace_id
+from src.utils.logger import get_logger
 
 
 class RuntimeSupervisor:
@@ -27,10 +28,13 @@ class RuntimeSupervisor:
         self.secret_store = secret_store
         self.validator = validator
         self.observability = observability
+        self.logger = get_logger(self.__class__.__name__)
         self._runtime: Any | None = None
         self._lock = asyncio.Lock()
         self.state = "stopped"
         self.last_error: str | None = None
+        self.last_error_code: str | None = None
+        self.last_error_trace_id: str | None = None
         self.last_started_at: str | None = None
         self.last_stopped_at: str | None = None
         self.last_validation: dict[str, Any] | None = None
@@ -38,10 +42,17 @@ class RuntimeSupervisor:
 
     @property
     def runtime(self) -> Any | None:
+        if self.state != "running":
+            return None
         return self._runtime
 
     def is_running(self) -> bool:
         return self._runtime is not None and self.state == "running"
+
+    @property
+    def has_runtime(self) -> bool:
+        """Whether a runtime handle still exists, including failed cleanup."""
+        return self._runtime is not None
 
     def _has_active_transition(self) -> bool:
         return self._transition_task is not None and not self._transition_task.done()
@@ -62,16 +73,55 @@ class RuntimeSupervisor:
             "running": self.is_running(),
             "busy": self.state in {"starting", "stopping"} or self._has_active_transition(),
             "last_error": self.last_error,
+            "last_error_code": self.last_error_code,
+            "last_error_trace_id": self.last_error_trace_id,
             "last_started_at": self.last_started_at,
             "last_stopped_at": self.last_stopped_at,
             "validation": self.last_validation,
         }
 
+    def public_status(self) -> dict[str, Any]:
+        error = None
+        if self.last_error_code:
+            error = {
+                "code": self.last_error_code,
+                "trace_id": self.last_error_trace_id,
+            }
+        return {
+            "state": self.state,
+            "running": self.is_running(),
+            "busy": self.state in {"starting", "stopping"} or self._has_active_transition(),
+            "error": error,
+            "last_started_at": self.last_started_at,
+            "last_stopped_at": self.last_stopped_at,
+        }
+
+    def _clear_error(self) -> None:
+        self.last_error = None
+        self.last_error_code = None
+        self.last_error_trace_id = None
+
+    def _record_error(
+        self,
+        code: str,
+        detail: str,
+        *,
+        log_exception: bool = False,
+    ) -> None:
+        trace_id = new_trace_id("runtime")
+        self.last_error = detail
+        self.last_error_code = code
+        self.last_error_trace_id = trace_id
+        if log_exception:
+            self.logger.exception(f"{code} trace_id={trace_id}")
+        else:
+            self.logger.error(f"{code} trace_id={trace_id}: {detail}")
+
     def request_start(self) -> dict[str, Any]:
-        if self.is_running() or self._has_active_transition():
+        if self._runtime is not None or self._has_active_transition():
             return self.status()
         self.state = "starting"
-        self.last_error = None
+        self._clear_error()
         return self._schedule_transition(self.start())
 
     def request_stop(self) -> dict[str, Any]:
@@ -87,7 +137,7 @@ class RuntimeSupervisor:
         if self._has_active_transition():
             return self.status()
         self.state = "stopping" if self._runtime is not None else "starting"
-        self.last_error = None
+        self._clear_error()
         return self._schedule_transition(self.restart())
 
     def validate_current_config(self) -> dict[str, Any]:
@@ -123,8 +173,16 @@ class RuntimeSupervisor:
         async with self._lock:
             if self.is_running():
                 return self.status()
+            if self._runtime is not None:
+                self.state = "failed"
+                if not self.last_error:
+                    self._record_error(
+                        "RUNTIME_CLEANUP_INCOMPLETE",
+                        "Previous runtime cleanup is incomplete",
+                    )
+                return self.status()
             self.state = "starting"
-            self.last_error = None
+            self._clear_error()
             try:
                 self.secret_store.load_into_environment()
                 try:
@@ -132,13 +190,19 @@ class RuntimeSupervisor:
                 except (json.JSONDecodeError, OSError) as exc:
                     self.last_validation = self._config_read_error_validation(exc)
                     self.state = "blocked"
-                    self.last_error = self.last_validation["items"][0]["message"]
+                    self._record_error(
+                        "CONFIG_READ_FAILED",
+                        self.last_validation["items"][0]["message"],
+                    )
                     return self.status()
                 validation = self.validator.validate(config)
                 self.last_validation = validation
                 if not validation.get("core_ok"):
                     self.state = "blocked"
-                    self.last_error = "Runtime config validation failed"
+                    self._record_error(
+                        "CONFIG_VALIDATION_FAILED",
+                        "Runtime config validation failed",
+                    )
                     return self.status()
                 config = self.validator.apply_world_disablements(config, validation)
 
@@ -152,7 +216,11 @@ class RuntimeSupervisor:
                 return self.status()
             except Exception as exc:
                 self.state = "failed"
-                self.last_error = f"{exc}\n{traceback.format_exc()}"
+                self._record_error(
+                    "RUNTIME_START_FAILED",
+                    f"{exc}\n{traceback.format_exc()}",
+                    log_exception=True,
+                )
                 return self.status()
 
     async def stop(self) -> dict[str, Any]:
@@ -162,20 +230,27 @@ class RuntimeSupervisor:
                 return self.status()
             self.state = "stopping"
             runtime = self._runtime
-            self._runtime = None
+            self._clear_error()
             try:
                 from src.system.system_runtime import set_system_runtime
 
                 set_system_runtime(None)
                 await runtime.shutdown()
+                self._runtime = None
                 self.state = "stopped"
                 self.last_stopped_at = datetime.now().isoformat(timespec="seconds")
                 return self.status()
             except Exception as exc:
                 self.state = "failed"
-                self.last_error = f"{exc}\n{traceback.format_exc()}"
+                self._record_error(
+                    "RUNTIME_STOP_FAILED",
+                    f"{exc}\n{traceback.format_exc()}",
+                    log_exception=True,
+                )
                 return self.status()
 
     async def restart(self) -> dict[str, Any]:
-        await self.stop()
+        stop_status = await self.stop()
+        if stop_status.get("state") != "stopped" or self._runtime is not None:
+            return stop_status
         return await self.start()

--- a/server/src/system/admin/secret_store.py
+++ b/server/src/system/admin/secret_store.py
@@ -6,11 +6,16 @@ from pathlib import Path
 from typing import Any
 
 
+_MISSING_ENVIRONMENT_VALUE = object()
+
+
 class SecretStore:
     """Local .env-backed secret store for runtime configuration."""
 
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
+        self._managed_keys: set[str] = set()
+        self._original_environment: dict[str, str | object] = {}
 
     def read(self) -> dict[str, str]:
         if not self.path.exists():
@@ -35,6 +40,7 @@ class SecretStore:
 
     def update(self, updates: dict[str, Any]) -> dict[str, str]:
         secrets = self.read()
+        self._capture_original_environment(secrets)
         for key, value in updates.items():
             key = str(key).strip()
             if not key:
@@ -49,9 +55,33 @@ class SecretStore:
 
     def load_into_environment(self) -> dict[str, str]:
         secrets = self.read()
+        self._capture_original_environment(secrets)
+
+        for key in self._managed_keys - secrets.keys():
+            original_value = self._original_environment.pop(
+                key,
+                _MISSING_ENVIRONMENT_VALUE,
+            )
+            if original_value is _MISSING_ENVIRONMENT_VALUE:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = str(original_value)
+
+        self._managed_keys.intersection_update(secrets)
         for key, value in secrets.items():
             os.environ[key] = value
+            self._managed_keys.add(key)
         return secrets
+
+    def _capture_original_environment(self, secrets: dict[str, str]) -> None:
+        for key in secrets:
+            if key in self._managed_keys:
+                continue
+            self._original_environment[key] = os.environ.get(
+                key,
+                _MISSING_ENVIRONMENT_VALUE,
+            )
+            self._managed_keys.add(key)
 
     def status(self, keys: list[str] | None = None) -> dict[str, dict[str, Any]]:
         secrets = self.read()

--- a/server/src/system/database/database_service.py
+++ b/server/src/system/database/database_service.py
@@ -1,10 +1,12 @@
 import os
 import hmac
+import hashlib
 import bcrypt
 from jose import jwt
 import json
 from typing import Dict, Any, Optional, List, Tuple, TYPE_CHECKING
 from datetime import datetime
+import time
 import uuid
 from sqlalchemy import and_, func, or_
 from src.utils.logger import get_logger
@@ -26,6 +28,10 @@ from src.system.database.event_store import EventStore
 from src.system.database.memory_store import MemoryStore
 from src.system.database.dynamic_store import DynamicStore
 from src.system.database.user_store import UserStore
+from src.system.token_config import (
+    DEFAULT_MESSAGE_TOKEN_TTL_SECONDS,
+    normalize_message_token_ttl_seconds,
+)
 
 from src.domain.chat import ContextInfo
 
@@ -75,6 +81,12 @@ class DatabaseManager:
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         self.config = config or {}
         self.jwt_secret = os.environ.get(JWT_SECRET_ENV)
+        self.message_token_ttl_seconds = normalize_message_token_ttl_seconds(
+            self.config.get(
+                "message_token_ttl_seconds",
+                DEFAULT_MESSAGE_TOKEN_TTL_SECONDS,
+            )
+        )
         self._redis: Optional[RedisBuffer] = None
         self.event_store: Optional[EventStore] = None
         self.memory_store: Optional[MemoryStore] = None
@@ -140,6 +152,27 @@ class DatabaseManager:
             # 自动从 get_redis_buffer 获取已初始化的实例
             self._redis = get_redis_buffer()
         return self._redis
+
+    def _cache_user_uuid(self, username: str, user_uuid: str) -> None:
+        try:
+            self._ensure_redis().setex(f"user_id:{username}", 3600, user_uuid)
+        except Exception as exc:
+            logger.warning(
+                "Failed to refresh username cache for %s (%s)",
+                username,
+                type(exc).__name__,
+            )
+
+    def _invalidate_username_caches(self, *usernames: str) -> None:
+        for username in set(filter(None, usernames)):
+            try:
+                self._ensure_redis().delete(f"user_id:{username}")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to invalidate username cache for %s (%s)",
+                    username,
+                    type(exc).__name__,
+                )
 
     def _new_session(self) -> "Session":
         """创建一个新的 SQL 会话。调用者负责关闭。"""
@@ -299,7 +332,12 @@ class DatabaseManager:
         db = self._new_session()
         try:
             user = db.query(User).filter_by(username=username).first()
-            return bool(user and user.auth_token == token)
+            return bool(
+                user
+                and user.auth_token
+                and token
+                and hmac.compare_digest(user.auth_token, token)
+            )
         finally:
             db.close()
 
@@ -320,43 +358,97 @@ class DatabaseManager:
         finally:
             db.close()
 
-    def generate_message_token(self, username: str) -> Optional[str]:
+    def _session_fingerprint(self, auth_token: str) -> Optional[str]:
+        if not self.jwt_secret or not auth_token:
+            return None
+        return hmac.new(
+            self.jwt_secret.encode("utf-8"),
+            auth_token.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def _encode_message_token(self, user_uuid: str, auth_token: str) -> Optional[str]:
+        if not self.jwt_secret:
+            logger.error("JWT_SECRET is not set. Cannot generate message token.")
+            return None
+        session_fp = self._session_fingerprint(auth_token)
+        if not session_fp:
+            return None
+        issued_at = int(time.time())
+        payload = {
+            "user_uuid": user_uuid,
+            "iat": issued_at,
+            "exp": issued_at + self.message_token_ttl_seconds,
+            "jti": str(uuid.uuid4()),
+            "session_fp": session_fp,
+        }
+        return jwt.encode(payload, self.jwt_secret, algorithm=ALGORITHM)
+
+    def generate_message_token(
+        self,
+        username: str,
+        expected_auth_token: Optional[str] = None,
+    ) -> Optional[str]:
         if not self.jwt_secret:
             logger.error("JWT_SECRET is not set. Cannot generate message token.")
             return None
         db = self._new_session()
         try:
             user = db.query(User).filter_by(username=username).first()
-            if not user:
+            if not user or not user.auth_token:
                 return None
-            message_token = jwt.encode({"user_uuid": user.uuid}, self.jwt_secret, algorithm=ALGORITHM)
-            redis = self._ensure_redis()
-            redis.setex(f"user_message_token:{user.uuid}", 3600, message_token)
-            return message_token
+            if expected_auth_token and not hmac.compare_digest(user.auth_token, expected_auth_token):
+                return None
+            return self._encode_message_token(user.uuid, user.auth_token)
         finally:
             db.close()
 
-    def decode_message_token(self, token: str) -> Optional[str]:
+    def _decode_message_token_claims(self, token: str) -> Optional[Dict[str, Any]]:
         if not self.jwt_secret:
             logger.error("JWT_SECRET is not set. Cannot decode message token.")
             return None
         try:
             payload = jwt.decode(token, self.jwt_secret, algorithms=[ALGORITHM])
-            return payload.get("user_uuid")
-        except jwt.JWTError:
+            required_claims = ("user_uuid", "iat", "exp", "jti", "session_fp")
+            if not isinstance(payload, dict) or any(not payload.get(name) for name in required_claims):
+                return None
+            issued_at = int(payload["iat"])
+            expires_at = int(payload["exp"])
+            now = int(time.time())
+            if expires_at <= now or issued_at > now + 60 or expires_at <= issued_at:
+                return None
+            return payload
+        except (jwt.JWTError, TypeError, ValueError):
             return None
+
+    def decode_message_token(self, token: str) -> Optional[str]:
+        payload = self._decode_message_token_claims(token)
+        return str(payload["user_uuid"]) if payload else None
 
     def check_message_token(self, username: str, token: str) -> Tuple[bool, Optional[str]]:
         '''
         检查消息 token 是否有效。
         '''
-        user_uuid = self.get_user_uuid_by_username(username)  # 确保缓存更新
-        if not user_uuid:
+        payload = self._decode_message_token_claims(token)
+        if not payload:
             return False, None
-        decoded_uuid = self.decode_message_token(token)
-        if decoded_uuid == user_uuid:
-            return True, user_uuid
-        return False, None
+        user_uuid = str(payload["user_uuid"])
+        db = self._new_session()
+        try:
+            user = (
+                db.query(User)
+                .filter(User.uuid == user_uuid, User.username == username)
+                .first()
+            )
+            if not user or not user.auth_token:
+                return False, None
+            expected_fp = self._session_fingerprint(user.auth_token)
+            actual_fp = str(payload["session_fp"])
+            if expected_fp and hmac.compare_digest(expected_fp, actual_fp):
+                return True, user_uuid
+            return False, None
+        finally:
+            db.close()
     
     # ────────────────────────────────────────────
     # 用户注册、登录、重置账户相关方法
@@ -369,12 +461,16 @@ class DatabaseManager:
         '''
         db = self._new_session()
         try:
-            code = db.query(InviteCode).filter_by(code=invite_code_str).first()
-            if not code:
+            available_code = (
+                db.query(InviteCode.code)
+                .filter(
+                    InviteCode.code == invite_code_str,
+                    InviteCode.is_used.is_(False),
+                )
+                .first()
+            )
+            if not available_code:
                 logger.info(f"Register failed: invalid invite code for username={username}")
-                return False, "注册失败，请检查邀请码或用户名"
-            if code.is_used:
-                logger.info(f"Register failed: invite code already used for username={username}")
                 return False, "注册失败，请检查邀请码或用户名"
 
             existing_user = db.query(User).filter_by(username=username).first()
@@ -382,18 +478,40 @@ class DatabaseManager:
                 logger.info(f"Register failed: username already exists: {username}")
                 return False, "注册失败，请检查邀请码或用户名"
 
-            new_user = User(username=username, password=_hash_password(password))
+            user_uuid = str(uuid.uuid4())
+            new_user = User(
+                uuid=user_uuid,
+                username=username,
+                password=_hash_password(password),
+            )
             db.add(new_user)
             db.flush()
 
-            code.is_used = True
-            code.used_at = datetime.now(tz=None)
-            code.user_id = new_user.uuid
+            claimed = (
+                db.query(InviteCode)
+                .filter(
+                    InviteCode.code == invite_code_str,
+                    InviteCode.is_used.is_(False),
+                )
+                .update(
+                    {
+                        InviteCode.is_used: True,
+                        InviteCode.used_at: datetime.now(tz=None),
+                        InviteCode.user_id: user_uuid,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            if claimed != 1:
+                db.rollback()
+                logger.info("Register failed: invite code unavailable for username=%s", username)
+                return False, "注册失败，请检查邀请码或用户名"
 
             db.commit()
+            self._cache_user_uuid(username, user_uuid)
             return True, "注册成功"
         except Exception as e:
-            logger.error(f"Error registering user {username}: {e}")
+            logger.error("Error registering user %s (%s)", username, type(e).__name__)
             db.rollback()
             return False, "注册失败，请检查邀请码或用户名"
         finally:
@@ -430,6 +548,7 @@ class DatabaseManager:
         使用邀请码重置账户（更改用户名和密码）。成功返回 (True, "重置成功")，失败返回 (False, "失败原因")。
         '''
         db = self._new_session()
+        old_username: Optional[str] = None
         try:
             code = db.query(InviteCode).filter_by(code=invite_code_str).first()
             if not code:
@@ -450,32 +569,109 @@ class DatabaseManager:
                 return False, "新用户名已被其他用户使用"
 
             old_username = user.username
+            user_uuid = user.uuid
+            self._invalidate_username_caches(old_username, new_username)
             user.username = new_username
             user.password = _hash_password(new_password)
             user.auth_token = None
             db.commit()
-            logger.info(
-                f"Account reset: invite_code={invite_code_str}, "
-                f"old_username={old_username}, new_username={new_username}"
-            )
+            self._invalidate_username_caches(old_username, new_username)
+            self._cache_user_uuid(new_username, user_uuid)
+            logger.info("Account reset: old_username=%s, new_username=%s", old_username, new_username)
             return True, "重置成功"
         except Exception as e:
-            logger.error(f"Error resetting account for invite_code={invite_code_str}: {e}")
             db.rollback()
+            if old_username:
+                self._invalidate_username_caches(old_username, new_username)
+            logger.error("Error resetting account for username=%s (%s)", new_username, type(e).__name__)
             return False, "重置失败"
         finally:
             db.close()
 
 
-    def authenticate_password_login(self, username: str, password: str) -> Optional[Dict[str, Any]]:
-        if not self.verify_user(username, password):
+    def _load_login_state(self, username: str) -> Optional[Dict[str, Any]]:
+        """Load authoritative login state without consulting the UUID cache."""
+        db = self._new_session()
+        try:
+            row = (
+                db.query(User.uuid, User.password, User.auth_token, User.last_login)
+                .filter(User.username == username)
+                .first()
+            )
+            if row is None:
+                return None
+            return {
+                "user_uuid": row.uuid,
+                "password": row.password,
+                "auth_token": row.auth_token,
+                "last_login": row.last_login,
+            }
+        finally:
+            db.close()
+
+    def _rotate_authenticated_session(
+        self,
+        *,
+        username: str,
+        state: Dict[str, Any],
+        expected_password: Optional[str] = None,
+        replacement_password: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Compare-and-swap the authenticated DB state and return its signed session."""
+        user_uuid = str(state["user_uuid"])
+        previous_auth_token = state.get("auth_token")
+        previous_last_login = state.get("last_login")
+        login_token = str(uuid.uuid4())
+        message_token = self._encode_message_token(user_uuid, login_token)
+        if message_token is None:
             return None
-        user_uuid = self.get_user_uuid_by_username(username)
-        if user_uuid is None:
+
+        now = datetime.now()
+        filters = [User.uuid == user_uuid, User.username == username]
+        if previous_auth_token is None:
+            filters.append(User.auth_token.is_(None))
+        else:
+            filters.append(User.auth_token == previous_auth_token)
+        if previous_last_login is None:
+            filters.append(User.last_login.is_(None))
+        else:
+            filters.append(User.last_login == previous_last_login)
+        if expected_password is not None:
+            filters.append(User.password == expected_password)
+
+        updates: Dict[Any, Any] = {
+            User.auth_token: login_token,
+            User.last_login: now,
+        }
+        if replacement_password is not None:
+            updates[User.password] = replacement_password
+
+        db = self._new_session()
+        try:
+            updated = (
+                db.query(User)
+                .filter(*filters)
+                .update(updates, synchronize_session=False)
+            )
+            if updated != 1:
+                db.rollback()
+                return None
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.error(
+                "Failed to rotate authenticated session for %s (%s)",
+                username,
+                type(exc).__name__,
+            )
             return None
-        login_token = self.update_auth_token(username)
-        message_token = self.generate_message_token(username)
-        elapsed = self.update_login_time(user_uuid)
+        finally:
+            db.close()
+
+        self._cache_user_uuid(username, user_uuid)
+        elapsed = None
+        if previous_last_login is not None:
+            elapsed = (now - previous_last_login).total_seconds()
         return {
             "user_uuid": user_uuid,
             "login_token": login_token,
@@ -483,21 +679,61 @@ class DatabaseManager:
             "elapsed_from_last_login": elapsed,
         }
 
+    def authenticate_password_login(self, username: str, password: str) -> Optional[Dict[str, Any]]:
+        if not self.jwt_secret:
+            logger.error("JWT_SECRET is not set. Cannot authenticate password login.")
+            return None
+        try:
+            state = self._load_login_state(username)
+            if state is None or not state["password"]:
+                return None
+
+            stored_password = str(state["password"])
+            replacement_password = None
+            if _is_bcrypt_hash(stored_password):
+                if not _verify_password(password, stored_password):
+                    return None
+            else:
+                if not hmac.compare_digest(stored_password, password):
+                    return None
+                replacement_password = _hash_password(password)
+
+            return self._rotate_authenticated_session(
+                username=username,
+                state=state,
+                expected_password=stored_password,
+                replacement_password=replacement_password,
+            )
+        except Exception as exc:
+            logger.error(
+                "Password authentication failed for %s (%s)",
+                username,
+                type(exc).__name__,
+            )
+            return None
+
     def authenticate_auto_login(self, username: str, token: str) -> Optional[Dict[str, Any]]:
-        if not self.check_auth_token(username, token):
+        if not self.jwt_secret:
+            logger.error("JWT_SECRET is not set. Cannot authenticate automatic login.")
             return None
-        user_uuid = self.get_user_uuid_by_username(username)
-        if user_uuid is None:
+        try:
+            state = self._load_login_state(username)
+            stored_auth_token = state.get("auth_token") if state else None
+            if (
+                not state
+                or not stored_auth_token
+                or not token
+                or not hmac.compare_digest(str(stored_auth_token), token)
+            ):
+                return None
+            return self._rotate_authenticated_session(username=username, state=state)
+        except Exception as exc:
+            logger.error(
+                "Automatic authentication failed for %s (%s)",
+                username,
+                type(exc).__name__,
+            )
             return None
-        login_token = self.update_auth_token(username)
-        message_token = self.generate_message_token(username)
-        elapsed = self.update_login_time(user_uuid)
-        return {
-            "user_uuid": user_uuid,
-            "login_token": login_token,
-            "message_token": message_token,
-            "elapsed_from_last_login": elapsed,
-        }
     
     def update_login_time(self, user_id: str) -> Optional[float]:
         """

--- a/server/src/system/database/event_store.py
+++ b/server/src/system/database/event_store.py
@@ -11,6 +11,7 @@ from datetime import datetime, date, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 
 from src.utils.logger import get_logger
 from src.utils.lunar_date import get_lunar_mmdd, lunar_to_solar, FIXED_SOLAR_HOLIDAYS, LUNAR_HOLIDAYS_MMDD, is_lunar_new_year_eve
@@ -60,6 +61,7 @@ class EventStore:
         self._all_events_cache: Optional[List[Dict[str, Any]]] = None
         self._due_events_cache: Dict[tuple[date, str], List[Tuple[Dict[str, Any], str]]] = {}
         self._cache_date: Optional[date] = None
+        self._cache_generation = 0
 
     def create_llm_module(self, llm_service: "LLMService"):
         llm_module_config = self.config.get("llm_module")
@@ -78,6 +80,7 @@ class EventStore:
 
     def _invalidate_cache(self) -> None:
         with self._cache_lock:
+            self._cache_generation += 1
             self._all_events_cache = None
             self._due_events_cache = {}
             self._cache_date = None
@@ -92,14 +95,20 @@ class EventStore:
         with self._cache_lock:
             if self._cache_valid() and self._all_events_cache is not None:
                 return self._all_events_cache
+            cache_generation = self._cache_generation
+            cache_date = date.today()
 
         db = self._get_session()
         try:
             rows = db.query(Event).filter(Event.is_active == True).all()
             result = [db_event_to_dict(r) for r in rows]
             with self._cache_lock:
-                self._all_events_cache = result
-                self._cache_date = date.today()
+                if (
+                    self._cache_generation == cache_generation
+                    and date.today() == cache_date
+                ):
+                    self._all_events_cache = result
+                    self._cache_date = cache_date
             return result
         finally:
             db.close()
@@ -372,6 +381,8 @@ class EventStore:
         with self._cache_lock:
             if self._cache_valid() and cache_key in self._due_events_cache:
                 return self._due_events_cache[cache_key]
+            cache_generation = self._cache_generation
+            cache_date = date.today()
 
         db = self._get_session()
         try:
@@ -399,8 +410,12 @@ class EventStore:
                         due_events.append((db_event_to_dict(row), condition_key))
                         break  # 同一事件只需触发一次触发条件
             with self._cache_lock:
-                self._due_events_cache[cache_key] = due_events
-                self._cache_date = date.today()
+                if (
+                    self._cache_generation == cache_generation
+                    and date.today() == cache_date
+                ):
+                    self._due_events_cache[cache_key] = due_events
+                    self._cache_date = cache_date
             return due_events
         finally:
             db.close()
@@ -620,7 +635,7 @@ class EventStore:
                     continue
                 existing = await self.find_matching_event(name, date_mmdd=f"{month:02d}-{day:02d}", source="system")
                 if existing:
-                    break # 所有的节日都是统一加进去的，一个有重复，说明所有的都加过了
+                    continue
                 await self.add_event({
                     "title": name,
                     "description": desc,
@@ -704,9 +719,21 @@ class EventStore:
 
     def mark_notified(self, event_id: str, user_id: str, trigger_key: str, character_id: str) -> None:
         """标记用户对某角色事件的某个触发条件已通知（并刷新缓存）。"""
+        self.try_claim_notification(event_id, user_id, trigger_key, character_id)
+
+    def try_claim_notification(
+        self,
+        event_id: str,
+        user_id: str,
+        trigger_key: str,
+        character_id: str,
+    ) -> bool:
+        """Atomically claim a notification key before dispatch.
+
+        The unique row becomes the durable notification record after a successful
+        dispatch. Call ``release_notification_claim`` if dispatch fails.
+        """
         character_id = character_id or "luotianyi"
-        if self.is_notified(event_id, user_id, trigger_key, character_id):
-            return
         db = self._get_session()
         try:
             notification = EventNotification(
@@ -718,8 +745,43 @@ class EventStore:
             db.add(notification)
             db.commit()
             self._invalidate_cache()
-        except Exception as e:
+            return True
+        except IntegrityError:
             db.rollback()
-            self.logger.warning(f"Failed to mark notification: {e}")
+            return False
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def release_notification_claim(
+        self,
+        event_id: str,
+        user_id: str,
+        trigger_key: str,
+        character_id: str,
+    ) -> bool:
+        """Release a claim whose dispatch did not reach the topic queue."""
+        character_id = character_id or "luotianyi"
+        db = self._get_session()
+        try:
+            deleted = (
+                db.query(EventNotification)
+                .filter(
+                    EventNotification.event_id == event_id,
+                    EventNotification.user_id == user_id,
+                    EventNotification.character_id == character_id,
+                    EventNotification.trigger_key == trigger_key,
+                )
+                .delete(synchronize_session=False)
+            )
+            db.commit()
+            if deleted:
+                self._invalidate_cache()
+            return bool(deleted)
+        except Exception:
+            db.rollback()
+            raise
         finally:
             db.close()

--- a/server/src/system/database/memory_store.py
+++ b/server/src/system/database/memory_store.py
@@ -248,23 +248,40 @@ class MemoryStore:
             metadata=metadata,
         )
 
+    def _load_recent_memory_updates(self, user_id: str) -> List[Dict[str, Any]]:
+        db = self._new_session()
+        try:
+            rows = (
+                db.query(MemoryUpdateRecord)
+                .filter(MemoryUpdateRecord.user_id == user_id)
+                .order_by(
+                    MemoryUpdateRecord.created_at.desc(),
+                    MemoryUpdateRecord.update_cmd_uuid.desc(),
+                )
+                .limit(10)
+                .all()
+            )
+            return [json.loads(row.update_command) for row in reversed(rows)]
+        finally:
+            db.close()
+
     def get_recent_memory_update_from_buffer(self, user_id: str) -> List[MemoryUpdateCommand]:
         """从 Redis 获取最近记忆更新列表。"""
         redis = self._ensure_redis()
         redis_key = f"user_recent_memory_update:{user_id}"
         raw_data = redis.get(redis_key)
-        if not raw_data:
-            self.prefill_buffer(user_id)
-            raw_data = redis.get(redis_key)
-
-        if raw_data:
+        if raw_data is None:
+            updates_list = self._load_recent_memory_updates(user_id)
+            raw_data = json.dumps(updates_list, ensure_ascii=False)
+            redis.setex(redis_key, 3600, raw_data)
+        else:
             updates_list = json.loads(raw_data)
-            return [
-                MemoryUpdateCommand(
-                    uuid=item.get("uuid"),
-                    content=item.get("content"),
-                    type=item.get("type"),
-                )
-                for item in updates_list
-            ]
-        return []
+
+        return [
+            MemoryUpdateCommand(
+                uuid=item.get("uuid"),
+                content=item.get("content"),
+                type=item.get("type"),
+            )
+            for item in updates_list
+        ]

--- a/server/src/system/database/sql_database.py
+++ b/server/src/system/database/sql_database.py
@@ -355,7 +355,6 @@ def init_sql_db(db_folder: str = None, db_file: str = None):
     engine = create_engine(
         DATABASE_URL,
         connect_args={"check_same_thread": False, "timeout": 30},
-        isolation_level="AUTOCOMMIT",
     )
 
     # 2. 注册监听器：在每个连接建立时执行 WAL 开启指令

--- a/server/src/system/database/vector_store.py
+++ b/server/src/system/database/vector_store.py
@@ -87,6 +87,7 @@ from chromadb.config import Settings
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
 
 import asyncio
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 class ChromaVectorStore(VectorStore):
@@ -113,11 +114,18 @@ class ChromaVectorStore(VectorStore):
         # 专用线程池，避免 Chroma 的同步 HTTP 调用耗尽 asyncio 默认线程池
         max_workers = config.get("vector_store_threads", 4)
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="chroma")
+        self._close_lock = threading.Lock()
+        self._closed = False
 
         # 初始化Chroma客户端
         self.client = None
         self.collection = None
-        self._init_chroma()
+        try:
+            self._init_chroma()
+        except BaseException:
+            self._executor.shutdown(wait=True, cancel_futures=False)
+            self._closed = True
+            raise
         
         self.logger.info(f"Chroma向量存储初始化完成: {self.collection_name}")
     
@@ -127,8 +135,19 @@ class ChromaVectorStore(VectorStore):
             # 初始化 Embedding 模型
             embedding_function = SiliconFlowEmbeddings(
                 model=self.embedding_model_name,
-                base_url="https://api.siliconflow.cn/v1",
-                api_key=self.api_key
+                base_url=self.embedding_model_config.get(
+                    "base_url",
+                    "https://api.siliconflow.cn/v1",
+                ),
+                api_key=self.api_key,
+                connect_timeout_seconds=self.embedding_model_config.get(
+                    "connect_timeout_seconds",
+                    5.0,
+                ),
+                read_timeout_seconds=self.embedding_model_config.get(
+                    "read_timeout_seconds",
+                    30.0,
+                ),
             )
             
             # 创建客户端
@@ -172,6 +191,9 @@ class ChromaVectorStore(VectorStore):
     async def search(self, user_id: str, query: str, k: int = 5, **kwargs) -> List[Tuple[BaseDocument, float]]:
         """搜索相似文档 (异步)"""
         try:
+            if self._closed:
+                raise RuntimeError("Vector store is closed")
+
             def _do_query():
                 return self.collection.query(
                     query_texts=[query],
@@ -213,6 +235,14 @@ class ChromaVectorStore(VectorStore):
             traceback.print_exc()
             self.logger.error(f"文档搜索失败: {e}")
             return []
+
+    def close(self) -> None:
+        """Wait for all owned search work and release the dedicated executor."""
+        with self._close_lock:
+            if self._closed:
+                return
+            self._executor.shutdown(wait=True, cancel_futures=False)
+            self._closed = True
     
     def delete_documents(self, doc_ids: List[str]) -> bool:
         """删除文档"""
@@ -329,11 +359,21 @@ class VectorStoreFactory:
 
 vector_store: Optional[VectorStore] = None
 
-def init_vector_store(config: Dict[str, Any]) -> None:
+def init_vector_store(config: Dict[str, Any]) -> VectorStore:
     """初始化向量存储"""
     global vector_store
     store_type = config.get("vector_store_type", "chroma")
     vector_store = VectorStoreFactory.create_vector_store(store_type, config)
+    return vector_store
+
+
+def clear_vector_store(expected: VectorStore | None = None) -> bool:
+    """Clear the shared store only when it still refers to ``expected``."""
+    global vector_store
+    if expected is not None and vector_store is not expected:
+        return False
+    vector_store = None
+    return True
 
 
 def get_vector_store() -> VectorStore:

--- a/server/src/system/system_runtime.py
+++ b/server/src/system/system_runtime.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Dict
 
 from src.agent_runtime import AgentRuntime
+from src.agent_runtime.agent_runtime import clear_agent_runtime
 from src.capabilities import CapabilityManager
 from src.chat_session import ChatSessionManager
+from src.chat_session import chat_stream_manager as chat_stream_manager_module
 from src.system.database import DatabaseManager, set_default_database_manager
 from src.system.observability import ObservabilityService, set_observability_service
 from src.system.user_interface import UserInterface
 from src.utils.llm_service import LLMService
-from src.utils.logger import install_observability_log_handler, uninstall_observability_log_handler
+from src.utils.logger import get_logger, install_observability_log_handler, uninstall_observability_log_handler
 from src.world import WorldRuntime
+
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -27,63 +33,159 @@ class SystemRuntime:
     llm_service: LLMService
     observability: ObservabilityService
     owns_observability: bool = field(default=True)
+    _shutdown_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+    _shutdown_complete: bool = field(default=False, init=False, repr=False)
+    _shutdown_completed_stages: set[str] = field(default_factory=set, init=False, repr=False)
 
     @classmethod
     async def initialize(cls, config: Dict, observability: ObservabilityService | None = None) -> "SystemRuntime":
-        # 1. 初始化观测服务，后续模块可统一写入指标和异常日志
         owns_observability = observability is None
-        if observability is None:
-            observability = ObservabilityService(config.get("observability", {}))
-            set_observability_service(observability)
-            install_observability_log_handler(observability)
+        database_manager: DatabaseManager | None = None
+        capability_manager: CapabilityManager | None = None
+        chat_session_manager: ChatSessionManager | None = None
+        world: WorldRuntime | None = None
+        agent_runtime: AgentRuntime | None = None
+        runtime: SystemRuntime | None = None
 
-        # 2. 初始化 LLM 服务
-        llm_service = LLMService(config.get("llm_service", {}))
+        try:
+            # 1. 初始化观测服务，后续模块可统一写入指标和异常日志
+            if observability is None:
+                observability = ObservabilityService(config.get("observability", {}))
+                set_observability_service(observability)
+                install_observability_log_handler(observability)
 
-        # 3. 初始化数据库管理器
-        database_manager = DatabaseManager(config.get("database", {}))
-        set_default_database_manager(database_manager)
+            # 2. 初始化 LLM 服务
+            llm_service = LLMService(config.get("llm_service", {}))
 
-        # 4. 初始化能力管理器
-        capability_manager = CapabilityManager(config.get("capabilities", {}), llm_service)
+            # 3. 初始化数据库管理器
+            database_manager = DatabaseManager(config.get("database", {}))
+            set_default_database_manager(database_manager)
 
-        # 5. 初始化聊天会话管理器
-        chat_session_manager = ChatSessionManager(
-            config.get("chat_session_manager", {}),
-            llm_service,
-            database_manager,
+            # 4. 初始化能力管理器。SpeechCapability 会在这里启动 TTS worker。
+            capability_manager = CapabilityManager(config.get("capabilities", {}), llm_service)
+
+            # 5. 初始化聊天会话管理器
+            chat_session_manager = ChatSessionManager(
+                config.get("chat_session_manager", {}),
+                llm_service,
+                database_manager,
+            )
+
+            # 6. 初始化箱庭世界运行时
+            world = WorldRuntime(config.get("world", {}))
+
+            # 7. 初始化 Agent 运行时
+            agent_runtime = AgentRuntime(
+                config.get("agent_runtime", {}),
+                llm_service,
+                capability_manager,
+                database_manager,
+            )
+
+            # 8. 组装系统运行时
+            runtime = cls(
+                user_interface=UserInterface(database_manager),
+                world=world,
+                database_manager=database_manager,
+                agent_runtime=agent_runtime,
+                capability_manager=capability_manager,
+                chat_session_manager=chat_session_manager,
+                llm_service=llm_service,
+                observability=observability,
+                owns_observability=owns_observability,
+            )
+
+            runtime._wire_dependencies()
+            runtime._start_background_services()
+            runtime.user_interface.generate_rsa_keys()
+            return runtime
+        except BaseException:
+            await cls._rollback_failed_initialization(
+                runtime=runtime,
+                world=world,
+                database_manager=database_manager,
+                capability_manager=capability_manager,
+                chat_session_manager=chat_session_manager,
+                agent_runtime=agent_runtime,
+                observability=observability,
+                owns_observability=owns_observability,
+            )
+            raise
+
+    @classmethod
+    async def _rollback_failed_initialization(
+        cls,
+        *,
+        runtime: "SystemRuntime | None",
+        world: "WorldRuntime | None",
+        database_manager: "DatabaseManager | None",
+        capability_manager: "CapabilityManager | None",
+        chat_session_manager: "ChatSessionManager | None",
+        agent_runtime: "AgentRuntime | None",
+        observability: "ObservabilityService | None",
+        owns_observability: bool,
+    ) -> None:
+        """Best-effort rollback that never masks the initialization error."""
+        errors: list[str] = []
+        shutdown_steps = (
+            ("world runtime", world.stop_background_services if world is not None else None),
+            (
+                "chat session manager",
+                chat_session_manager.stop_background_services if chat_session_manager is not None else None,
+            ),
+            (
+                "agent runtime",
+                getattr(agent_runtime, "shutdown", None) if agent_runtime is not None else None,
+            ),
+            ("capability manager", capability_manager.stop if capability_manager is not None else None),
+            ("database manager", database_manager.shutdown if database_manager is not None else None),
         )
-        
-        # 6. 初始化箱庭世界运行时
-        world = WorldRuntime(
-            config.get("world", {}),
-        )
+        for name, stop in shutdown_steps:
+            if stop is None:
+                continue
+            try:
+                await stop()
+            except BaseException as error:
+                errors.append(f"{name}: {type(error).__name__}: {error}")
 
-        # 7. 初始化 Agent 运行时
-        agent_runtime = AgentRuntime(
-            config.get("agent_runtime", {}),
-            llm_service,
-            capability_manager,
-            database_manager,
-        )
-
-        # 8. 组装系统运行时
-        runtime = cls(
-            user_interface=UserInterface(database_manager),
-            world=world,
+        cls._clear_global_references(
+            runtime=runtime,
             database_manager=database_manager,
-            agent_runtime=agent_runtime,
-            capability_manager=capability_manager,
             chat_session_manager=chat_session_manager,
-            llm_service=llm_service,
-            observability=observability,
-            owns_observability=owns_observability,
+            agent_runtime=agent_runtime,
         )
+        if owns_observability and observability is not None:
+            try:
+                observability.close()
+            except Exception as error:
+                errors.append(f"observability: {type(error).__name__}: {error}")
+            finally:
+                set_observability_service(None)
+                uninstall_observability_log_handler()
 
-        runtime._wire_dependencies()
-        runtime._start_background_services()
-        runtime.user_interface.generate_rsa_keys()
-        return runtime
+        if errors:
+            logger.error("SystemRuntime initialization rollback had errors: " + "; ".join(errors))
+
+    @staticmethod
+    def _clear_global_references(
+        *,
+        runtime: "SystemRuntime | None",
+        database_manager: "DatabaseManager | None",
+        chat_session_manager: "ChatSessionManager | None",
+        agent_runtime: "AgentRuntime | None",
+    ) -> None:
+        global _system_runtime
+        if runtime is not None and _system_runtime is runtime:
+            _system_runtime = None
+        if agent_runtime is not None:
+            clear_agent_runtime(agent_runtime)
+        if database_manager is not None:
+            # The runtime is the sole owner of the legacy database singleton.
+            set_default_database_manager(None)
+        if chat_session_manager is not None:
+            manager = getattr(chat_session_manager, "chat_stream_manager", None)
+            if chat_stream_manager_module.chat_stream_manager is manager:
+                chat_stream_manager_module.chat_stream_manager = None
 
     def _wire_dependencies(self) -> None:
         """把顶层模块依赖分发给各运行时模块。"""
@@ -114,13 +216,67 @@ class SystemRuntime:
 
     async def shutdown(self) -> None:
         """按依赖反向顺序关闭后台服务和资源。"""
-        await self.world.stop_background_services()
-        await self.chat_session_manager.stop_background_services()
-        await self.database_manager.shutdown()
-        if self.owns_observability:
-            self.observability.close()
-            set_observability_service(None)
-            uninstall_observability_log_handler()
+        async with self._shutdown_lock:
+            if self._shutdown_complete:
+                return
+            errors: list[str] = []
+            shutdown_steps = (
+                ("world runtime", self.world.stop_background_services),
+                ("chat sessions", self.chat_session_manager.stop_background_services),
+                ("agent runtime", getattr(self.agent_runtime, "shutdown", None)),
+                ("capability manager", self.capability_manager.stop),
+                ("database manager", self.database_manager.shutdown),
+            )
+            core_stages = {name for name, _stop in shutdown_steps}
+
+            for name, stop in shutdown_steps:
+                if name in self._shutdown_completed_stages:
+                    continue
+                if stop is None:
+                    self._shutdown_completed_stages.add(name)
+                    continue
+                try:
+                    await stop()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    errors.append(f"{name}: {type(error).__name__}: {error}")
+                    break
+                else:
+                    self._shutdown_completed_stages.add(name)
+
+            if core_stages.issubset(self._shutdown_completed_stages):
+                if "global references" not in self._shutdown_completed_stages:
+                    try:
+                        self._clear_global_references(
+                            runtime=self,
+                            database_manager=self.database_manager,
+                            chat_session_manager=self.chat_session_manager,
+                            agent_runtime=self.agent_runtime,
+                        )
+                    except Exception as error:
+                        errors.append(f"global references: {type(error).__name__}: {error}")
+                    else:
+                        self._shutdown_completed_stages.add("global references")
+
+                if "observability" not in self._shutdown_completed_stages:
+                    try:
+                        if self.owns_observability:
+                            self.observability.close()
+                            set_observability_service(None)
+                            uninstall_observability_log_handler()
+                    except Exception as error:
+                        errors.append(f"observability: {type(error).__name__}: {error}")
+                    else:
+                        self._shutdown_completed_stages.add("observability")
+
+            self._shutdown_complete = {
+                *core_stages,
+                "global references",
+                "observability",
+            }.issubset(self._shutdown_completed_stages)
+            if errors:
+                raise RuntimeError("System runtime shutdown failed: " + "; ".join(errors))
 
     def ensure_dependencies(self) -> None:
         """检查系统运行时所有顶层模块依赖已经完成派发。"""

--- a/server/src/system/token_config.py
+++ b/server/src/system/token_config.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+
+DEFAULT_MESSAGE_TOKEN_TTL_SECONDS = 3600
+MIN_MESSAGE_TOKEN_TTL_SECONDS = 60
+MAX_MESSAGE_TOKEN_TTL_SECONDS = 86400
+
+
+def normalize_message_token_ttl_seconds(value: Any) -> int:
+    """Return a safe TTL when DatabaseManager is used without config validation."""
+    if type(value) is not int:
+        return DEFAULT_MESSAGE_TOKEN_TTL_SECONDS
+    return min(
+        MAX_MESSAGE_TOKEN_TTL_SECONDS,
+        max(MIN_MESSAGE_TOKEN_TTL_SECONDS, value),
+    )

--- a/server/src/system/user_interface/account.py
+++ b/server/src/system/user_interface/account.py
@@ -3,13 +3,15 @@ from cryptography.hazmat.primitives import serialization, hashes
 import base64
 import os
 import hmac
+import hashlib
 import bcrypt
 from fastapi import HTTPException
 from jose import jwt
 import uuid
+import time
 from sqlalchemy.orm import Session
 from datetime import datetime
-from typing import Tuple
+from typing import Any, Optional, Tuple
 
 from src.utils.logger import get_logger
 from src.system.database import User, InviteCode
@@ -68,54 +70,84 @@ def update_auth_token(db_session: Session, username: str) -> str:
     
 def check_auth_token(db_session: Session, username: str, token: str) -> bool:
     user: User = db_session.query(User).filter_by(username=username).first()
-    if user and user.auth_token == token:
-        return True
-    return False
+    if not user or not user.auth_token or not isinstance(token, str):
+        return False
+    return hmac.compare_digest(user.auth_token, token)
 
 # 发送消息时使用的token，编码用户的UUID
 
 JWT_SECRET_ENV = "JWT_SECRET"
 ALGORITHM = "HS256"
+MESSAGE_TOKEN_TTL_SECONDS = 3600
 
 
 def _get_jwt_secret() -> str | None:
     return os.environ.get(JWT_SECRET_ENV)
 
 
-def generate_message_token(db_session: Session, username: str) -> str:
+def _session_fingerprint(jwt_secret: str, auth_token: str) -> str:
+    return hmac.new(
+        jwt_secret.encode("utf-8"),
+        auth_token.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def generate_message_token(db_session: Session, username: str) -> Optional[str]:
     jwt_secret = _get_jwt_secret()
     if not jwt_secret:
         logger.error("JWT_SECRET is not set. Cannot generate legacy message token.")
         return None
     user: User = db_session.query(User).filter_by(username=username).first()
-    if not user:
+    if not user or not user.auth_token:
         return None
-    user_uuid = user.uuid
+    issued_at = int(time.time())
     payload = {
-        "user_uuid": user_uuid,
+        "user_uuid": user.uuid,
+        "iat": issued_at,
+        "exp": issued_at + MESSAGE_TOKEN_TTL_SECONDS,
+        "jti": str(uuid.uuid4()),
+        "session_fp": _session_fingerprint(jwt_secret, user.auth_token),
     }
-    token = jwt.encode(payload, jwt_secret, algorithm=ALGORITHM)
-    return token
+    return jwt.encode(payload, jwt_secret, algorithm=ALGORITHM)
 
-def decode_message_token(token: str) -> str:
+
+def _decode_message_token_claims(token: str) -> Optional[dict[str, Any]]:
     jwt_secret = _get_jwt_secret()
     if not jwt_secret:
         logger.error("JWT_SECRET is not set. Cannot decode legacy message token.")
         return None
     try:
         payload = jwt.decode(token, jwt_secret, algorithms=[ALGORITHM])
-        return payload.get("user_uuid")
-    except jwt.JWTError:
+        required_claims = ("user_uuid", "iat", "exp", "jti", "session_fp")
+        if not isinstance(payload, dict) or any(not payload.get(name) for name in required_claims):
+            return None
+        issued_at = int(payload["iat"])
+        expires_at = int(payload["exp"])
+        now = int(time.time())
+        if expires_at <= now or issued_at > now + 60 or expires_at <= issued_at:
+            return None
+        return payload
+    except (jwt.JWTError, TypeError, ValueError):
         return None
-    
-def check_message_token(db_session: Session, username: str, token: str) -> Tuple[bool, str]:
-    user: User = db_session.query(User).filter_by(username=username).first()
-    if not user:
+
+
+def decode_message_token(token: str) -> Optional[str]:
+    payload = _decode_message_token_claims(token)
+    return str(payload["user_uuid"]) if payload else None
+
+
+def check_message_token(db_session: Session, username: str, token: str) -> Tuple[bool, Optional[str]]:
+    payload = _decode_message_token_claims(token)
+    if not payload:
         return False, None
-    user_uuid = user.uuid
-    decoded_uuid = decode_message_token(token)
-    if decoded_uuid == user_uuid:
-        return True, user_uuid
+    user: User = db_session.query(User).filter_by(username=username).first()
+    if not user or not user.auth_token or str(payload["user_uuid"]) != user.uuid:
+        return False, None
+    jwt_secret = _get_jwt_secret()
+    expected_fingerprint = _session_fingerprint(jwt_secret, user.auth_token)
+    if hmac.compare_digest(expected_fingerprint, str(payload["session_fp"])):
+        return True, user.uuid
     return False, None
 
 
@@ -140,34 +172,54 @@ def _verify_password(password: str, stored_hash: str) -> bool:
 
 
 def register_user(db_session: Session, username: str, password: str, invite_code_str: str):
-    # 1. Check Invite Code
-    code = db_session.query(InviteCode).filter_by(code=invite_code_str).first()
-    if not code:
-        logger.info(f"Register failed: invalid invite code for username={username}")
+    try:
+        available_code = (
+            db_session.query(InviteCode.code)
+            .filter(
+                InviteCode.code == invite_code_str,
+                InviteCode.is_used.is_(False),
+            )
+            .first()
+        )
+        if not available_code:
+            logger.info("Register failed: invalid invite code for username=%s", username)
+            return False, "注册失败，请检查邀请码或用户名"
+
+        existing_user = db_session.query(User).filter_by(username=username).first()
+        if existing_user:
+            logger.info("Register failed: username already exists: %s", username)
+            return False, "注册失败，请检查邀请码或用户名"
+
+        new_user = User(username=username, password=_hash_password(password))
+        db_session.add(new_user)
+        db_session.flush()
+
+        claimed = (
+            db_session.query(InviteCode)
+            .filter(
+                InviteCode.code == invite_code_str,
+                InviteCode.is_used.is_(False),
+            )
+            .update(
+                {
+                    InviteCode.is_used: True,
+                    InviteCode.used_at: datetime.now(tz=None),
+                    InviteCode.user_id: new_user.uuid,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed != 1:
+            db_session.rollback()
+            logger.info("Register failed: invite code unavailable for username=%s", username)
+            return False, "注册失败，请检查邀请码或用户名"
+
+        db_session.commit()
+        return True, "注册成功"
+    except Exception as exc:
+        db_session.rollback()
+        logger.error("Error registering legacy user %s (%s)", username, type(exc).__name__)
         return False, "注册失败，请检查邀请码或用户名"
-    if code.is_used:
-        logger.info(f"Register failed: invite code already used for username={username}")
-        return False, "注册失败，请检查邀请码或用户名"
-        
-    # 2. Check Username
-    existing_user = db_session.query(User).filter_by(username=username).first()
-    if existing_user:
-        logger.info(f"Register failed: username already exists: {username}")
-        return False, "注册失败，请检查邀请码或用户名"
-        
-    # 3. Create User
-    password_hash = _hash_password(password)
-    new_user = User(username=username, password=password_hash)
-    db_session.add(new_user)
-    db_session.flush() # Populate defaults like uuid
-    
-    # 4. Update Invite Code
-    code.is_used = True
-    code.used_at = datetime.now(tz=None)
-    code.user_id = new_user.uuid
-    
-    db_session.commit()
-    return True, "注册成功"
 
 def verify_user(db_session: Session, username: str, password: str) -> bool:
     user = db_session.query(User).filter_by(username=username).first()
@@ -219,8 +271,5 @@ def reset_account(
     user.auth_token = None
     db_session.commit()
 
-    logger.info(
-        f"Account reset: invite_code={invite_code_str}, "
-        f"old_username={old_username}, new_username={new_username}"
-    )
+    logger.info("Account reset: old_username=%s, new_username=%s", old_username, new_username)
     return True, "重置成功"

--- a/server/src/system/user_interface/rate_limits.py
+++ b/server/src/system/user_interface/rate_limits.py
@@ -1,7 +1,7 @@
-from fastapi import  HTTPException, Request
-from typing import Dict
+from fastapi import HTTPException, Request
+import hashlib
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from threading import Lock
 
 _RATE_LIMITS = {
@@ -9,27 +9,70 @@ _RATE_LIMITS = {
     "auth_register": (5, 60),
     "auth_auto_login": (10, 60),
     "auth_reset": (3, 300),
+    "admin_login": (5, 300),
 }
 _rate_limit_lock = Lock()
-_rate_limit_store: Dict[str, deque] = {}
+_RATE_LIMIT_MAX_KEYS = 4096
+_rate_limit_store: "OrderedDict[str, deque[float]]" = OrderedDict()
 
 
-def _get_client_key(request: Request, username: str | None) -> str:
-    client_ip = request.client.host if request.client else "unknown"
-    user = username or "unknown"
-    return f"{client_ip}:{user}"
+def _get_client_ip(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
 
 
-def enforce_rate_limit(request: Request, bucket: str, username: str | None) -> None:
+def _subject_digest(subject: str) -> str:
+    normalized = subject.strip().casefold().encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()[:24]
+
+
+def _prune_expired(now: float) -> None:
+    for key in list(_rate_limit_store):
+        bucket = key.split(":", 1)[0]
+        config = _RATE_LIMITS.get(bucket)
+        if config is None:
+            _rate_limit_store.pop(key, None)
+            continue
+        _, window_sec = config
+        timestamps = _rate_limit_store[key]
+        while timestamps and now - timestamps[0] >= window_sec:
+            timestamps.popleft()
+        if not timestamps:
+            _rate_limit_store.pop(key, None)
+
+
+def _reset_rate_limit_state() -> None:
+    """Clear process-local limiter state. Intended for isolated tests."""
+    with _rate_limit_lock:
+        _rate_limit_store.clear()
+
+
+def enforce_rate_limit(request: Request, bucket: str, subject: str | None) -> None:
     if bucket not in _RATE_LIMITS:
         return
     limit, window_sec = _RATE_LIMITS[bucket]
-    key = f"{bucket}:{_get_client_key(request, username)}"
+    client_ip = _get_client_ip(request)
+    keys = [f"{bucket}:ip:{client_ip}"]
+    if subject:
+        keys.append(f"{bucket}:subject:{_subject_digest(subject)}")
     now = time.monotonic()
     with _rate_limit_lock:
-        timestamps = _rate_limit_store.setdefault(key, deque())
-        while timestamps and now - timestamps[0] > window_sec:
-            timestamps.popleft()
-        if len(timestamps) >= limit:
+        _prune_expired(now)
+        new_key_count = sum(1 for key in keys if key not in _rate_limit_store)
+        if len(_rate_limit_store) + new_key_count > _RATE_LIMIT_MAX_KEYS:
             raise HTTPException(status_code=429, detail="请求过于频繁，请稍后再试")
-        timestamps.append(now)
+
+        states = []
+        for key in keys:
+            timestamps = _rate_limit_store.get(key)
+            if timestamps is None:
+                timestamps = deque()
+            while timestamps and now - timestamps[0] >= window_sec:
+                timestamps.popleft()
+            if len(timestamps) >= limit:
+                raise HTTPException(status_code=429, detail="请求过于频繁，请稍后再试")
+            states.append((key, timestamps))
+
+        for key, timestamps in states:
+            timestamps.append(now)
+            _rate_limit_store[key] = timestamps
+            _rate_limit_store.move_to_end(key)

--- a/server/src/system/user_interface/types.py
+++ b/server/src/system/user_interface/types.py
@@ -11,12 +11,20 @@ class HistoryRequest(BaseModel):
     count: int = 10
     end_index: int = -1
 
+
+class HistoryQuery(BaseModel):
+    username: str
+    count: int = 10
+    end_index: int = -1
+
 class ChatResponse(BaseModel):
     uuid: str
     text: str
     audio: str | None = None
     expression: str | None = None
     is_final_package: bool = True
+    audio_error: bool | None = None
+    error_code: str | None = None
     display_in_chat: bool = True
     is_ephemeral: bool = False
 
@@ -57,6 +65,12 @@ class DynamicListRequest(BaseModel):
     cursor: str | None = None
 
 
+class DynamicListQuery(BaseModel):
+    username: str
+    limit: int = 20
+    cursor: str | None = None
+
+
 class DynamicCreateRequest(BaseModel):
     username: str
     token: str
@@ -66,6 +80,12 @@ class DynamicCreateRequest(BaseModel):
 class DynamicCommentListRequest(BaseModel):
     username: str
     token: str | None = None
+    limit: int = 100
+    cursor: str | None = None
+
+
+class DynamicCommentListQuery(BaseModel):
+    username: str
     limit: int = 100
     cursor: str | None = None
 
@@ -80,6 +100,10 @@ class DynamicCommentCreateRequest(BaseModel):
 class DynamicUnreadRequest(BaseModel):
     username: str
     token: str | None = None
+
+
+class DynamicUnreadQuery(BaseModel):
+    username: str
 
 
 class DynamicReadMarkRequest(BaseModel):

--- a/server/src/system/user_interface/user_interface.py
+++ b/server/src/system/user_interface/user_interface.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Optional
 import os
 from contextlib import asynccontextmanager
@@ -37,6 +38,21 @@ class UserInterface:
         self.websocket_service: WebSocketService = WebSocketService()
         self.database_manager: "DatabaseManager" = database_manager
         self.user_conversation_helper = UserConversationHelper(database_manager)
+        self._auth_work_slots = asyncio.Semaphore(4)
+        self._auth_work_admission_timeout = 1.0
+
+    async def _run_auth_work(self, func, *args):
+        try:
+            await asyncio.wait_for(
+                self._auth_work_slots.acquire(),
+                timeout=self._auth_work_admission_timeout,
+            )
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(status_code=503, detail="认证服务繁忙，请稍后再试") from exc
+        try:
+            return await asyncio.to_thread(func, *args)
+        finally:
+            self._auth_work_slots.release()
 
 
     def bind_database_manager(self, database_manager: "DatabaseManager"):
@@ -87,7 +103,11 @@ class UserInterface:
         """
         if request is not None:
             enforce_rate_limit(request, "auth_auto_login", req.username)
-        auth_result = system_runtime.database_manager.authenticate_auto_login(req.username, req.token)
+        auth_result = await self._run_auth_work(
+            system_runtime.database_manager.authenticate_auto_login,
+            req.username,
+            req.token,
+        )
         if auth_result:
             user_uuid = auth_result["user_uuid"]
             await system_runtime.chat_session_manager.on_user_login(
@@ -112,8 +132,11 @@ class UserInterface:
         if request is not None:
             enforce_rate_limit(request, "auth_register", req.username)
         decrypted_password = self.decrypt_user_password(req.password)
-        success, msg = system_runtime.database_manager.register_user(
-            req.username, decrypted_password, req.invite_code
+        success, msg = await self._run_auth_work(
+            system_runtime.database_manager.register_user,
+            req.username,
+            decrypted_password,
+            req.invite_code,
         )
         if not success:
             raise HTTPException(status_code=400, detail=msg)
@@ -127,10 +150,13 @@ class UserInterface:
     ):
         """以邀请码重置账号的用户名和密码"""
         if request is not None:
-            enforce_rate_limit(request, "auth_reset", req.new_username)
+            enforce_rate_limit(request, "auth_reset", req.invite_code)
         decrypted_password = self.decrypt_user_password(req.new_password)
-        success, msg = system_runtime.database_manager.reset_account(
-            req.invite_code, req.new_username, decrypted_password
+        success, msg = await self._run_auth_work(
+            system_runtime.database_manager.reset_account,
+            req.invite_code,
+            req.new_username,
+            decrypted_password,
         )
         if not success:
             raise HTTPException(status_code=400, detail=msg)
@@ -147,8 +173,10 @@ class UserInterface:
         if request is not None:
             enforce_rate_limit(request, "auth_login", req.username)
         decrypted_password = self.decrypt_user_password(req.password)
-        auth_result = system_runtime.database_manager.authenticate_password_login(
-            req.username, decrypted_password
+        auth_result = await self._run_auth_work(
+            system_runtime.database_manager.authenticate_password_login,
+            req.username,
+            decrypted_password,
         )
         if auth_result:
             user_uuid = auth_result["user_uuid"]

--- a/server/src/system/user_interface/websocket_service.py
+++ b/server/src/system/user_interface/websocket_service.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from enum import Enum
 from typing import TYPE_CHECKING, Dict
 import time
 from fastapi import WebSocket, WebSocketDisconnect
@@ -8,13 +9,26 @@ from src.domain.stimulus import Stimulus
 from src.legacy.chat_input_adapter import (
     is_chat_related_ws_message,
     stimulus_to_chat_input_event,
+    validate_ws_chat_message,
     ws_message_to_stimulus,
 )
 from src.domain.chat import ChatInputEvent
 from src.utils.logger import get_logger
 
 if TYPE_CHECKING:
+    from src.chat_session.chat_pipeline.chat_stream import ChatStream
     from src.system.database.database_service import DatabaseManager
+
+
+NEGATIVE_ACK_CAPABILITY = "negative_ack_v1"
+
+
+class ChatEventAcceptance(str, Enum):
+    ACCEPTED = "accepted"
+    DUPLICATE = "duplicate"
+    BAD_MESSAGE = "bad_message"
+    UNSUPPORTED = "unsupported"
+    OVERLOADED = "overloaded"
 
 
 class WebSocketService:
@@ -77,8 +91,9 @@ class WebSocketService:
         event: WSMessage,
     ) -> bool:
         websocket = ws_connection.websocket
-        username = event.payload.get("username", "")
-        token = event.payload.get("token", "")
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        username = payload.get("username", "")
+        token = payload.get("token", "")
         if not username or not token:
             await websocket.send_json(
                 self._make_event(
@@ -109,10 +124,21 @@ class WebSocketService:
 
         authed_user_uuid = user_uuid
         authed_username = username
+        raw_capabilities = payload.get("capabilities", [])
+        negotiated_capabilities = (
+            {NEGATIVE_ACK_CAPABILITY}
+            if isinstance(raw_capabilities, list)
+            and NEGATIVE_ACK_CAPABILITY in raw_capabilities[:32]
+            else set()
+        )
+        ws_connection.capabilities = negotiated_capabilities
         await websocket.send_json(
             self._make_event(
                 WSEventType.AUTH_OK,
-                {"message": "authentication successful for user " + authed_username},
+                {
+                    "message": "authentication successful for user " + authed_username,
+                    "capabilities": sorted(negotiated_capabilities),
+                },
                 reply_to=event.client_msg_id,
             )
         )
@@ -121,7 +147,8 @@ class WebSocketService:
     
     async def handle_ping_event(self, ws_connection: "WebSocketConnection", event: WSMessage) -> None:
         websocket = ws_connection.websocket
-        event_ping_id = event.payload.get("ping_id")
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        event_ping_id = payload.get("ping_id")
         if event_ping_id is None:
             await self.send_error_event(
                 websocket=websocket,
@@ -173,10 +200,41 @@ class WebSocketService:
             return
         ack_event = self._make_event(
             WSEventType.SERVER_ACK,
-            {"received_event_type": event.event_type},
+            {
+                "ok": True,
+                "received_event_type": event.event_type,
+            },
             reply_to=event.client_msg_id,
         )
         await websocket_connection.websocket.send_json(ack_event)
+
+    async def send_nack_event(
+        self,
+        websocket_connection: "WebSocketConnection",
+        event: WSMessage,
+        *,
+        code: str,
+        message: str,
+        retryable: bool,
+    ) -> None:
+        """Report that a client event was not accepted for processing."""
+        supports_negative_ack = (
+            NEGATIVE_ACK_CAPABILITY in websocket_connection.capabilities
+        )
+        payload = {
+            "received_event_type": event.event_type,
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+        }
+        if supports_negative_ack:
+            payload["ok"] = False
+        nack_event = self._make_event(
+            WSEventType.SERVER_ACK if supports_negative_ack else WSEventType.SERVER_ERROR,
+            payload,
+            reply_to=event.client_msg_id,
+        )
+        await websocket_connection.websocket.send_json(nack_event)
 
     async def send_duplicate_ack_event(self, websocket_connection: "WebSocketConnection", event: WSMessage) -> None:
         """对重复客户端消息返回 ACK，但不让上游再次处理同一条业务消息。"""
@@ -186,6 +244,7 @@ class WebSocketService:
         ack_event = self._make_event(
             WSEventType.SERVER_ACK,
             {
+                "ok": True,
                 "received_event_type": event.event_type,
                 "duplicate": True,
             },
@@ -194,22 +253,47 @@ class WebSocketService:
         await websocket_connection.websocket.send_json(ack_event)
 
     def is_duplicate_client_message(self, websocket_connection: "WebSocketConnection", event: WSMessage) -> bool:
-        """按用户和 client_msg_id 做短期幂等，避免客户端 ACK 超时重发导致重复处理。"""
-        if not event.client_msg_id:
+        """Check recent accepted messages without marking a new event as accepted."""
+        key = self._client_message_key(websocket_connection, event)
+        if key is None:
             return False
 
         now = time.monotonic()
         self._prune_recent_client_messages(now)
-        owner = websocket_connection.user_uuid or websocket_connection.user_name or "anonymous"
-        key = f"{owner}:{event.client_msg_id}"
-        if key in self._recent_client_messages:
-            self._recent_client_messages.move_to_end(key)
-            return True
+        return key in self._recent_client_messages
 
+    def mark_client_message_accepted(
+        self,
+        websocket_connection: "WebSocketConnection",
+        event: WSMessage,
+    ) -> bool:
+        """Record idempotency only after the ingress queue accepted the event."""
+        key = self._client_message_key(websocket_connection, event)
+        if key is None:
+            return False
+        now = time.monotonic()
+        self._prune_recent_client_messages(now)
         self._recent_client_messages[key] = now
+        self._recent_client_messages.move_to_end(key)
         while len(self._recent_client_messages) > self._recent_client_msg_limit:
             self._recent_client_messages.popitem(last=False)
-        return False
+        return True
+
+    def has_valid_client_message_id(self, event: WSMessage) -> bool:
+        return (
+            isinstance(event.client_msg_id, str)
+            and 0 < len(event.client_msg_id) <= 128
+        )
+
+    def _client_message_key(
+        self,
+        websocket_connection: "WebSocketConnection",
+        event: WSMessage,
+    ) -> str | None:
+        if not self.has_valid_client_message_id(event):
+            return None
+        owner = websocket_connection.user_uuid or websocket_connection.user_name or "anonymous"
+        return f"{owner}:{event.client_msg_id}"
 
     def _prune_recent_client_messages(self, now: float) -> None:
         expired_before = now - self._recent_client_msg_ttl_seconds
@@ -222,19 +306,73 @@ class WebSocketService:
     def is_chat_related_event(self, event: WSMessage) -> bool:
         return is_chat_related_ws_message(event)
 
+    def try_accept_chat_event(
+        self,
+        websocket_connection: "WebSocketConnection",
+        event: WSMessage,
+        chat_stream: "ChatStream",
+    ) -> ChatEventAcceptance:
+        """Convert and enqueue atomically with respect to event-loop tasks."""
+        if not self.has_valid_client_message_id(event):
+            return ChatEventAcceptance.BAD_MESSAGE
+        try:
+            validate_ws_chat_message(event)
+            chat_event = self.convert_to_chat_input_event(
+                event,
+                sender_user_id=websocket_connection.user_uuid,
+                default_character_id=getattr(chat_stream, "character_id", None) or "luotianyi",
+            )
+            self._validate_chat_event_targets(chat_stream, chat_event)
+        except (KeyError, TypeError, ValueError):
+            return ChatEventAcceptance.BAD_MESSAGE
+        if chat_event is None:
+            return ChatEventAcceptance.UNSUPPORTED
+        if self.is_duplicate_client_message(websocket_connection, event):
+            return ChatEventAcceptance.DUPLICATE
+        if not chat_stream.try_feed_event(chat_event):
+            return ChatEventAcceptance.OVERLOADED
+        self.mark_client_message_accepted(websocket_connection, event)
+        return ChatEventAcceptance.ACCEPTED
+
+    @staticmethod
+    def _validate_chat_event_targets(
+        chat_stream: "ChatStream",
+        chat_event: ChatInputEvent | None,
+    ) -> None:
+        if chat_event is None:
+            return
+        payload = chat_event.payload or {}
+        raw_targets = payload.get("target_character_ids")
+        targets = (raw_targets,) if isinstance(raw_targets, str) else tuple(raw_targets or ())
+        system_runtime = getattr(chat_stream, "system_runtime", None)
+        agent_runtime = getattr(system_runtime, "agent_runtime", None)
+        registry = getattr(agent_runtime, "character_registry", None)
+        if registry is not None:
+            registry.resolve_targets(targets)
+
     def convert_to_stimulus(
         self,
         event: WSMessage,
         sender_user_id: str | None = None,
+        default_character_id: str = "luotianyi",
     ) -> Stimulus | None:
-        return ws_message_to_stimulus(event, sender_user_id=sender_user_id)
+        return ws_message_to_stimulus(
+            event,
+            sender_user_id=sender_user_id,
+            default_character_id=default_character_id,
+        )
 
     def convert_to_chat_input_event(
         self,
         event: WSMessage,
         sender_user_id: str | None = None,
+        default_character_id: str = "luotianyi",
     ) -> ChatInputEvent | None:
-        stimulus = self.convert_to_stimulus(event, sender_user_id=sender_user_id)
+        stimulus = self.convert_to_stimulus(
+            event,
+            sender_user_id=sender_user_id,
+            default_character_id=default_character_id,
+        )
         if stimulus is None:
             return None
         return stimulus_to_chat_input_event(stimulus)
@@ -252,29 +390,79 @@ class WebSocketService:
 
 
 class WebSocketConnection:
+    AUTH_TIMEOUT_SECONDS = 15.0
+    AUTH_MAX_ATTEMPTS = 5
+
     def __init__(self, websocket: WebSocket, user_uuid: str | None, user_name: str | None):
         self.websocket = websocket
         self.user_uuid = user_uuid
         self.user_name = user_name
         self.last_ping_id: int | None = None
         self.last_ping_time: int | None = None
+        self.capabilities: set[str] = set()
 
     def set_user(self, user_uuid: str, user_name: str):
         self.user_uuid = user_uuid
         self.user_name = user_name
         
-    async def auth(self, websocket_service: "WebSocketService", database: "DatabaseManager") -> bool:
+    async def auth(
+        self,
+        websocket_service: "WebSocketService",
+        database: "DatabaseManager",
+        *,
+        timeout_seconds: float | None = None,
+        max_attempts: int | None = None,
+    ) -> bool:
         '''
         进行认证流程，成功返回True，失败返回False
         '''
-        while True:
-            client_event: WSMessage | None = await websocket_service.try_recv_client_msg(self)
+        timeout = max(0.001, float(timeout_seconds or self.AUTH_TIMEOUT_SECONDS))
+        attempt_limit = max(1, int(max_attempts or self.AUTH_MAX_ATTEMPTS))
+        deadline = asyncio.get_running_loop().time() + timeout
+
+        for _ in range(attempt_limit):
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                await self._reject_auth(websocket_service, "AUTH_TIMEOUT", "authentication timed out")
+                return False
+            try:
+                client_event: WSMessage | None = await asyncio.wait_for(
+                    websocket_service.try_recv_client_msg(self),
+                    timeout=remaining,
+                )
+            except asyncio.TimeoutError:
+                await self._reject_auth(websocket_service, "AUTH_TIMEOUT", "authentication timed out")
+                return False
             if client_event is None:
-                await asyncio.sleep(0.1)  # 避免空循环占用过多CPU
                 continue
             if client_event.event_type == WSEventType.USER_AUTH.value:
                 ret = await websocket_service.handle_auth_event(self, database, client_event)
-                if ret:  # 验证成功
-                    
-                    break  # 认证成功后跳出循环，进入正常的消息处理流程
-        return True
+                if ret:
+                    return True
+
+        await self._reject_auth(
+            websocket_service,
+            "AUTH_ATTEMPTS_EXCEEDED",
+            "too many authentication attempts",
+        )
+        return False
+
+    async def _reject_auth(
+        self,
+        websocket_service: "WebSocketService",
+        code: str,
+        message: str,
+    ) -> None:
+        try:
+            await self.websocket.send_json(
+                websocket_service._make_event(
+                    WSEventType.AUTH_ERROR,
+                    {"code": code, "message": message},
+                )
+            )
+        except Exception:
+            pass
+        try:
+            await self.websocket.close(code=1008)
+        except Exception:
+            pass

--- a/server/src/utils/asyncio_helpers.py
+++ b/server/src/utils/asyncio_helpers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Executor
+from functools import partial
+from typing import Any, Callable, Iterable
+
+
+DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS = 30.0
+
+
+async def run_sync_owned(
+    call: Callable[..., Any],
+    *args: Any,
+    executor: Executor | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Run owned sync work without abandoning it when the caller is cancelled."""
+    loop = asyncio.get_running_loop()
+    bound_call = partial(call, *args, **kwargs)
+    future = loop.run_in_executor(executor, bound_call)
+    try:
+        return await asyncio.shield(future)
+    except asyncio.CancelledError:
+        await asyncio.shield(asyncio.gather(future, return_exceptions=True))
+        raise
+
+
+def cancel_task_once(task: asyncio.Task) -> None:
+    """Request cancellation without interrupting an in-progress owned cleanup wait."""
+    if task.done() or task.cancelling():
+        return
+    task.cancel()
+
+
+async def wait_for_owned_tasks(
+    tasks: Iterable[asyncio.Task],
+    *,
+    timeout_seconds: float = DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+) -> tuple[set[asyncio.Task], set[asyncio.Task]]:
+    """Wait for owned tasks without cancelling or detaching them on timeout."""
+    owned_tasks = set(tasks)
+    if not owned_tasks:
+        return set(), set()
+    timeout = max(0.001, float(timeout_seconds))
+    return await asyncio.wait(owned_tasks, timeout=timeout)

--- a/server/src/utils/llm/embedding.py
+++ b/server/src/utils/llm/embedding.py
@@ -5,12 +5,23 @@ from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
 
 
 class SiliconFlowEmbeddings(EmbeddingFunction):
-    def __init__(self, model="BAAI/bge-m3", api_key=None, base_url="https://api.siliconflow.cn/v1"):
+    def __init__(
+        self,
+        model="BAAI/bge-m3",
+        api_key=None,
+        base_url="https://api.siliconflow.cn/v1",
+        connect_timeout_seconds=5.0,
+        read_timeout_seconds=30.0,
+    ):
         self.model = model
         self.api_key = api_key
         if not self.api_key:
             raise ValueError("API key for SiliconFlowEmbeddings cannot be None.")
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/")
+        self.request_timeout = (
+            max(0.1, float(connect_timeout_seconds)),
+            max(0.1, float(read_timeout_seconds)),
+        )
 
     def __call__(self, input: Documents) -> Embeddings: # not used?
         return self.embed_documents(input)
@@ -31,7 +42,12 @@ class SiliconFlowEmbeddings(EmbeddingFunction):
         url = f"{self.base_url}/embeddings"
         headers = {"Authorization": f"Bearer {self.api_key}"}
         payload = {"model": self.model, "input": text}
-        resp = requests.post(url, headers=headers, json=payload)
+        resp = requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=self.request_timeout,
+        )
         resp.raise_for_status()
         return resp.json()["data"][0]["embedding"]
     

--- a/server/src/utils/logger.py
+++ b/server/src/utils/logger.py
@@ -5,11 +5,13 @@
 """
 
 import os
+import re
 import sys
 from typing import Optional, Dict, Any
 from pathlib import Path
 import logging
 from logging.handlers import RotatingFileHandler
+from urllib.parse import unquote_plus
 import colorlog
 
 
@@ -99,10 +101,92 @@ def get_logger(name: str) -> logging.Logger:
     
     return logger
 
+_SENSITIVE_QUERY_KEYS = {
+    "token",
+    "message_token",
+    "login_token",
+    "access_token",
+    "refresh_token",
+    "invite_code",
+    "setup_token",
+    "authorization",
+    "api_key",
+    "apikey",
+    "password",
+    "secret",
+}
+_ACCESS_REQUEST_TARGET_RE = re.compile(
+    r'(?P<prefix>"[A-Z]+\s+)(?P<target>\S+)(?P<suffix>\s+HTTP/\d(?:\.\d+)?")'
+)
+
+
+def _normalized_query_key(raw_key: str) -> str:
+    decoded = raw_key
+    for _ in range(3):
+        next_value = unquote_plus(decoded)
+        if next_value == decoded:
+            break
+        decoded = next_value
+    return decoded.strip().casefold().replace("-", "_")
+
+
+def _is_sensitive_query_key(raw_key: str) -> bool:
+    normalized = _normalized_query_key(raw_key)
+    return (
+        normalized in _SENSITIVE_QUERY_KEYS
+        or normalized.endswith("_token")
+        or normalized.endswith("_secret")
+    )
+
+
+def _redact_sensitive_query(target: str) -> str:
+    base, separator, query = target.partition("?")
+    if not separator:
+        return target
+    redacted_fields = []
+    changed = False
+    for field in query.split("&"):
+        raw_key, equals, _ = field.partition("=")
+        if _is_sensitive_query_key(raw_key):
+            redacted_fields.append(f"{raw_key}=REDACTED")
+            changed = True
+        else:
+            redacted_fields.append(field if equals else raw_key)
+    if not changed:
+        return target
+    return f"{base}?{'&'.join(redacted_fields)}"
+
+
+def _redact_access_message(message: str) -> str:
+    return _ACCESS_REQUEST_TARGET_RE.sub(
+        lambda match: (
+            f"{match.group('prefix')}"
+            f"{_redact_sensitive_query(match.group('target'))}"
+            f"{match.group('suffix')}"
+        ),
+        message,
+    )
+
+
 class AdminSuccessAccessLogFilter(logging.Filter):
     """Hide noisy successful admin polling from uvicorn access logs."""
 
     def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args if isinstance(record.args, tuple) else ()
+        if len(args) >= 3:
+            sanitized_args = list(args)
+            sanitized_args[2] = _redact_sensitive_query(str(sanitized_args[2]))
+            record.args = tuple(sanitized_args)
+        else:
+            try:
+                message = record.getMessage()
+            except (TypeError, ValueError):
+                message = ""
+            sanitized_message = _redact_access_message(message)
+            if sanitized_message != message:
+                record.msg = sanitized_message
+                record.args = ()
+
         if record.levelno >= logging.WARNING:
             return True
         args = record.args if isinstance(record.args, tuple) else ()

--- a/server/src/world/world_clock.py
+++ b/server/src/world/world_clock.py
@@ -7,6 +7,12 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, Optional
 
 from src.utils.logger import get_logger
+from src.utils.asyncio_helpers import (
+    DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS,
+    cancel_task_once,
+    run_sync_owned,
+    wait_for_owned_tasks,
+)
 
 
 ClockAction = Callable[[], Any]
@@ -38,6 +44,7 @@ class WorldClock:
         self._tasks: Dict[str, asyncio.Task] = {}
         self._stop_event: Optional[asyncio.Event] = None
         self.last_results: Dict[str, Any] = {}
+        self.stop_timeout_seconds = DEFAULT_OWNED_TASK_STOP_TIMEOUT_SECONDS
 
     def register_interval_action(
         self,
@@ -87,15 +94,30 @@ class WorldClock:
     async def stop(self) -> None:
         if self._stop_event is not None:
             self._stop_event.set()
-        tasks = list(self._tasks.values())
-        for task in tasks:
-            task.cancel()
-        for task in tasks:
+        task_items = list(self._tasks.items())
+        for _, task in task_items:
+            cancel_task_once(task)
+        done, pending = await wait_for_owned_tasks(
+            (task for _, task in task_items),
+            timeout_seconds=self.stop_timeout_seconds,
+        )
+        errors: list[str] = []
+        for key, task in task_items:
+            if task not in done:
+                continue
             try:
-                await task
+                task.result()
             except asyncio.CancelledError:
                 pass
-        self._tasks.clear()
+            except Exception as error:
+                errors.append(f"{key}: {type(error).__name__}: {error}")
+            finally:
+                if self._tasks.get(key) is task:
+                    self._tasks.pop(key, None)
+        if pending:
+            errors.append(f"{len(pending)} world task(s) still stopping")
+        if errors:
+            raise RuntimeError("World clock shutdown failed: " + "; ".join(errors))
         self._stop_event = None
 
     def _start_interval_action(self, action: _IntervalAction) -> None:
@@ -139,7 +161,7 @@ class WorldClock:
             if inspect.iscoroutinefunction(action):
                 result = action()
             else:
-                result = await asyncio.to_thread(action)
+                result = await run_sync_owned(action)
             if inspect.isawaitable(result):
                 result = await result
             self.last_results[name] = result

--- a/server/tests/test_admin_auth_concurrency.py
+++ b/server/tests/test_admin_auth_concurrency.py
@@ -1,0 +1,63 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from src.system.admin.auth import AdminAuthService
+
+
+@pytest.mark.asyncio
+async def test_admin_password_work_is_bounded_without_blocking_event_loop(tmp_path, monkeypatch):
+    auth = AdminAuthService(tmp_path / "auth.json", tmp_path / "setup-token.txt")
+    monkeypatch.setattr(auth, "is_configured", lambda: True)
+    auth._password_work_admission_timeout = 0.02
+
+    release = threading.Event()
+    entered = 0
+    entered_lock = threading.Lock()
+
+    def slow_verify(_password):
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+        release.wait(timeout=2)
+        return True
+
+    monkeypatch.setattr(auth, "_verify_password", slow_verify)
+
+    def response():
+        return SimpleNamespace(set_cookie=lambda *_args, **_kwargs: None)
+
+    workers = [
+        asyncio.create_task(auth.login_async("password", response()))
+        for _ in range(4)
+    ]
+    try:
+        for _ in range(100):
+            with entered_lock:
+                if entered == 4:
+                    break
+            await asyncio.sleep(0.005)
+
+        with entered_lock:
+            assert entered == 4
+
+        heartbeat_advanced = False
+
+        async def heartbeat():
+            nonlocal heartbeat_advanced
+            await asyncio.sleep(0)
+            heartbeat_advanced = True
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+        with pytest.raises(HTTPException) as exc_info:
+            await auth.login_async("password", response())
+        await heartbeat_task
+
+        assert exc_info.value.status_code == 503
+        assert heartbeat_advanced is True
+    finally:
+        release.set()
+        await asyncio.gather(*workers)

--- a/server/tests/test_admin_runtime.py
+++ b/server/tests/test_admin_runtime.py
@@ -60,6 +60,7 @@ def minimal_config(tmp_path: Path) -> dict:
             },
         },
         "database": {
+            "message_token_ttl_seconds": 3600,
             "event_store": {"llm_module": {"llm": {"name": "main"}, "prompt_name": "p"}},
             "memory_store": {"llm_module": {"llm": {"name": "main"}, "prompt_name": "p"}},
         },
@@ -191,6 +192,57 @@ def test_validator_blocks_core_but_only_disables_world(tmp_path, monkeypatch):
     assert runtime_config["world"]["citywalk"]["enabled"] is False
     assert runtime_config["world"]["bili_dynamic_fetcher"]["enabled"] is False
     assert runtime_config["world"]["auto_song_learner"]["enabled"] is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, "3600", 59, 86401, 3600.5],
+)
+def test_validator_rejects_invalid_message_token_ttl(tmp_path, monkeypatch, value):
+    monkeypatch.setenv("JWT_SECRET", "jwt")
+    monkeypatch.setenv("AMAP_KEY", "amap")
+    validator = RuntimeConfigValidator(
+        root_dir=tmp_path,
+        secret_store=SecretStore(tmp_path / "secrets.local.env"),
+    )
+    config = minimal_config(tmp_path)
+    config["database"]["message_token_ttl_seconds"] = value
+
+    result = validator.validate(config)
+
+    assert result["core_ok"] is False
+    item = next(
+        item
+        for item in result["items"]
+        if item["name"] == "config.database.message_token_ttl_seconds"
+    )
+    assert item["status"] == "error"
+
+
+def test_validator_warns_and_uses_safe_default_when_message_token_ttl_is_missing(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("JWT_SECRET", "jwt")
+    monkeypatch.setenv("AMAP_KEY", "amap")
+    validator = RuntimeConfigValidator(
+        root_dir=tmp_path,
+        secret_store=SecretStore(tmp_path / "secrets.local.env"),
+    )
+    config = minimal_config(tmp_path)
+    del config["database"]["message_token_ttl_seconds"]
+
+    result = validator.validate(config)
+
+    item = next(
+        item
+        for item in result["items"]
+        if item["name"] == "config.database.message_token_ttl_seconds"
+    )
+    assert result["core_ok"] is True
+    assert item["status"] == "warning"
+    assert item["severity"] == "warning"
+    assert "3600" in item["message"]
 
 
 def test_validator_rejects_flat_singing_character_config(tmp_path, monkeypatch):
@@ -377,6 +429,62 @@ def test_admin_success_access_log_filter_keeps_user_and_errors():
     assert access_filter.filter(admin_ok) is False
     assert access_filter.filter(admin_error) is True
     assert access_filter.filter(user_ok) is True
+
+
+def test_access_log_filter_redacts_sensitive_query_parameters():
+    import logging
+    from src.utils.logger import AdminSuccessAccessLogFilter
+
+    access_filter = AdminSuccessAccessLogFilter()
+    record = logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "",
+        0,
+        '%s - "%s %s HTTP/%s" %d',
+        (
+            "127.0.0.1:1234",
+            "GET",
+            (
+                "/dynamics?username=alice&ToKeN=first-secret"
+                "&%6dessage%5Ftoken=second-secret&token=third-secret"
+                "&cursor=x%20y"
+            ),
+            "1.1",
+            401,
+        ),
+        None,
+    )
+
+    assert access_filter.filter(record) is True
+    rendered = record.getMessage()
+
+    assert "first-secret" not in rendered
+    assert "second-secret" not in rendered
+    assert "third-secret" not in rendered
+    assert rendered.count("REDACTED") == 3
+    assert "username=alice" in rendered
+    assert "cursor=x%20y" in rendered
+
+
+def test_access_log_filter_redacts_fallback_message():
+    import logging
+    from src.utils.logger import AdminSuccessAccessLogFilter
+
+    access_filter = AdminSuccessAccessLogFilter()
+    record = logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "",
+        0,
+        '127.0.0.1:1234 - "GET /history?%74oken=fallback-secret HTTP/1.1" 401',
+        (),
+        None,
+    )
+
+    assert access_filter.filter(record) is True
+    assert "fallback-secret" not in record.getMessage()
+    assert "REDACTED" in record.getMessage()
 
 
 def test_llm_config_draft_updates_interfaces_and_bindings(tmp_path):

--- a/server/tests/test_agent_failure_modes.py
+++ b/server/tests/test_agent_failure_modes.py
@@ -1,0 +1,105 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.agent.main_chat import DEFAULT_LLM_FAILURE_RESPONSE, MainChat
+from src.utils.llm.llm_api_interface import LLMContentInspectionError
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.warnings = []
+        self.errors = []
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+    def error(self, message):
+        self.errors.append(message)
+
+
+class SequenceLLM:
+    def __init__(self, *outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    async def generate_response(self, **_kwargs):
+        outcome = self.outcomes[self.calls]
+        self.calls += 1
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def build_main_chat(llm, *, max_attempts=2, fallback=DEFAULT_LLM_FAILURE_RESPONSE):
+    chat = MainChat.__new__(MainChat)
+    chat.llm = llm
+    chat.logger = RecordingLogger()
+    chat.llm_failure_max_attempts = max_attempts
+    chat.llm_failure_retry_delay_seconds = 0
+    chat.llm_failure_response = fallback
+    return chat
+
+
+@pytest.mark.asyncio
+async def test_transient_llm_failure_retries_then_returns_response():
+    llm = SequenceLLM(TimeoutError("first attempt timed out"), "[中性]现在可以回复了")
+    chat = build_main_chat(llm)
+
+    response = await chat._call_llm(reply_topic="hello")
+
+    assert response == "[中性]现在可以回复了"
+    assert llm.calls == 2
+    assert len(chat.logger.warnings) == 1
+    assert chat.logger.errors == []
+
+
+@pytest.mark.asyncio
+async def test_exhausted_llm_failure_has_bounded_attempts_and_non_empty_fallback():
+    llm = SequenceLLM(TimeoutError("timeout"), RuntimeError("provider unavailable"))
+    chat = build_main_chat(llm)
+
+    response = await chat._call_llm(reply_topic="hello")
+
+    assert llm.calls == 2
+    assert response == DEFAULT_LLM_FAILURE_RESPONSE
+    assert response.strip()
+    assert response.startswith("[中性]")
+    assert len(chat.logger.errors) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_llm_responses_are_retried_then_use_non_empty_fallback():
+    llm = SequenceLLM("", "   ")
+    chat = build_main_chat(llm)
+
+    response = await chat._call_llm(reply_topic="hello")
+
+    assert llm.calls == 2
+    assert response == DEFAULT_LLM_FAILURE_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_content_inspection_failure_is_not_retried():
+    llm = SequenceLLM(
+        LLMContentInspectionError("blocked"),
+        AssertionError("must not retry content inspection failures"),
+    )
+    chat = build_main_chat(llm)
+
+    response = await chat._call_llm(reply_topic="hello")
+
+    assert llm.calls == 1
+    assert response == "[中性]这个话题不太合适，我们聊点别的吧"
+
+
+def test_configured_failure_text_is_always_structured_and_non_empty():
+    assert MainChat._structured_failure_response("稍后再试") == "[中性]稍后再试"
+    assert MainChat._structured_failure_response("") == DEFAULT_LLM_FAILURE_RESPONSE
+    assert MainChat._structured_failure_response("[中性]") == DEFAULT_LLM_FAILURE_RESPONSE

--- a/server/tests/test_auth_rate_limits.py
+++ b/server/tests/test_auth_rate_limits.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, Response
+
+from src.system.user_interface import rate_limits
+
+
+@pytest.fixture(autouse=True)
+def clear_rate_limits():
+    rate_limits._reset_rate_limit_state()
+    yield
+    rate_limits._reset_rate_limit_state()
+
+
+def _request(ip: str):
+    return SimpleNamespace(client=SimpleNamespace(host=ip))
+
+
+def test_rotating_subjects_cannot_bypass_ip_limit():
+    request = _request("203.0.113.10")
+    for index in range(10):
+        rate_limits.enforce_rate_limit(request, "auth_login", f"user-{index}")
+
+    with pytest.raises(HTTPException) as exc_info:
+        rate_limits.enforce_rate_limit(request, "auth_login", "another-user")
+
+    assert exc_info.value.status_code == 429
+
+
+def test_rotating_ips_cannot_bypass_subject_limit():
+    for index in range(10):
+        rate_limits.enforce_rate_limit(
+            _request(f"203.0.113.{index + 20}"),
+            "auth_login",
+            "target-user",
+        )
+
+    with pytest.raises(HTTPException) as exc_info:
+        rate_limits.enforce_rate_limit(
+            _request("203.0.113.99"),
+            "auth_login",
+            "target-user",
+        )
+
+    assert exc_info.value.status_code == 429
+
+
+def test_reset_limiter_keys_by_invite_credential_digest():
+    request = _request("203.0.113.11")
+    for _ in range(3):
+        rate_limits.enforce_rate_limit(request, "auth_reset", "SECRET-INVITE-CODE")
+
+    keys = list(rate_limits._rate_limit_store)
+    assert all("SECRET-INVITE-CODE" not in key for key in keys)
+    with pytest.raises(HTTPException):
+        rate_limits.enforce_rate_limit(request, "auth_reset", "SECRET-INVITE-CODE")
+
+
+def test_limiter_fails_closed_at_key_capacity(monkeypatch):
+    monkeypatch.setattr(rate_limits, "_RATE_LIMIT_MAX_KEYS", 2)
+    rate_limits.enforce_rate_limit(_request("203.0.113.12"), "auth_login", None)
+    rate_limits.enforce_rate_limit(_request("203.0.113.13"), "auth_login", None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        rate_limits.enforce_rate_limit(_request("203.0.113.14"), "auth_login", None)
+
+    assert exc_info.value.status_code == 429
+
+
+def test_admin_login_is_limited_across_rotating_ips():
+    for index in range(5):
+        rate_limits.enforce_rate_limit(
+            _request(f"203.0.113.{index + 15}"),
+            "admin_login",
+            "admin",
+        )
+
+    with pytest.raises(HTTPException) as exc_info:
+        rate_limits.enforce_rate_limit(
+            _request("203.0.113.99"),
+            "admin_login",
+            "admin",
+        )
+
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_admin_login_endpoint_uses_stable_nonsecret_subject(monkeypatch):
+    from src.system.admin import admin_interface
+
+    calls = []
+
+    def record_rate_limit(request, bucket, subject):
+        calls.append((bucket, subject))
+
+    class StubAuth:
+        async def login_async(self, password, response):
+            return {"ok": False}
+
+    monkeypatch.setattr(admin_interface, "enforce_rate_limit", record_rate_limit)
+    monkeypatch.setattr(
+        admin_interface,
+        "get_admin_shell",
+        lambda: SimpleNamespace(auth=StubAuth()),
+    )
+
+    await admin_interface.admin_auth_login(
+        _request("203.0.113.20"),
+        Response(),
+        {"password": "ADMIN-PASSWORD-MUST-NOT-BE-A-LIMITER-KEY"},
+    )
+
+    assert calls == [("admin_login", "admin")]
+    assert "PASSWORD" not in repr(calls)

--- a/server/tests/test_auth_security.py
+++ b/server/tests/test_auth_security.py
@@ -1,0 +1,225 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
+import time
+
+import pytest
+from jose import jwt
+
+from src.system.database import database_service
+from src.system.database.database_service import ALGORITHM, DatabaseManager
+from src.system.database.sql_database import InviteCode, User
+from src.system.token_config import (
+    DEFAULT_MESSAGE_TOKEN_TTL_SECONDS,
+    MAX_MESSAGE_TOKEN_TTL_SECONDS,
+    MIN_MESSAGE_TOKEN_TTL_SECONDS,
+)
+from src.system.user_interface.account import (
+    check_message_token as check_legacy_message_token,
+    generate_message_token as generate_legacy_message_token,
+)
+
+
+@pytest.fixture
+def authenticated_user(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "message-token-test-secret")
+    monkeypatch.setattr(database_service, "_hash_password", lambda password: f"hash:{password}")
+    monkeypatch.setattr(
+        database_service,
+        "_is_bcrypt_hash",
+        lambda value: bool(value and value.startswith("hash:")),
+    )
+    monkeypatch.setattr(
+        database_service,
+        "_verify_password",
+        lambda password, stored: stored == f"hash:{password}",
+    )
+    manager = DatabaseManager(
+        {
+            "sql_db_folder": str(tmp_path / "db"),
+            "sql_db_file": "auth.db",
+            "message_token_ttl_seconds": 120,
+        }
+    )
+    session = manager.open_sql_session()
+    try:
+        session.add(InviteCode(code="AUTH-CODE", is_used=False))
+        session.commit()
+    finally:
+        session.close()
+    assert manager.register_user("alice", "password", "AUTH-CODE")[0] is True
+    auth_token = manager.update_auth_token("alice")
+    message_token = manager.generate_message_token("alice", expected_auth_token=auth_token)
+    return manager, auth_token, message_token
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, DEFAULT_MESSAGE_TOKEN_TTL_SECONDS),
+        (True, DEFAULT_MESSAGE_TOKEN_TTL_SECONDS),
+        ("3600", DEFAULT_MESSAGE_TOKEN_TTL_SECONDS),
+        (0, MIN_MESSAGE_TOKEN_TTL_SECONDS),
+        (MIN_MESSAGE_TOKEN_TTL_SECONDS, MIN_MESSAGE_TOKEN_TTL_SECONDS),
+        (MAX_MESSAGE_TOKEN_TTL_SECONDS, MAX_MESSAGE_TOKEN_TTL_SECONDS),
+        (MAX_MESSAGE_TOKEN_TTL_SECONDS + 1, MAX_MESSAGE_TOKEN_TTL_SECONDS),
+    ],
+)
+def test_database_manager_bounds_message_token_ttl_without_validator(
+    monkeypatch,
+    value,
+    expected,
+):
+    monkeypatch.setattr(DatabaseManager, "init_all_databases", lambda self: None)
+
+    manager = DatabaseManager({"message_token_ttl_seconds": value})
+
+    assert manager.message_token_ttl_seconds == expected
+
+
+def test_message_token_has_expiring_session_bound_claims(authenticated_user):
+    manager, auth_token, message_token = authenticated_user
+    claims = jwt.get_unverified_claims(message_token)
+
+    assert {"user_uuid", "iat", "exp", "jti", "session_fp"} <= claims.keys()
+    assert claims["exp"] > claims["iat"]
+    assert auth_token not in claims.values()
+    assert manager.check_message_token("alice", message_token) == (True, claims["user_uuid"])
+
+
+def test_relogin_invalidates_previous_message_token(authenticated_user):
+    manager, _, old_message_token = authenticated_user
+    new_auth_token = manager.update_auth_token("alice")
+    new_message_token = manager.generate_message_token("alice", expected_auth_token=new_auth_token)
+
+    assert manager.check_message_token("alice", old_message_token) == (False, None)
+    assert manager.check_message_token("alice", new_message_token)[0] is True
+
+
+def test_expired_message_token_is_rejected(authenticated_user):
+    manager, auth_token, valid_token = authenticated_user
+    claims = jwt.get_unverified_claims(valid_token)
+    now = int(time.time())
+    expired_token = jwt.encode(
+        {
+            **claims,
+            "iat": now - 120,
+            "exp": now - 60,
+            "session_fp": manager._session_fingerprint(auth_token),
+        },
+        manager.jwt_secret,
+        algorithm=ALGORITHM,
+    )
+
+    assert manager.check_message_token("alice", expired_token) == (False, None)
+
+
+def test_message_token_validation_ignores_poisoned_username_cache(authenticated_user):
+    manager, _, message_token = authenticated_user
+    manager._ensure_redis().setex("user_id:alice", 3600, "attacker-controlled-id")
+
+    ok, user_uuid = manager.check_message_token("alice", message_token)
+
+    assert ok is True
+    assert user_uuid != "attacker-controlled-id"
+
+
+def test_password_login_ignores_poisoned_username_cache(authenticated_user):
+    manager, _, _ = authenticated_user
+    session = manager.open_sql_session()
+    try:
+        database_uuid = session.query(User.uuid).filter(User.username == "alice").scalar()
+    finally:
+        session.close()
+    manager._ensure_redis().setex("user_id:alice", 3600, "attacker-controlled-id")
+
+    result = manager.authenticate_password_login("alice", "password")
+
+    assert result is not None
+    assert result["user_uuid"] == database_uuid
+    assert jwt.get_unverified_claims(result["message_token"])["user_uuid"] == database_uuid
+
+
+def test_inflight_password_login_cannot_restore_session_after_reset(
+    authenticated_user,
+    monkeypatch,
+):
+    manager, _, _ = authenticated_user
+    ready = Event()
+    release = Event()
+    original_rotate = manager._rotate_authenticated_session
+
+    def delayed_rotate(*args, **kwargs):
+        ready.set()
+        if not release.wait(timeout=5):
+            raise AssertionError("test did not release authentication")
+        return original_rotate(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "_rotate_authenticated_session", delayed_rotate)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(manager.authenticate_password_login, "alice", "password")
+        try:
+            assert ready.wait(timeout=5)
+            assert manager.reset_account("AUTH-CODE", "alice", "new-password")[0] is True
+        finally:
+            release.set()
+        result = future.result(timeout=10)
+
+    assert result is None
+    session = manager.open_sql_session()
+    try:
+        assert session.query(User.auth_token).filter(User.username == "alice").scalar() is None
+    finally:
+        session.close()
+
+
+def test_concurrent_auto_login_token_can_only_be_rotated_once(
+    authenticated_user,
+    monkeypatch,
+):
+    manager, auth_token, _ = authenticated_user
+    barrier = Barrier(2)
+    original_rotate = manager._rotate_authenticated_session
+
+    def synchronized_rotate(*args, **kwargs):
+        barrier.wait(timeout=5)
+        return original_rotate(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "_rotate_authenticated_session", synchronized_rotate)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(manager.authenticate_auto_login, "alice", auth_token)
+            for _ in range(2)
+        ]
+        results = [future.result(timeout=10) for future in futures]
+
+    successful = [result for result in results if result is not None]
+    assert len(successful) == 1
+    assert manager.check_auth_token("alice", auth_token) is False
+    assert manager.check_message_token("alice", successful[0]["message_token"])[0] is True
+
+
+def test_account_reset_invalidates_message_token(authenticated_user):
+    manager, _, message_token = authenticated_user
+
+    assert manager.reset_account("AUTH-CODE", "alice-renamed", "new-password")[0] is True
+    assert manager.check_message_token("alice", message_token) == (False, None)
+    assert manager.check_message_token("alice-renamed", message_token) == (False, None)
+
+
+def test_legacy_message_token_path_is_expiring_and_session_bound(authenticated_user):
+    manager, _, _ = authenticated_user
+    session = manager.open_sql_session()
+    try:
+        token = generate_legacy_message_token(session, "alice")
+        claims = jwt.get_unverified_claims(token)
+        assert {"iat", "exp", "jti", "session_fp"} <= claims.keys()
+        assert check_legacy_message_token(session, "alice", token)[0] is True
+    finally:
+        session.close()
+
+    manager.update_auth_token("alice")
+    session = manager.open_sql_session()
+    try:
+        assert check_legacy_message_token(session, "alice", token) == (False, None)
+    finally:
+        session.close()

--- a/server/tests/test_character_validation.py
+++ b/server/tests/test_character_validation.py
@@ -1,0 +1,75 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.agent.main_chat import MainChat
+
+
+def load_static_variables(path: Path) -> MainChat:
+    main_chat = MainChat.__new__(MainChat)
+    main_chat.character_profile = SimpleNamespace(
+        character_id="test-character",
+        static_variables_file=str(path),
+    )
+    main_chat._init_static_variables_sync()
+    return main_chat
+
+
+def test_character_static_variables_file_must_exist(tmp_path):
+    missing_path = tmp_path / "missing.json"
+
+    with pytest.raises(FileNotFoundError, match="test-character"):
+        load_static_variables(missing_path)
+
+
+def test_character_static_variables_must_be_valid_json(tmp_path):
+    path = tmp_path / "invalid.json"
+    path.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="contains invalid JSON"):
+        load_static_variables(path)
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["character_name", "character_persona", "speaking_style"],
+)
+def test_character_static_variables_require_critical_fields(tmp_path, missing_field):
+    static_variables = {
+        "character_name": "Test Character",
+        "character_persona": ["kind", "curious"],
+        "speaking_style": ["brief", "friendly"],
+    }
+    del static_variables[missing_field]
+    path = tmp_path / "incomplete.json"
+    path.write_text(json.dumps(static_variables), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=missing_field):
+        load_static_variables(path)
+
+
+def test_character_static_variables_are_loaded_before_runtime_use(tmp_path):
+    path = tmp_path / "valid.json"
+    path.write_text(
+        json.dumps(
+            {
+                "character_name": " Test Character ",
+                "character_persona": [" kind ", " curious "],
+                "speaking_style": [" brief ", " friendly "],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    main_chat = load_static_variables(path)
+
+    assert main_chat.character_name == "Test Character"
+    assert main_chat.character_persona == "kindcurious"
+    assert main_chat.speaking_style == "brieffriendly"

--- a/server/tests/test_chat_stream_lifecycle.py
+++ b/server/tests/test_chat_stream_lifecycle.py
@@ -1,0 +1,217 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+import src.chat_session.chat_stream_manager as chat_stream_manager_module
+from src.agent_runtime.character_registry import CharacterRegistry
+from src.chat_session.chat_stream_manager import ChatStreamManager
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_connections_create_one_stream_and_worker(monkeypatch):
+    release_start = asyncio.Event()
+    worker_stop = asyncio.Event()
+    instances = []
+
+    class ControlledChatStream:
+        def __init__(self, config, ws_connection, character_id):
+            self.config = config
+            self.ws_connection = ws_connection
+            self.character_id = character_id
+            self.connection_lost_time = None
+            self.start_calls = 0
+            self.reconnect_calls = []
+            self.worker_task = None
+            instances.append(self)
+
+        def set_system_runtime(self, system_runtime):
+            self.system_runtime = system_runtime
+
+        async def start_if_needed(self):
+            self.start_calls += 1
+            self.worker_task = asyncio.create_task(worker_stop.wait())
+            await release_start.wait()
+
+        async def reconnect(self, ws_connection):
+            self.reconnect_calls.append(ws_connection)
+            self.ws_connection = ws_connection
+
+        def clean_up(self):
+            if self.worker_task is not None:
+                self.worker_task.cancel()
+
+    monkeypatch.setattr(chat_stream_manager_module, "ChatStream", ControlledChatStream)
+    manager = ChatStreamManager({"stream_lock_stripes": 1}, None, None, None, None)
+    first_connection = SimpleNamespace(user_uuid="user-1", user_name="alice")
+    second_connection = SimpleNamespace(user_uuid="user-1", user_name="alice")
+
+    first = asyncio.create_task(
+        manager.get_or_register_chat_stream(first_connection, system_runtime=object())
+    )
+    second = asyncio.create_task(
+        manager.get_or_register_chat_stream(second_connection, system_runtime=object())
+    )
+    asyncio.get_running_loop().call_soon(release_start.set)
+    first_result, second_result = await asyncio.gather(first, second)
+
+    assert first_result is second_result
+    assert len(instances) == 1
+    assert instances[0].start_calls == 1
+    assert instances[0].reconnect_calls == [second_connection]
+    assert manager.user_streams[("user-1", "luotianyi")] is instances[0]
+    assert instances[0].worker_task is not None
+    assert not instances[0].worker_task.done()
+
+    instances[0].clean_up()
+    await asyncio.gather(instances[0].worker_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_stream_uses_runtime_default_character_when_unspecified(monkeypatch):
+    instances = []
+
+    class CapturingChatStream:
+        def __init__(self, _config, ws_connection, character_id):
+            self.ws_connection = ws_connection
+            self.character_id = character_id
+            instances.append(self)
+
+        def set_system_runtime(self, system_runtime):
+            self.system_runtime = system_runtime
+
+        async def start_if_needed(self):
+            return None
+
+    registry = CharacterRegistry(
+        {"characters": {"miku": {"enabled": True, "default_target": True}}}
+    )
+    runtime = SimpleNamespace(
+        agent_runtime=SimpleNamespace(
+            default_character_id="miku",
+            character_registry=registry,
+        )
+    )
+    monkeypatch.setattr(chat_stream_manager_module, "ChatStream", CapturingChatStream)
+    manager = ChatStreamManager({}, None, None, None, None)
+    connection = SimpleNamespace(user_uuid="user-1", user_name="alice")
+
+    stream = await manager.get_or_register_chat_stream(
+        connection,
+        system_runtime=runtime,
+    )
+
+    assert stream.character_id == "miku"
+    assert manager.user_streams[("user-1", "miku")] is stream
+    assert len(instances) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_first_start_is_cleaned_and_not_registered(monkeypatch):
+    instances = []
+
+    class FailingChatStream:
+        def __init__(self, config, ws_connection, character_id):
+            self.cleaned = False
+            instances.append(self)
+
+        def set_system_runtime(self, system_runtime):
+            self.system_runtime = system_runtime
+
+        async def start_if_needed(self):
+            raise RuntimeError("start failed")
+
+        def clean_up(self):
+            self.cleaned = True
+
+    monkeypatch.setattr(chat_stream_manager_module, "ChatStream", FailingChatStream)
+    manager = ChatStreamManager({}, None, None, None, None)
+    connection = SimpleNamespace(user_uuid="user-1", user_name="alice")
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await manager.get_or_register_chat_stream(connection, system_runtime=object())
+
+    assert len(instances) == 1
+    assert instances[0].cleaned is True
+    assert manager.user_streams == {}
+
+
+class FakeWebSocket:
+    def __init__(self, error=None):
+        self.error = error
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+        if self.error is not None:
+            raise self.error
+
+
+class CleanupStream:
+    def __init__(self, ws_connection=None, *, lost_at=None, cleanup_error=None):
+        self.ws_connection = ws_connection
+        self.connection_lost_time = lost_at
+        self.cleanup_error = cleanup_error
+        self.cleanup_calls = 0
+
+    def lost_connection(self, ws_connection=None):
+        if ws_connection is not None and self.ws_connection is not ws_connection:
+            return False
+        self.ws_connection = None
+        self.connection_lost_time = 100.0
+        return True
+
+    def clean_up(self):
+        self.cleanup_calls += 1
+        if self.cleanup_error is not None:
+            raise self.cleanup_error
+
+
+@pytest.mark.asyncio
+async def test_stale_connection_close_error_does_not_skip_other_streams():
+    failed_websocket = FakeWebSocket(RuntimeError("close failed"))
+    healthy_websocket = FakeWebSocket()
+    failed_connection = SimpleNamespace(websocket=failed_websocket, last_ping_time=1)
+    healthy_connection = SimpleNamespace(websocket=healthy_websocket, last_ping_time=1)
+    failed_stream = CleanupStream(failed_connection)
+    healthy_stream = CleanupStream(healthy_connection)
+    manager = ChatStreamManager({"heartbeat_timeout_seconds": 10}, None, None, None, None)
+    manager.user_streams = {
+        ("user-1", "luotianyi"): failed_stream,
+        ("user-2", "luotianyi"): healthy_stream,
+    }
+
+    await manager._cleanup_once(expiration_seconds=3600, current_time=100.0)
+
+    assert failed_websocket.close_calls == 1
+    assert healthy_websocket.close_calls == 1
+    assert failed_stream.ws_connection is None
+    assert healthy_stream.ws_connection is None
+    assert set(manager.user_streams) == {
+        ("user-1", "luotianyi"),
+        ("user-2", "luotianyi"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_expired_stream_cleanup_error_does_not_skip_other_streams():
+    failed_stream = CleanupStream(lost_at=1.0, cleanup_error=RuntimeError("cleanup failed"))
+    healthy_stream = CleanupStream(lost_at=1.0)
+    manager = ChatStreamManager({}, None, None, None, None)
+    manager.user_streams = {
+        ("user-1", "luotianyi"): failed_stream,
+        ("user-2", "luotianyi"): healthy_stream,
+    }
+
+    await manager._cleanup_once(expiration_seconds=10, current_time=100.0)
+
+    assert failed_stream.cleanup_calls == 1
+    assert healthy_stream.cleanup_calls == 1
+    assert manager.user_streams == {("user-1", "luotianyi"): failed_stream}

--- a/server/tests/test_chat_stream_reconnect.py
+++ b/server/tests/test_chat_stream_reconnect.py
@@ -2,11 +2,14 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 server_root = str(Path(__file__).resolve().parent.parent)
 if server_root not in sys.path:
     sys.path.insert(0, server_root)
 
 from src.chat_session.chat_pipeline.chat_stream import ChatStream
+from src.chat_session.chat_stream_manager import ChatStreamManager
 
 
 def test_set_system_runtime_does_not_require_live_websocket_after_disconnect():
@@ -18,3 +21,30 @@ def test_set_system_runtime_does_not_require_live_websocket_after_disconnect():
 
     assert stream.system_runtime is not None
     assert stream.ws_connection is None
+
+
+@pytest.mark.asyncio
+async def test_stale_disconnect_does_not_drop_replacement_connection():
+    old_connection = SimpleNamespace(user_name="tester", user_uuid="user-1", websocket=object())
+    replacement = SimpleNamespace(user_name="tester", user_uuid="user-1", websocket=object())
+    replacement_stream = ChatStream({}, old_connection, character_id="luotianyi")
+    other_character_stream = ChatStream({}, old_connection, character_id="miku")
+
+    async def already_started():
+        return None
+
+    replacement_stream.start_if_needed = already_started
+    await replacement_stream.reconnect(replacement)
+
+    manager = ChatStreamManager({}, None, None, None, None)
+    manager.user_streams = {
+        ("user-1", "luotianyi"): replacement_stream,
+        ("user-1", "miku"): other_character_stream,
+    }
+
+    manager.ws_lost_connection(old_connection)
+
+    assert replacement_stream.ws_connection is replacement
+    assert replacement_stream.connection_lost_time is None
+    assert other_character_stream.ws_connection is None
+    assert other_character_stream.connection_lost_time is not None

--- a/server/tests/test_database_atomicity.py
+++ b/server/tests/test_database_atomicity.py
@@ -1,0 +1,136 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import pytest
+
+from src.system.database import database_service
+from src.system.database.database_service import DatabaseManager
+from src.system.database.sql_database import InviteCode, User
+
+
+@pytest.fixture
+def db_manager(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "atomicity-test-secret")
+    monkeypatch.setattr(database_service, "_hash_password", lambda password: f"hash:{password}")
+    return DatabaseManager(
+        {
+            "sql_db_folder": str(tmp_path / "db"),
+            "sql_db_file": "atomicity.db",
+        }
+    )
+
+
+def add_invite(manager: DatabaseManager, code: str) -> None:
+    session = manager.open_sql_session()
+    try:
+        session.add(InviteCode(code=code, is_used=False))
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_flush_then_rollback_does_not_persist_user(db_manager):
+    session = db_manager.open_sql_session()
+    try:
+        session.add(User(uuid="rollback-user-id", username="rollback-user", password="hash"))
+        session.flush()
+        session.rollback()
+    finally:
+        session.close()
+
+    session = db_manager.open_sql_session()
+    try:
+        assert session.query(User).filter_by(username="rollback-user").first() is None
+    finally:
+        session.close()
+
+
+def test_concurrent_registration_claims_invite_once(db_manager, monkeypatch):
+    add_invite(db_manager, "ONE-TIME-CODE")
+    barrier = Barrier(2)
+
+    def synchronized_hash(password: str) -> str:
+        barrier.wait(timeout=5)
+        return f"hash:{password}"
+
+    monkeypatch.setattr(database_service, "_hash_password", synchronized_hash)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda username: db_manager.register_user(username, "password", "ONE-TIME-CODE"),
+                ("alice", "bob"),
+            )
+        )
+
+    assert sum(ok for ok, _ in results) == 1
+    session = db_manager.open_sql_session()
+    try:
+        users = session.query(User).filter(User.username.in_(["alice", "bob"])).all()
+        invite = session.query(InviteCode).filter_by(code="ONE-TIME-CODE").one()
+        assert len(users) == 1
+        assert invite.is_used is True
+        assert invite.user_id == users[0].uuid
+    finally:
+        session.close()
+
+
+def test_registration_commit_failure_rolls_back_user_and_invite(db_manager, monkeypatch):
+    add_invite(db_manager, "ROLLBACK-CODE")
+    real_new_session = db_manager._new_session
+
+    class CommitFailingSession:
+        def __init__(self):
+            self._session = real_new_session()
+
+        def __getattr__(self, name):
+            return getattr(self._session, name)
+
+        def commit(self):
+            raise RuntimeError("injected commit failure")
+
+    monkeypatch.setattr(db_manager, "_new_session", CommitFailingSession)
+    ok, _ = db_manager.register_user("rollback-register", "password", "ROLLBACK-CODE")
+
+    assert ok is False
+    session = real_new_session()
+    try:
+        assert session.query(User).filter_by(username="rollback-register").first() is None
+        invite = session.query(InviteCode).filter_by(code="ROLLBACK-CODE").one()
+        assert invite.is_used is False
+        assert invite.user_id is None
+    finally:
+        session.close()
+
+
+def test_reset_invalidates_old_and_new_username_cache_keys(db_manager):
+    add_invite(db_manager, "RESET-CODE")
+    assert db_manager.register_user("old-name", "password", "RESET-CODE")[0] is True
+    original_uuid = db_manager.get_user_uuid_by_username("old-name")
+
+    assert db_manager.reset_account("RESET-CODE", "new-name", "new-password")[0] is True
+    add_invite(db_manager, "REUSE-CODE")
+    assert db_manager.register_user("old-name", "other-password", "REUSE-CODE")[0] is True
+
+    reused_uuid = db_manager.get_user_uuid_by_username("old-name")
+    assert reused_uuid != original_uuid
+    assert db_manager.get_user_uuid_by_username("new-name") == original_uuid
+
+
+def test_cache_errors_after_commit_do_not_report_false_failure(db_manager, monkeypatch):
+    add_invite(db_manager, "CACHE-FAIL-CODE")
+    redis = db_manager._ensure_redis()
+
+    def fail_cache_operation(*args, **kwargs):
+        raise RuntimeError("injected cache failure")
+
+    monkeypatch.setattr(redis, "setex", fail_cache_operation)
+    assert db_manager.register_user("cache-user", "password", "CACHE-FAIL-CODE")[0] is True
+
+    monkeypatch.setattr(redis, "delete", fail_cache_operation)
+    assert db_manager.reset_account("CACHE-FAIL-CODE", "cache-user-new", "password")[0] is True
+
+    session = db_manager.open_sql_session()
+    try:
+        assert session.query(User).filter_by(username="cache-user-new").one()
+    finally:
+        session.close()

--- a/server/tests/test_embedding_timeouts.py
+++ b/server/tests/test_embedding_timeouts.py
@@ -1,0 +1,27 @@
+from src.utils.llm import embedding as embedding_module
+from src.utils.llm.embedding import SiliconFlowEmbeddings
+
+
+def test_embedding_request_has_finite_connect_and_read_timeouts(monkeypatch):
+    captured = {}
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": [{"embedding": [0.1, 0.2]}]}
+
+    def fake_post(_url, **kwargs):
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(embedding_module.requests, "post", fake_post)
+    embeddings = SiliconFlowEmbeddings(
+        api_key="test-key",
+        connect_timeout_seconds=1.5,
+        read_timeout_seconds=4.5,
+    )
+
+    assert embeddings.embed_query("hello") == [0.1, 0.2]
+    assert captured["timeout"] == (1.5, 4.5)

--- a/server/tests/test_event_store_character.py
+++ b/server/tests/test_event_store_character.py
@@ -186,3 +186,21 @@ def test_event_notification_is_scoped_by_character(tmp_path):
         db.close()
 
     assert {row.character_id for row in rows} == {"luotianyi", "miku"}
+
+
+def test_event_notification_claim_is_atomic_and_releasable(tmp_path):
+    init_sql_db(str(tmp_path), "events.db")
+    store = EventStore({}, get_sql_session, NoopRedis())
+
+    assert store.try_claim_notification(
+        "event-claim", "user-1", "day_of_event", "luotianyi"
+    ) is True
+    assert store.try_claim_notification(
+        "event-claim", "user-1", "day_of_event", "luotianyi"
+    ) is False
+    assert store.release_notification_claim(
+        "event-claim", "user-1", "day_of_event", "luotianyi"
+    ) is True
+    assert store.try_claim_notification(
+        "event-claim", "user-1", "day_of_event", "luotianyi"
+    ) is True

--- a/server/tests/test_event_store_concurrency.py
+++ b/server/tests/test_event_store_concurrency.py
@@ -1,0 +1,166 @@
+import json
+import sys
+import threading
+from datetime import date, datetime, time
+from pathlib import Path
+from types import SimpleNamespace
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.system.database.event_store import EventStore
+
+
+class NoopRedis:
+    pass
+
+
+class SnapshotSource:
+    def __init__(self, rows):
+        self.rows = rows
+        self.snapshot_captured = threading.Event()
+        self.release_snapshot = threading.Event()
+
+
+class SnapshotQuery:
+    def __init__(self, source, block):
+        self.source = source
+        self.block = block
+
+    def filter(self, *args):
+        return self
+
+    def all(self):
+        snapshot = list(self.source.rows)
+        if self.block:
+            self.source.snapshot_captured.set()
+            if not self.source.release_snapshot.wait(timeout=2):
+                raise TimeoutError("test did not release the stale event snapshot")
+        return snapshot
+
+
+class SnapshotSession:
+    def __init__(self, source, block):
+        self.source = source
+        self.block = block
+
+    def query(self, *args):
+        return SnapshotQuery(self.source, self.block)
+
+    def close(self):
+        pass
+
+
+class SnapshotSessionFactory:
+    def __init__(self, source):
+        self.source = source
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def __call__(self):
+        with self._lock:
+            self.calls += 1
+            block = self.calls == 1
+        return SnapshotSession(self.source, block)
+
+
+def make_event_row(event_id, title):
+    now = datetime.now()
+    return SimpleNamespace(
+        id=event_id,
+        character="luotianyi",
+        event_type="general",
+        title=title,
+        description="",
+        date_type="solar",
+        date_mmdd="",
+        start_datetime=datetime.combine(date.today(), time(hour=12)),
+        end_datetime=None,
+        duration_minutes=None,
+        trigger_conditions=json.dumps(["day_of_event"]),
+        is_recurring=False,
+        is_personal=False,
+        target_user_id=None,
+        source="test",
+        source_url="",
+        source_platform="",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def run_stale_read(read):
+    result = []
+    errors = []
+
+    def target():
+        try:
+            result.append(read())
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=target)
+    thread.start()
+    return thread, result, errors
+
+
+def finish_thread(thread, errors):
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert errors == []
+
+
+def test_stale_all_events_read_does_not_repopulate_invalidated_cache():
+    old_row = make_event_row("old", "Old snapshot")
+    new_row = make_event_row("new", "Committed event")
+    source = SnapshotSource([old_row])
+    sessions = SnapshotSessionFactory(source)
+    store = EventStore({}, sessions, NoopRedis())
+
+    thread, stale_result, errors = run_stale_read(store.get_all_events)
+    assert source.snapshot_captured.wait(timeout=2)
+
+    source.rows = [new_row]
+    store._invalidate_cache()
+    source.release_snapshot.set()
+    finish_thread(thread, errors)
+
+    assert [event["id"] for event in stale_result[0]] == ["old"]
+    assert store._all_events_cache is None
+    assert [event["id"] for event in store.get_all_events()] == ["new"]
+    assert sessions.calls == 2
+
+
+def test_stale_due_events_read_does_not_repopulate_invalidated_cache():
+    new_row = make_event_row("new", "Due after write")
+    source = SnapshotSource([])
+    sessions = SnapshotSessionFactory(source)
+    store = EventStore({}, sessions, NoopRedis())
+    cache_key = (date.today(), "luotianyi")
+
+    thread, stale_result, errors = run_stale_read(
+        lambda: store.get_events_due_for_trigger(
+            character="luotianyi",
+            today=date.today(),
+        )
+    )
+    assert source.snapshot_captured.wait(timeout=2)
+
+    source.rows = [new_row]
+    store._invalidate_cache()
+    source.release_snapshot.set()
+    finish_thread(thread, errors)
+
+    assert stale_result == [[]]
+    assert cache_key not in store._due_events_cache
+    fresh = store.get_events_due_for_trigger(
+        character="luotianyi",
+        today=date.today(),
+    )
+    assert [(event["id"], trigger) for event, trigger in fresh] == [
+        ("new", "day_of_event")
+    ]
+    assert sessions.calls == 2

--- a/server/tests/test_event_store_holidays.py
+++ b/server/tests/test_event_store_holidays.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+import src.system.database.event_store as event_store_module
+from src.system.database.event_store import EventStore
+
+
+class NoopRedis:
+    pass
+
+
+async def test_existing_fixed_holiday_does_not_skip_later_missing_holiday(monkeypatch):
+    store = EventStore({}, lambda: None, NoopRedis())
+    created = []
+
+    async def find_matching_event(title, **kwargs):
+        return {"id": "existing"} if title == "Existing Holiday" else None
+
+    async def add_event(event_data):
+        created.append(event_data)
+        return "created"
+
+    monkeypatch.setattr(
+        event_store_module,
+        "FIXED_SOLAR_HOLIDAYS",
+        {
+            "01-01": ("Existing Holiday", "already stored"),
+            "02-02": ("Missing Holiday", "must be added"),
+        },
+    )
+    monkeypatch.setattr(event_store_module, "LUNAR_HOLIDAYS_MMDD", {})
+    monkeypatch.setattr(event_store_module, "is_lunar_new_year_eve", lambda *args: False)
+    monkeypatch.setattr(store, "find_matching_event", find_matching_event)
+    monkeypatch.setattr(store, "add_event", add_event)
+
+    added = await store.ensure_holidays([2026])
+
+    assert added == 1
+    assert [event["title"] for event in created] == ["Missing Holiday"]

--- a/server/tests/test_http_secret_security.py
+++ b/server/tests/test_http_secret_security.py
@@ -1,0 +1,143 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import server_main
+from src.system.admin import admin_interface
+from src.system.admin.secret_store import SecretStore
+from src.system.user_interface.types import (
+    DynamicCommentListQuery,
+    DynamicListQuery,
+    DynamicUnreadQuery,
+    HistoryQuery,
+    RegisterRequest,
+    ResetAccountRequest,
+)
+
+
+class RecordingUserInterface:
+    def __init__(self):
+        self.calls = []
+
+    async def get_history(self, username, token, count, end_index, runtime):
+        self.calls.append(("history", token))
+        return {}
+
+    async def list_dynamics(self, request, runtime):
+        self.calls.append(("dynamics", request.token))
+        return {}
+
+    async def get_dynamic_unread(self, request, runtime):
+        self.calls.append(("unread", request.token))
+        return {}
+
+    async def list_dynamic_comments(self, dynamic_id, request, runtime):
+        self.calls.append(("comments", request.token))
+        return {}
+
+    async def register(self, request, runtime, http_request):
+        return {"ok": True}
+
+    async def reset_account(self, request, runtime, http_request):
+        return {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_user_get_routes_accept_tokens_only_from_bearer_header():
+    user_interface = RecordingUserInterface()
+    runtime = SimpleNamespace(user_interface=user_interface)
+
+    assert "token" not in HistoryQuery.model_fields
+    assert "token" not in DynamicListQuery.model_fields
+    assert "token" not in DynamicUnreadQuery.model_fields
+    assert "token" not in DynamicCommentListQuery.model_fields
+
+    await server_main.get_history(HistoryQuery(username="alice"), "Bearer header-token", runtime)
+    await server_main.list_dynamics(DynamicListQuery(username="alice"), "Bearer header-token", runtime)
+    await server_main.get_dynamic_unread(DynamicUnreadQuery(username="alice"), "Bearer header-token", runtime)
+    await server_main.list_dynamic_comments(
+        "dynamic-id",
+        DynamicCommentListQuery(username="alice"),
+        "Bearer header-token",
+        runtime,
+    )
+
+    assert user_interface.calls == [
+        ("history", "header-token"),
+        ("dynamics", "header-token"),
+        ("unread", "header-token"),
+        ("comments", "header-token"),
+    ]
+
+
+@pytest.mark.parametrize("header", [None, "", "Basic token", "Bearer", "Bearer token extra"])
+def test_bearer_header_rejects_missing_or_malformed_values(header):
+    with pytest.raises(HTTPException) as exc_info:
+        server_main.require_bearer_token(header)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_register_and_reset_route_logs_do_not_contain_invite_code(monkeypatch):
+    messages = []
+
+    def record(message, *args):
+        messages.append(message % args if args else message)
+
+    monkeypatch.setattr(server_main.logger, "info", record)
+    runtime = SimpleNamespace(user_interface=RecordingUserInterface())
+    invite_code = "SECRET-INVITE-CODE"
+
+    await server_main.register(
+        RegisterRequest(username="alice", password="encrypted", invite_code=invite_code),
+        runtime,
+        None,
+    )
+    await server_main.reset_account(
+        ResetAccountRequest(
+            invite_code=invite_code,
+            new_username="alice-renamed",
+            new_password="encrypted",
+        ),
+        runtime,
+        None,
+    )
+
+    assert invite_code not in "\n".join(messages)
+
+
+def test_secret_deletion_restores_original_environment(tmp_path, monkeypatch):
+    key = "SECRET_STORE_RESTORE_TEST"
+    monkeypatch.setenv(key, "deployment-value")
+    store = SecretStore(tmp_path / "secrets.env")
+    store.write({key: "stored-value"})
+    store.load_into_environment()
+    assert store.update({key: None}) == {}
+    assert __import__("os").environ[key] == "deployment-value"
+
+
+def test_secret_deletion_removes_environment_key_without_original(tmp_path, monkeypatch):
+    key = "SECRET_STORE_REMOVE_TEST"
+    monkeypatch.delenv(key, raising=False)
+    store = SecretStore(tmp_path / "secrets.env")
+    store.write({key: "stored-value"})
+    store.load_into_environment()
+    store.update({key: None})
+    assert key not in __import__("os").environ
+
+
+@pytest.mark.asyncio
+async def test_secret_update_marks_running_runtime_for_restart(tmp_path, monkeypatch):
+    store = SecretStore(tmp_path / "secrets.env")
+    shell = SimpleNamespace(
+        secret_store=store,
+        config_store=SimpleNamespace(read_raw=lambda: {}),
+        runtime_supervisor=SimpleNamespace(is_running=lambda: True),
+    )
+    monkeypatch.setattr(admin_interface, "get_admin_shell", lambda: shell)
+
+    result = await admin_interface.update_secrets({"RUNTIME_SECRET_TEST": "new-value"})
+
+    assert result["restart_required"] is True
+    assert result["changed_keys"] == ["RUNTIME_SECRET_TEST"]

--- a/server/tests/test_legacy_account_atomicity.py
+++ b/server/tests/test_legacy_account_atomicity.py
@@ -1,0 +1,149 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from src.system.database.sql_database import Base, InviteCode, User
+from src.system.user_interface import account
+
+
+@pytest.fixture
+def session_factory(tmp_path):
+    database_path = tmp_path / "legacy-account.db"
+    engine = create_engine(
+        f"sqlite:///{database_path}",
+        connect_args={"check_same_thread": False, "timeout": 30},
+    )
+
+    @event.listens_for(engine, "connect")
+    def configure_sqlite(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.execute("PRAGMA busy_timeout=15000")
+        cursor.close()
+
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    yield factory
+    engine.dispose()
+
+
+def _add_invite(session_factory, code: str) -> None:
+    session = session_factory()
+    try:
+        session.add(InviteCode(code=code, is_used=False))
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_legacy_concurrent_registration_claims_invite_once(session_factory, monkeypatch):
+    _add_invite(session_factory, "LEGACY-ONE-TIME")
+    barrier = Barrier(2)
+
+    def synchronized_hash(password: str) -> str:
+        barrier.wait(timeout=5)
+        return f"hash:{password}"
+
+    monkeypatch.setattr(account, "_hash_password", synchronized_hash)
+
+    def register(username: str):
+        session = session_factory()
+        try:
+            return account.register_user(
+                session,
+                username,
+                "password",
+                "LEGACY-ONE-TIME",
+            )
+        finally:
+            session.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(register, ("alice", "bob")))
+
+    assert sum(ok for ok, _ in results) == 1
+    session = session_factory()
+    try:
+        users = session.query(User).filter(User.username.in_(["alice", "bob"])).all()
+        invite = session.query(InviteCode).filter_by(code="LEGACY-ONE-TIME").one()
+        assert len(users) == 1
+        assert invite.is_used is True
+        assert invite.user_id == users[0].uuid
+    finally:
+        session.close()
+
+
+def test_legacy_registration_commit_failure_rolls_back_user_and_invite(
+    session_factory,
+    monkeypatch,
+):
+    _add_invite(session_factory, "LEGACY-ROLLBACK")
+    monkeypatch.setattr(account, "_hash_password", lambda password: f"hash:{password}")
+    session = session_factory()
+
+    def fail_commit():
+        raise RuntimeError("injected commit failure")
+
+    monkeypatch.setattr(session, "commit", fail_commit)
+    try:
+        ok, _ = account.register_user(
+            session,
+            "rollback-user",
+            "password",
+            "LEGACY-ROLLBACK",
+        )
+    finally:
+        session.close()
+
+    assert ok is False
+    verification_session = session_factory()
+    try:
+        assert (
+            verification_session.query(User)
+            .filter_by(username="rollback-user")
+            .first()
+            is None
+        )
+        invite = (
+            verification_session.query(InviteCode)
+            .filter_by(code="LEGACY-ROLLBACK")
+            .one()
+        )
+        assert invite.is_used is False
+        assert invite.user_id is None
+    finally:
+        verification_session.close()
+
+
+def test_legacy_auth_token_uses_constant_time_comparison(session_factory, monkeypatch):
+    session = session_factory()
+    session.add(
+        User(
+            uuid="legacy-token-user",
+            username="legacy-user",
+            password="hash:password",
+            auth_token="stored-token",
+        )
+    )
+    session.commit()
+    comparisons = []
+
+    def compare_digest(left: str, right: str) -> bool:
+        comparisons.append((left, right))
+        return left == right
+
+    monkeypatch.setattr(account.hmac, "compare_digest", compare_digest)
+    try:
+        assert account.check_auth_token(session, "legacy-user", "stored-token") is True
+        assert account.check_auth_token(session, "legacy-user", "wrong-token") is False
+    finally:
+        session.close()
+
+    assert comparisons == [
+        ("stored-token", "stored-token"),
+        ("stored-token", "wrong-token"),
+    ]

--- a/server/tests/test_memory_store_cold_cache.py
+++ b/server/tests/test_memory_store_cold_cache.py
@@ -1,0 +1,57 @@
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.system.database.memory_store import MemoryStore
+from src.system.database.redis_buffer import RedisBuffer
+from src.system.database.sql_database import Base, MemoryUpdateRecord
+
+
+def test_recent_memory_updates_are_loaded_from_sql_on_cold_cache():
+    engine = create_engine("sqlite:///:memory:")
+    session_factory = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    started_at = datetime(2026, 8, 1, 12, 0, 0)
+    db = session_factory()
+    try:
+        for index in range(12):
+            db.add(
+                MemoryUpdateRecord(
+                    update_cmd_uuid=f"command-{index:02d}",
+                    user_id="user-1",
+                    update_command=json.dumps(
+                        {
+                            "uuid": f"memory-{index}",
+                            "content": f"content-{index}",
+                            "type": "write_user_memory",
+                        }
+                    ),
+                    created_at=started_at + timedelta(seconds=index),
+                )
+            )
+        db.commit()
+    finally:
+        db.close()
+
+    redis = RedisBuffer()
+    store = MemoryStore({}, session_factory, redis)
+
+    updates = store.get_recent_memory_update_from_buffer("user-1")
+
+    assert [update.uuid for update in updates] == [
+        f"memory-{index}" for index in range(2, 12)
+    ]
+    cached = json.loads(redis.get("user_recent_memory_update:user-1"))
+    assert [item["uuid"] for item in cached] == [
+        f"memory-{index}" for index in range(2, 12)
+    ]

--- a/server/tests/test_pipeline_backpressure.py
+++ b/server/tests/test_pipeline_backpressure.py
@@ -1,0 +1,140 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.chat_session.chat_pipeline.chat_stream import ChatStream
+from src.chat_session.chat_pipeline.ingress_helper import IngressHelper
+from src.chat_session.chat_pipeline.reflection_worker import ReflectionWorker
+from src.chat_session.chat_pipeline.topic_replier import TopicReplier
+from src.chat_session.chat_pipeline.unread_store import UnreadStore
+from src.domain.chat import ChatInputEvent, ChatInputEventType, UnreadMessage
+
+
+class FakeConnection:
+    user_name = "alice"
+    user_uuid = "user-1"
+    websocket = None
+
+
+def _event(index: int) -> ChatInputEvent:
+    return ChatInputEvent(
+        event_type=ChatInputEventType.USER_TEXT,
+        text=f"message-{index}",
+        client_msg_id=f"msg-{index}",
+    )
+
+
+def test_ingress_queue_rejects_above_configured_capacity():
+    helper = IngressHelper(
+        {"queue_maxsize": 2},
+        username="alice",
+        user_id="user-1",
+    )
+
+    assert helper.put_nowait(_event(1)) is True
+    assert helper.put_nowait(_event(2)) is True
+    assert helper.put_nowait(_event(3)) is False
+    assert helper.ingress_queue.qsize() == 2
+
+
+def test_all_pipeline_queues_have_configured_bounds():
+    stream = ChatStream(
+        {
+            "response_queue_maxsize": 7,
+            "ingress_helper": {"queue_maxsize": 3},
+            "topic_planner": {"unread_store": {"maxsize": 4}},
+            "topic_replier": {"queue_maxsize": 5},
+            "reflection_worker": {"queue_maxsize": 6},
+        },
+        FakeConnection(),
+    )
+
+    assert stream.ingress_helper.ingress_queue.maxsize == 3
+    assert stream.topic_planner.unread_store.maxsize == 4
+    assert stream.topic_replier.topic_queue.maxsize == 5
+    assert stream.reflection_worker.reflection_queue.maxsize == 6
+    assert stream.response_queue.maxsize == 7
+
+
+def test_standalone_internal_workers_use_bounded_defaults():
+    topic_replier = TopicReplier({}, "alice", "user-1")
+    reflection_worker = ReflectionWorker({}, "alice", "user-1")
+
+    assert topic_replier.topic_queue.maxsize == 64
+    assert reflection_worker.reflection_queue.maxsize == 64
+
+
+@pytest.mark.asyncio
+async def test_unread_snapshot_keeps_capacity_until_commit():
+    store = UnreadStore({"maxsize": 2}, "alice", "user-1")
+    first = UnreadMessage("msg-1", "text", "one")
+    second = UnreadMessage("msg-2", "text", "two")
+    third = UnreadMessage("msg-3", "text", "three")
+    await store.append(first)
+    await store.append(second)
+
+    snapshot = await store.snapshot()
+    blocked_append = asyncio.create_task(store.append(third))
+    await asyncio.sleep(0)
+
+    assert blocked_append.done() is False
+    assert await store.pending_count() == 2
+
+    await store.update_unread_message(snapshot, [second])
+    await asyncio.wait_for(blocked_append, timeout=0.5)
+
+    assert await store.pending_count() == 2
+
+
+@pytest.mark.asyncio
+async def test_full_unread_store_blocks_worker_until_ingress_rejects():
+    store = UnreadStore({"maxsize": 1}, "alice", "user-1")
+    await store.append(UnreadMessage("existing", "text", "existing"))
+    consumer_started = asyncio.Event()
+
+    async def consume(event):
+        consumer_started.set()
+        await store.append(UnreadMessage(event.client_msg_id, "text", event.text or ""))
+
+    class FakeAgentRuntime:
+        async def try_handle_reflex(self, **_kwargs):
+            return False
+
+    helper = IngressHelper({"queue_maxsize": 1}, "alice", "user-1")
+    helper.set_system_runtime(SimpleNamespace(agent_runtime=FakeAgentRuntime()))
+    helper.set_msg_consumer(consume)
+    helper.send_reply_callback = lambda _response: None
+    helper.start_processing()
+    held = ChatInputEvent(ChatInputEventType.SYSTEM_EVENT, "held", client_msg_id="held")
+    queued = ChatInputEvent(ChatInputEventType.SYSTEM_EVENT, "queued", client_msg_id="queued")
+    rejected = ChatInputEvent(ChatInputEventType.SYSTEM_EVENT, "rejected", client_msg_id="rejected")
+
+    try:
+        assert helper.put_nowait(held) is True
+        await asyncio.wait_for(consumer_started.wait(), timeout=0.5)
+        assert helper.put_nowait(queued) is True
+        assert helper.put_nowait(rejected) is False
+    finally:
+        await store.clear()
+        helper.ingress_worker_task.cancel()
+        await asyncio.gather(helper.ingress_worker_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_reflection_topic_callback_is_awaited():
+    callback_started = asyncio.Event()
+    release_callback = asyncio.Event()
+
+    async def callback(_topic):
+        callback_started.set()
+        await release_callback.wait()
+
+    worker = ReflectionWorker({}, "alice", "user-1", reply_topic_callback=callback)
+    dispatch = asyncio.create_task(worker._safe_reply_topic(object()))
+    await asyncio.wait_for(callback_started.wait(), timeout=0.5)
+
+    assert dispatch.done() is False
+
+    release_callback.set()
+    await asyncio.wait_for(dispatch, timeout=0.5)

--- a/server/tests/test_pipeline_reliability.py
+++ b/server/tests/test_pipeline_reliability.py
@@ -1,0 +1,92 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.agent.main_chat import OneSentenceChat
+from src.chat_session.dependency.global_speaking_worker import GlobalSpeakingWorker, SpeakingJob
+
+
+async def run_text_job(stream_factory):
+    responses = []
+
+    class FakeSpeech:
+        def say_stream(self, _character_id, _text, _tone):
+            return stream_factory()
+
+    worker = GlobalSpeakingWorker({})
+    worker.set_capabilities(SimpleNamespace(speech=FakeSpeech()))
+
+    async def record(response):
+        responses.append(response)
+
+    await worker.enqueue(
+        SpeakingJob(
+            send_reply_callback=record,
+            job_content=OneSentenceChat(
+                uuid="reply-1",
+                content="已经生成的文本",
+                sound_content="需要合成的文本",
+                tone="normal",
+                expression="微笑脸",
+            ),
+        )
+    )
+    await asyncio.wait_for(worker.queue.join(), timeout=1)
+    await worker.stop()
+    return responses
+
+
+@pytest.mark.asyncio
+async def test_zero_tts_chunks_send_one_error_terminal_with_original_text():
+    def empty_stream():
+        if False:
+            yield "unreachable"
+
+    responses = await run_text_job(empty_stream)
+
+    assert len(responses) == 1
+    terminal = responses[0]
+    assert terminal.is_final_package is True
+    assert terminal.audio_error is True
+    assert terminal.error_code == "TTS_EMPTY"
+    assert terminal.text == "已经生成的文本"
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_tts_failure_sends_exactly_one_terminal_and_keeps_text():
+    def failing_stream():
+        yield "YXVkaW8="
+        raise RuntimeError("stream broke")
+
+    responses = await run_text_job(failing_stream)
+
+    terminals = [response for response in responses if response.is_final_package]
+    assert len(responses) == 2
+    assert len(terminals) == 1
+    assert terminals[0].audio_error is True
+    assert terminals[0].error_code == "TTS_STREAM_ERROR"
+    assert "".join(response.text for response in responses) == "已经生成的文本"
+
+
+@pytest.mark.asyncio
+async def test_successful_tts_stream_still_sends_exactly_one_terminal():
+    def successful_stream():
+        yield "YXVkaW8tMQ=="
+        yield "YXVkaW8tMg=="
+
+    responses = await run_text_job(successful_stream)
+
+    terminals = [response for response in responses if response.is_final_package]
+    assert len(responses) == 3
+    assert len(terminals) == 1
+    assert terminals[0].audio_error is False
+    assert terminals[0].error_code is None
+    assert "".join(response.text for response in responses) == "已经生成的文本"

--- a/server/tests/test_proactive_topic_maker.py
+++ b/server/tests/test_proactive_topic_maker.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,7 +9,11 @@ server_root = str(Path(__file__).resolve().parent.parent)
 if server_root not in sys.path:
     sys.path.insert(0, server_root)
 
-from src.chat_session.dependency.proactive_topic_maker import ProactiveTopicMaker
+from src.chat_session.dependency.proactive_topic_maker import (
+    ActionActivity,
+    ActivityType,
+    ProactiveTopicMaker,
+)
 
 
 class FakeEventStore:
@@ -40,13 +45,41 @@ class FakeEventStore:
     def mark_notified(self, event_id, user_id, trigger_key, character_id):
         self.notified.add((event_id, user_id, trigger_key, character_id))
 
+    def try_claim_notification(self, event_id, user_id, trigger_key, character_id):
+        key = (event_id, user_id, trigger_key, character_id)
+        if key in self.notified:
+            return False
+        self.notified.add(key)
+        return True
+
+    def release_notification_claim(self, event_id, user_id, trigger_key, character_id):
+        key = (event_id, user_id, trigger_key, character_id)
+        existed = key in self.notified
+        self.notified.discard(key)
+        return existed
+
 
 class FakeTopicReplier:
+    def __init__(self, *, fail=False):
+        self.topics = []
+        self.fail = fail
+
+    async def add_topic(self, topic):
+        if self.fail:
+            raise RuntimeError("topic queue unavailable")
+        self.topics.append(topic)
+
+
+class BlockingTopicReplier:
     def __init__(self):
         self.topics = []
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
 
     async def add_topic(self, topic):
         self.topics.append(topic)
+        self.entered.set()
+        await self.release.wait()
 
 
 class FakeChatStream:
@@ -167,3 +200,234 @@ async def test_login_activity_is_released_after_chat_stream_ready():
     assert stream.proactive_idle_checks == 0
     assert len(stream.topic_replier.topics) == 1
     assert "用户已1天未登录" in stream.topic_replier.topics[0].topic_content
+
+
+@pytest.mark.asyncio
+async def test_login_does_not_mark_unsupported_event_before_periodic_dispatch():
+    event_store = FakeEventStore(
+        [
+            (
+                {
+                    "id": "concert-1",
+                    "character": "luotianyi",
+                    "event_type": "concert",
+                    "title": "今晚演唱会",
+                    "description": "",
+                    "is_personal": False,
+                },
+                "day_of_event",
+            )
+        ]
+    )
+    stream = FakeChatStream("luotianyi", idle=True)
+    maker = ProactiveTopicMaker({"proactive_idle_seconds": 0})
+    maker.configure(
+        conversation_service=SimpleNamespace(),
+        database_manager=SimpleNamespace(event_store=event_store),
+        chat_stream_manager=FakeStreamManager([("alice", "luotianyi", stream)]),
+    )
+
+    await maker.dispatch_action(
+        ActionActivity(ActivityType.REGULAR_LOGIN),
+        "alice",
+        stream,
+    )
+
+    assert stream.topic_replier.topics == []
+    assert event_store.notified == set()
+
+    sent = await maker.run_periodic_checks()
+
+    assert sent == 1
+    assert len(stream.topic_replier.topics) == 1
+    assert event_store.notified == {
+        ("concert-1", "alice", "day_of_event", "luotianyi")
+    }
+
+
+@pytest.mark.asyncio
+async def test_login_build_failure_does_not_mark_event(monkeypatch):
+    event_store = FakeEventStore(
+        [
+            (
+                {
+                    "id": "holiday-1",
+                    "character": "luotianyi",
+                    "event_type": "holiday",
+                    "title": "测试节日",
+                    "is_personal": False,
+                },
+                "day_of_event",
+            )
+        ]
+    )
+    stream = FakeChatStream("luotianyi", idle=True)
+    maker = ProactiveTopicMaker({"proactive_idle_seconds": 0})
+    maker.configure(
+        conversation_service=SimpleNamespace(),
+        database_manager=SimpleNamespace(event_store=event_store),
+        chat_stream_manager=FakeStreamManager([]),
+    )
+
+    def fail_build(event_dict):
+        raise ValueError("invalid event payload")
+
+    monkeypatch.setattr(maker, "_build_login_reminder_topic", fail_build)
+
+    await maker.dispatch_action(
+        ActionActivity(ActivityType.REGULAR_LOGIN),
+        "alice",
+        stream,
+    )
+
+    assert stream.topic_replier.topics == []
+    assert event_store.notified == set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dispatch_path", ["login", "periodic"])
+async def test_enqueue_failure_does_not_mark_event(dispatch_path):
+    event_store = FakeEventStore(
+        [
+            (
+                {
+                    "id": "holiday-1",
+                    "character": "luotianyi",
+                    "event_type": "holiday",
+                    "title": "测试节日",
+                    "is_personal": False,
+                },
+                "day_of_event",
+            )
+        ]
+    )
+    stream = FakeChatStream("luotianyi", idle=True)
+    stream.topic_replier = FakeTopicReplier(fail=True)
+    maker = ProactiveTopicMaker({"proactive_idle_seconds": 0})
+    maker.configure(
+        conversation_service=SimpleNamespace(),
+        database_manager=SimpleNamespace(event_store=event_store),
+        chat_stream_manager=FakeStreamManager([("alice", "luotianyi", stream)]),
+    )
+
+    if dispatch_path == "login":
+        with pytest.raises(RuntimeError, match="topic queue unavailable"):
+            await maker.dispatch_action(
+                ActionActivity(ActivityType.REGULAR_LOGIN),
+                "alice",
+                stream,
+            )
+    else:
+        assert await maker.run_periodic_checks() == 0
+
+    assert event_store.notified == set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dispatch_path", ["login", "periodic"])
+async def test_reminders_filter_user_and_character_before_dispatch(dispatch_path):
+    events = [
+        (
+            {
+                "id": "bob-private",
+                "character": "luotianyi",
+                "event_type": "new_song",
+                "title": "Bob的私人事件",
+                "is_personal": True,
+                "target_user_id": "bob",
+            },
+            "day_of_event",
+        ),
+        (
+            {
+                "id": "wrong-character",
+                "character": "miku",
+                "event_type": "new_song",
+                "title": "其他角色事件",
+                "is_personal": True,
+                "target_user_id": "alice",
+            },
+            "day_of_event",
+        ),
+        (
+            {
+                "id": "alice-private",
+                "character": "luotianyi",
+                "event_type": "new_song",
+                "title": "Alice的事件",
+                "is_personal": True,
+                "target_user_id": "alice",
+            },
+            "day_of_event",
+        ),
+    ]
+    event_store = FakeEventStore(events)
+    stream = FakeChatStream("luotianyi", idle=True)
+    maker = ProactiveTopicMaker({"proactive_idle_seconds": 0})
+    maker.configure(
+        conversation_service=SimpleNamespace(),
+        database_manager=SimpleNamespace(event_store=event_store),
+        chat_stream_manager=FakeStreamManager([("alice", "luotianyi", stream)]),
+    )
+
+    if dispatch_path == "login":
+        await maker.dispatch_action(
+            ActionActivity(ActivityType.REGULAR_LOGIN),
+            "alice",
+            stream,
+        )
+    else:
+        assert await maker.run_periodic_checks() == 1
+
+    assert len(stream.topic_replier.topics) == 1
+    content = stream.topic_replier.topics[0].topic_content
+    assert "Alice的事件" in content
+    assert "Bob的私人事件" not in content
+    assert "其他角色事件" not in content
+    assert event_store.notified == {
+        ("alice-private", "alice", "day_of_event", "luotianyi")
+    }
+
+
+@pytest.mark.asyncio
+async def test_login_and_periodic_dispatch_share_one_inflight_claim():
+    events = [
+        (
+            {
+                "id": "holiday-claim",
+                "character": "luotianyi",
+                "event_type": "holiday",
+                "title": "测试节日",
+                "description": "",
+                "is_personal": False,
+            },
+            "day_of_event",
+        )
+    ]
+    event_store = FakeEventStore(events)
+    stream = FakeChatStream("luotianyi", idle=True)
+    stream.topic_replier = BlockingTopicReplier()
+    maker = ProactiveTopicMaker({"proactive_idle_seconds": 0})
+    maker.configure(
+        conversation_service=SimpleNamespace(),
+        database_manager=SimpleNamespace(event_store=event_store),
+        chat_stream_manager=FakeStreamManager([("alice", "luotianyi", stream)]),
+    )
+
+    login = asyncio.create_task(
+        maker.dispatch_action(
+            ActionActivity(ActivityType.REGULAR_LOGIN),
+            "alice",
+            stream,
+        )
+    )
+    await asyncio.wait_for(stream.topic_replier.entered.wait(), timeout=0.5)
+
+    assert await maker.run_periodic_checks() == 0
+
+    stream.topic_replier.release.set()
+    await asyncio.wait_for(login, timeout=0.5)
+    assert len(stream.topic_replier.topics) == 1
+    assert event_store.notified == {
+        ("holiday-claim", "alice", "day_of_event", "luotianyi")
+    }

--- a/server/tests/test_runtime_error_surface.py
+++ b/server/tests/test_runtime_error_surface.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.system.admin import admin_interface
+from src.system.admin.runtime_supervisor import RuntimeSupervisor
+
+
+def _supervisor(tmp_path):
+    return RuntimeSupervisor(
+        config_store=SimpleNamespace(),
+        secret_store=SimpleNamespace(),
+        validator=SimpleNamespace(),
+        observability=SimpleNamespace(),
+    )
+
+
+def test_public_status_exposes_only_stable_error_metadata(tmp_path):
+    supervisor = _supervisor(tmp_path)
+    supervisor.state = "failed"
+    supervisor.last_error = "Traceback (most recent call last): C:\\secret\\runtime.py"
+    supervisor.last_error_code = "RUNTIME_START_FAILED"
+    supervisor.last_error_trace_id = "runtime-test123"
+
+    public = supervisor.public_status()
+
+    assert public["error"] == {
+        "code": "RUNTIME_START_FAILED",
+        "trace_id": "runtime-test123",
+    }
+    assert "last_error" not in public
+    assert "secret" not in str(public)
+    assert "Traceback" not in str(public)
+    assert "Traceback" in supervisor.status()["last_error"]
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_health_uses_public_runtime_status(monkeypatch, tmp_path):
+    supervisor = _supervisor(tmp_path)
+    supervisor.state = "failed"
+    supervisor.last_error = "Traceback: C:\\private\\server.py"
+    supervisor.last_error_code = "RUNTIME_START_FAILED"
+    supervisor.last_error_trace_id = "runtime-test456"
+    shell = SimpleNamespace(
+        auth=SimpleNamespace(status=lambda: {"configured": True}),
+        runtime_supervisor=supervisor,
+        observability=object(),
+    )
+    monkeypatch.setattr(admin_interface, "get_admin_shell", lambda: shell)
+
+    response = await admin_interface.admin_health()
+
+    assert response["runtime"]["error"]["code"] == "RUNTIME_START_FAILED"
+    assert "Traceback" not in str(response)
+    assert "private" not in str(response)

--- a/server/tests/test_runtime_initialization_rollback.py
+++ b/server/tests/test_runtime_initialization_rollback.py
@@ -1,0 +1,265 @@
+import asyncio
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.agent_runtime import agent_runtime as agent_runtime_module
+from src.agent_runtime.agent_runtime import AgentRuntime
+from src.chat_session import chat_session_manager as chat_session_module
+from src.system import system_runtime as runtime_module
+from src.system.database import vector_store as vector_store_module
+from src.system.database.vector_store import ChromaVectorStore
+
+
+@pytest.mark.asyncio
+async def test_late_initialization_failure_rolls_back_resources_and_globals(monkeypatch):
+    calls = []
+    database_ref = {"value": None}
+    observability_ref = {"value": None}
+
+    class FakeObservability:
+        def __init__(self, _config):
+            calls.append("observability_created")
+
+        def close(self):
+            calls.append("observability_closed")
+
+    class FakeLLM:
+        def __init__(self, _config):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+    class FakeDatabase:
+        def __init__(self, _config):
+            calls.append("database_created")
+
+        def wire_dependencies(self, **_kwargs):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+        async def shutdown(self):
+            calls.append("database_stopped")
+
+    class FakeCapability:
+        def __init__(self, _config, _llm):
+            calls.append("tts_started")
+
+        def wire_dependencies(self, **_kwargs):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+        async def stop(self):
+            calls.append("tts_stopped")
+
+    class FakeChatSessions:
+        def __init__(self, _config, _llm, _database):
+            self.chat_stream_manager = object()
+            runtime_module.chat_stream_manager_module.chat_stream_manager = self.chat_stream_manager
+
+        def wire_dependencies(self, **_kwargs):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+        def start_background_services(self):
+            calls.append("chat_started")
+
+        async def stop_background_services(self):
+            calls.append("chat_stop_attempted")
+            raise RuntimeError("chat cleanup failed")
+
+    class FakeWorld:
+        def __init__(self, _config):
+            pass
+
+        def wire_dependencies(self, **_kwargs):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+        def start_background_services(self):
+            calls.append("world_started")
+
+        async def stop_background_services(self):
+            calls.append("world_stopped")
+
+    class FakeAgentRuntime:
+        def __init__(self, *_args):
+            pass
+
+        def wire_dependencies(self, **_kwargs):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+    class FailingUserInterface:
+        def __init__(self, _database):
+            pass
+
+        def wire_dependencies(self, **_kwargs):
+            pass
+
+        def ensure_dependencies(self):
+            pass
+
+        def generate_rsa_keys(self):
+            calls.append("rsa_generation_failed")
+            raise RuntimeError("late initialization failure")
+
+    def set_database(value):
+        database_ref["value"] = value
+        calls.append("database_global_set" if value is not None else "database_global_cleared")
+
+    def set_observability(value):
+        observability_ref["value"] = value
+        calls.append("observability_global_set" if value is not None else "observability_global_cleared")
+
+    monkeypatch.setattr(runtime_module, "ObservabilityService", FakeObservability)
+    monkeypatch.setattr(runtime_module, "LLMService", FakeLLM)
+    monkeypatch.setattr(runtime_module, "DatabaseManager", FakeDatabase)
+    monkeypatch.setattr(runtime_module, "CapabilityManager", FakeCapability)
+    monkeypatch.setattr(runtime_module, "ChatSessionManager", FakeChatSessions)
+    monkeypatch.setattr(runtime_module, "WorldRuntime", FakeWorld)
+    monkeypatch.setattr(runtime_module, "AgentRuntime", FakeAgentRuntime)
+    monkeypatch.setattr(runtime_module, "UserInterface", FailingUserInterface)
+    monkeypatch.setattr(runtime_module, "set_default_database_manager", set_database)
+    monkeypatch.setattr(runtime_module, "set_observability_service", set_observability)
+    monkeypatch.setattr(
+        runtime_module,
+        "install_observability_log_handler",
+        lambda _observability: calls.append("observability_handler_installed"),
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "uninstall_observability_log_handler",
+        lambda: calls.append("observability_handler_uninstalled"),
+    )
+    monkeypatch.setattr(runtime_module, "_system_runtime", None)
+
+    with pytest.raises(RuntimeError, match="late initialization failure"):
+        await runtime_module.SystemRuntime.initialize({})
+
+    assert calls.index("chat_started") < calls.index("rsa_generation_failed")
+    assert calls.index("world_started") < calls.index("rsa_generation_failed")
+    assert calls.index("world_stopped") < calls.index("chat_stop_attempted")
+    assert calls.index("chat_stop_attempted") < calls.index("tts_stopped")
+    assert calls.index("tts_stopped") < calls.index("database_stopped")
+    assert database_ref["value"] is None
+    assert observability_ref["value"] is None
+    assert runtime_module.chat_stream_manager_module.chat_stream_manager is None
+    assert "observability_closed" in calls
+    assert "observability_handler_uninstalled" in calls
+
+
+def test_chat_session_constructor_clears_published_manager_on_late_failure(monkeypatch):
+    class Dependency:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def configure(self, **_kwargs):
+            pass
+
+    class FailingCallManager:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("call manager failed")
+
+    monkeypatch.setattr(chat_session_module, "ConversationService", Dependency)
+    monkeypatch.setattr(chat_session_module, "GlobalSpeakingWorker", Dependency)
+    monkeypatch.setattr(chat_session_module, "ProactiveTopicMaker", Dependency)
+    monkeypatch.setattr(chat_session_module, "ActivityContextProvider", Dependency)
+    monkeypatch.setattr(chat_session_module, "ChatStreamManager", Dependency)
+    monkeypatch.setattr(chat_session_module, "CallStreamManager", FailingCallManager)
+    monkeypatch.setattr(chat_session_module.chat_stream_manager_module, "chat_stream_manager", None)
+
+    with pytest.raises(RuntimeError, match="call manager failed"):
+        chat_session_module.ChatSessionManager({}, object(), object())
+
+    assert chat_session_module.chat_stream_manager_module.chat_stream_manager is None
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_shutdown_closes_owned_vector_store_once(monkeypatch):
+    class FakeVectorStore:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    vector_store = FakeVectorStore()
+    runtime = object.__new__(AgentRuntime)
+    runtime.vector_store = vector_store
+    runtime._shutdown_lock = asyncio.Lock()
+    runtime._shutdown_complete = False
+    monkeypatch.setattr(agent_runtime_module, "_agent_runtime", runtime)
+    monkeypatch.setattr(vector_store_module, "vector_store", vector_store)
+
+    await runtime.shutdown()
+    await runtime.shutdown()
+
+    assert vector_store.close_calls == 1
+    assert agent_runtime_module._agent_runtime is None
+    assert vector_store_module.vector_store is None
+
+
+@pytest.mark.asyncio
+async def test_old_agent_shutdown_preserves_replacement_globals(monkeypatch):
+    class FakeVectorStore:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    old_store = FakeVectorStore()
+    replacement_store = FakeVectorStore()
+    old_runtime = object.__new__(AgentRuntime)
+    old_runtime.vector_store = old_store
+    old_runtime._shutdown_lock = asyncio.Lock()
+    old_runtime._shutdown_complete = False
+    replacement_runtime = object()
+    monkeypatch.setattr(agent_runtime_module, "_agent_runtime", replacement_runtime)
+    monkeypatch.setattr(vector_store_module, "vector_store", replacement_store)
+
+    await old_runtime.shutdown()
+
+    assert old_store.close_calls == 1
+    assert agent_runtime_module._agent_runtime is replacement_runtime
+    assert vector_store_module.vector_store is replacement_store
+
+
+def test_chroma_vector_store_close_is_idempotent():
+    class FakeExecutor:
+        def __init__(self):
+            self.shutdown_calls = []
+
+        def shutdown(self, *, wait, cancel_futures):
+            self.shutdown_calls.append((wait, cancel_futures))
+
+    executor = FakeExecutor()
+    store = object.__new__(ChromaVectorStore)
+    store._executor = executor
+    store._close_lock = threading.Lock()
+    store._closed = False
+
+    store.close()
+    store.close()
+
+    assert executor.shutdown_calls == [(True, False)]
+    assert store._closed is True

--- a/server/tests/test_runtime_shutdown.py
+++ b/server/tests/test_runtime_shutdown.py
@@ -1,0 +1,345 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.chat_session.chat_pipeline.chat_stream import ChatStream
+from src.chat_session.chat_session_manager import ChatSessionManager
+from src.chat_session.chat_stream_manager import ChatStreamManager
+from src.system.admin import admin_shell as admin_shell_module
+from src.system.admin.admin_shell import AdminShell
+from src.system.admin.runtime_supervisor import RuntimeSupervisor
+from src.system.system_runtime import SystemRuntime
+from src.world.world_clock import WorldClock
+
+
+class FakeWebSocket:
+    def __init__(self, failures=0):
+        self.failures = failures
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+        if self.close_calls <= self.failures:
+            raise RuntimeError("close failed")
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_stop_awaits_workers_and_is_idempotent():
+    websocket = FakeWebSocket()
+    connection = SimpleNamespace(user_name="alice", user_uuid="user-1", websocket=websocket)
+    stream = ChatStream({}, connection)
+    release_workers = asyncio.Event()
+    started = [asyncio.Event() for _ in range(5)]
+
+    async def worker(started_event):
+        started_event.set()
+        await release_workers.wait()
+
+    tasks = [asyncio.create_task(worker(event)) for event in started]
+    stream.ingress_helper.ingress_worker_task = tasks[0]
+    stream.topic_planner.processor_task = tasks[1]
+    stream.topic_replier.processor_task = tasks[2]
+    stream.reflection_worker.processor_task = tasks[3]
+    stream.response_sender_task = tasks[4]
+    await asyncio.gather(*(event.wait() for event in started))
+
+    await stream.stop()
+    await stream.stop()
+
+    assert websocket.close_calls == 1
+    assert stream.ws_connection is None
+    assert all(task.done() for task in tasks)
+    assert stream.ingress_helper.ingress_worker_task is None
+    assert stream.topic_planner.processor_task is None
+    assert stream.topic_replier.processor_task is None
+    assert stream.reflection_worker.processor_task is None
+    assert stream.response_sender_task is None
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_stop_retries_after_websocket_close_failure():
+    websocket = FakeWebSocket(failures=1)
+    connection = SimpleNamespace(user_name="alice", user_uuid="user-1", websocket=websocket)
+    stream = ChatStream({}, connection)
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        await stream.stop()
+
+    await stream.stop()
+    await stream.stop()
+
+    assert websocket.close_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_manager_retains_only_failed_stream_for_retry():
+    class RetryableStream:
+        def __init__(self, failures=0):
+            self.failures = failures
+            self.stop_calls = 0
+
+        async def stop(self, *, close_connection):
+            assert close_connection is True
+            self.stop_calls += 1
+            if self.stop_calls <= self.failures:
+                raise RuntimeError("stream stop failed")
+
+    failed_then_ok = RetryableStream(failures=1)
+    healthy = RetryableStream()
+    manager = ChatStreamManager({}, None, None, None, None)
+    manager.user_streams = {
+        ("user-1", "luotianyi"): failed_then_ok,
+        ("user-2", "luotianyi"): healthy,
+    }
+
+    with pytest.raises(RuntimeError, match="stream stop failed"):
+        await manager.stop_all_streams()
+
+    assert manager.user_streams == {("user-1", "luotianyi"): failed_then_ok}
+    assert healthy.stop_calls == 1
+
+    await manager.stop_all_streams()
+
+    assert manager.user_streams == {}
+    assert failed_then_ok.stop_calls == 2
+    assert healthy.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_session_shutdown_attempts_all_owned_services():
+    calls = []
+
+    class Streams:
+        async def stop_all_streams(self):
+            calls.append("streams")
+            raise RuntimeError("stream failure")
+
+    class Calls:
+        async def stop_background_services(self):
+            calls.append("calls")
+
+    class Speaking:
+        async def stop(self):
+            calls.append("speaking")
+
+    manager = object.__new__(ChatSessionManager)
+    manager.chat_stream_manager = Streams()
+    manager.call_stream_manager = Calls()
+    manager.global_speaking_worker = Speaking()
+
+    with pytest.raises(RuntimeError, match="Chat session shutdown failed"):
+        await manager.stop_background_services()
+
+    assert calls == ["streams", "calls", "speaking"]
+
+
+class OrderedAsyncService:
+    def __init__(self, calls, name, method_name, failures=0):
+        self.calls = calls
+        self.name = name
+        self.failures = failures
+        self.call_count = 0
+        setattr(self, method_name, self.stop)
+
+    async def stop(self):
+        self.calls.append(self.name)
+        self.call_count += 1
+        if self.call_count <= self.failures:
+            raise RuntimeError(f"{self.name} failed")
+
+
+@pytest.mark.asyncio
+async def test_system_runtime_shutdown_is_ordered_idempotent_and_retryable():
+    calls = []
+    chat = OrderedAsyncService(calls, "chat", "stop_background_services")
+    world = OrderedAsyncService(calls, "world", "stop_background_services", failures=1)
+    agent = OrderedAsyncService(calls, "agent", "shutdown")
+    capability = OrderedAsyncService(calls, "capability", "stop")
+    database = OrderedAsyncService(calls, "database", "shutdown")
+    runtime = SystemRuntime(
+        user_interface=object(),
+        world=world,
+        database_manager=database,
+        agent_runtime=agent,
+        capability_manager=capability,
+        chat_session_manager=chat,
+        llm_service=object(),
+        observability=object(),
+        owns_observability=False,
+    )
+
+    with pytest.raises(RuntimeError, match="world failed"):
+        await runtime.shutdown()
+
+    assert calls == ["world"]
+
+    await runtime.shutdown()
+    await runtime.shutdown()
+
+    assert calls == ["world", "world", "chat", "agent", "capability", "database"]
+    assert runtime._shutdown_complete is True
+
+
+@pytest.mark.asyncio
+async def test_world_clock_stop_is_bounded_and_retains_owned_sync_task_for_retry():
+    import threading
+
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def blocking_action():
+        nonlocal calls
+        calls += 1
+        started.set()
+        release.wait(timeout=2)
+
+    clock = WorldClock()
+    clock.stop_timeout_seconds = 0.02
+    clock.register_interval_action(
+        "blocking",
+        interval_seconds=60,
+        action=blocking_action,
+        run_immediately=True,
+    )
+    clock.start()
+    assert await asyncio.to_thread(started.wait, 1)
+
+    with pytest.raises(RuntimeError, match="still stopping"):
+        await clock.stop()
+
+    assert calls == 1
+    assert clock._tasks
+
+    release.set()
+    await clock.stop()
+
+    assert calls == 1
+    assert clock._tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_admin_shell_keeps_retry_handle_until_runtime_cleanup_succeeds(monkeypatch):
+    events = []
+
+    class FlakySupervisor:
+        def __init__(self):
+            self.has_runtime = True
+            self.stop_calls = 0
+
+        async def stop(self):
+            self.stop_calls += 1
+            if self.stop_calls == 1:
+                return {"state": "failed", "last_error": "cleanup failed"}
+            self.has_runtime = False
+            return {"state": "stopped", "last_error": None}
+
+    class Observability:
+        def close(self):
+            events.append("observability_closed")
+
+    shell = object.__new__(AdminShell)
+    shell.runtime_supervisor = FlakySupervisor()
+    shell.observability = Observability()
+    monkeypatch.setattr(admin_shell_module, "_admin_shell", shell)
+    monkeypatch.setattr(
+        admin_shell_module,
+        "set_observability_service",
+        lambda value: events.append(("observability_global", value)),
+    )
+    monkeypatch.setattr(
+        admin_shell_module,
+        "uninstall_observability_log_handler",
+        lambda: events.append("handler_uninstalled"),
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await admin_shell_module.shutdown_admin_shell()
+
+    assert admin_shell_module._admin_shell is shell
+    assert events == []
+
+    await admin_shell_module.shutdown_admin_shell()
+
+    assert admin_shell_module._admin_shell is None
+    assert events == [
+        "observability_closed",
+        ("observability_global", None),
+        "handler_uninstalled",
+    ]
+
+
+def make_supervisor():
+    return RuntimeSupervisor(
+        config_store=object(),
+        secret_store=object(),
+        validator=object(),
+        observability=object(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_supervisor_retains_runtime_until_retry_succeeds():
+    class FlakyRuntime:
+        def __init__(self):
+            self.shutdown_calls = 0
+
+        async def shutdown(self):
+            self.shutdown_calls += 1
+            if self.shutdown_calls == 1:
+                raise RuntimeError("shutdown failed")
+
+    runtime = FlakyRuntime()
+    supervisor = make_supervisor()
+    supervisor._runtime = runtime
+    supervisor.state = "running"
+
+    failed = await supervisor.stop()
+
+    assert failed["state"] == "failed"
+    assert supervisor._runtime is runtime
+    assert supervisor.runtime is None
+
+    blocked_start = await supervisor.start()
+
+    assert blocked_start["state"] == "failed"
+    assert supervisor._runtime is runtime
+
+    stopped = await supervisor.stop()
+
+    assert stopped["state"] == "stopped"
+    assert supervisor._runtime is None
+    assert runtime.shutdown_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_supervisor_restart_does_not_start_after_failed_shutdown():
+    class FailingRuntime:
+        async def shutdown(self):
+            raise RuntimeError("shutdown failed")
+
+    supervisor = make_supervisor()
+    supervisor._runtime = FailingRuntime()
+    supervisor.state = "running"
+    start_calls = 0
+
+    async def forbidden_start():
+        nonlocal start_calls
+        start_calls += 1
+        return supervisor.status()
+
+    supervisor.start = forbidden_start
+
+    status = await supervisor.restart()
+
+    assert status["state"] == "failed"
+    assert supervisor._runtime is not None
+    assert start_calls == 0

--- a/server/tests/test_streaming_tts_shutdown.py
+++ b/server/tests/test_streaming_tts_shutdown.py
@@ -1,0 +1,404 @@
+import asyncio
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.agent.main_chat import OneSentenceChat, SongSegmentChat
+from src.capabilities import capability_manager as capability_manager_module
+from src.capabilities.speech import speech as speech_module
+from src.capabilities.speech import tts_module as tts_module_module
+from src.capabilities.speech.speech import SpeechCapability
+from src.capabilities.speech.tts_server import TTSServer
+from src.chat_session.dependency.global_speaking_worker import (
+    GlobalSpeakingWorker,
+    SpeakingJob,
+    _iter_sync_gen_in_executor,
+)
+
+
+def test_speaking_queue_size_is_configurable_and_never_unbounded():
+    assert GlobalSpeakingWorker({}).queue.maxsize == 512
+    assert GlobalSpeakingWorker({"queue_maxsize": 7}).queue.maxsize == 7
+    assert GlobalSpeakingWorker({"queue_maxsize": 0}).queue.maxsize == 1
+
+
+@pytest.mark.asyncio
+async def test_executor_generator_cancellation_waits_for_next_and_closes_generator():
+    started = threading.Event()
+    release = threading.Event()
+    closed = threading.Event()
+
+    def source():
+        try:
+            started.set()
+            release.wait(timeout=2)
+            yield "chunk"
+        finally:
+            closed.set()
+
+    async def consume():
+        async for _chunk in _iter_sync_gen_in_executor(source()):
+            pass
+
+    task = asyncio.create_task(consume())
+    assert await asyncio.to_thread(started.wait, 1)
+
+    task.cancel()
+    await asyncio.sleep(0.02)
+
+    assert not task.done(), "cancellation must wait for the executor's active next() call"
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_speaking_worker_stop_signals_stream_then_waits_before_backend_stop():
+    started = threading.Event()
+    release = threading.Event()
+    events = []
+
+    class FakeServer:
+        def __init__(self):
+            self.stop_calls = 0
+
+        def request_stop(self):
+            events.append("stop_requested")
+            release.set()
+
+        def stop(self):
+            self.stop_calls += 1
+            events.append("backend_stopped")
+
+    server = FakeServer()
+
+    class FakeModule:
+        tts_server = server
+
+        def stream_synthesize_speech_with_tone(self, _text, _tone):
+            try:
+                started.set()
+                release.wait(timeout=2)
+                yield b"audio"
+            finally:
+                events.append("generator_closed")
+
+        @staticmethod
+        def encode_audio_to_base64(_audio):
+            return "audio"
+
+    speech = object.__new__(SpeechCapability)
+    speech.tts_config = {}
+    speech.tts_module = {"luotianyi": FakeModule()}
+    speech._stop_lock = asyncio.Lock()
+    speech._stopped_server_ids = set()
+    speech._stop_signaled_server_ids = set()
+
+    worker = GlobalSpeakingWorker({})
+    worker.set_capabilities(SimpleNamespace(speech=speech))
+
+    async def send_reply(_response):
+        pass
+
+    await worker.enqueue(
+        SpeakingJob(
+            send_reply_callback=send_reply,
+            job_content=OneSentenceChat(content="hello", sound_content="hello", tone="normal"),
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+
+    await worker.stop()
+    await speech.stop()
+
+    assert worker.worker_task is None
+    assert events == ["stop_requested", "generator_closed", "backend_stopped"]
+    assert server.stop_calls == 1
+    with pytest.raises(RuntimeError, match="cannot be restarted"):
+        worker.start_if_needed()
+
+
+@pytest.mark.asyncio
+async def test_speaking_worker_closes_generator_when_cancelled_during_send():
+    callback_started = asyncio.Event()
+    release_stream = threading.Event()
+    generator_closed = threading.Event()
+
+    class FakeSpeech:
+        def request_stop(self):
+            release_stream.set()
+
+        def say_stream(self, _character, _text, _tone):
+            try:
+                yield "audio"
+                release_stream.wait(timeout=2)
+                yield "late-audio"
+            finally:
+                generator_closed.set()
+
+    worker = GlobalSpeakingWorker({})
+    worker.set_capabilities(SimpleNamespace(speech=FakeSpeech()))
+
+    async def blocked_send(_response):
+        callback_started.set()
+        await asyncio.Event().wait()
+
+    await worker.enqueue(
+        SpeakingJob(
+            send_reply_callback=blocked_send,
+            job_content=OneSentenceChat(content="hello", sound_content="hello", tone="normal"),
+        )
+    )
+    await asyncio.wait_for(callback_started.wait(), timeout=1)
+
+    await worker.stop()
+
+    assert generator_closed.is_set()
+
+
+def test_tts_server_refuses_restart_while_old_request_is_active(tmp_path):
+    server = TTSServer(str(tmp_path / "tts.yaml"))
+    server._active_requests = 1
+
+    with pytest.raises(RuntimeError, match="requests are still active"):
+        server.start()
+
+
+@pytest.mark.asyncio
+async def test_tts_start_waits_until_stop_finishes_closing_old_queues(tmp_path):
+    join_started = threading.Event()
+    release_join = threading.Event()
+    events = []
+
+    class FakeProcess:
+        def __init__(self):
+            self.alive = True
+
+        def is_alive(self):
+            return self.alive
+
+        def join(self, timeout):
+            _ = timeout
+            join_started.set()
+            release_join.wait(timeout=2)
+            self.alive = False
+
+        def terminate(self):
+            self.alive = False
+
+    class FakeQueue:
+        def put(self, _message):
+            pass
+
+        def close(self):
+            events.append("queue_closed")
+
+        def cancel_join_thread(self):
+            pass
+
+    class FakeEvent:
+        def set(self):
+            pass
+
+    server = TTSServer(str(tmp_path / "tts.yaml"))
+    server.server_process = FakeProcess()
+    server.request_queue = FakeQueue()
+    server.response_queue = FakeQueue()
+    server.stop_event = FakeEvent()
+    server._start = lambda: events.append("start_body")
+
+    stop_task = asyncio.create_task(asyncio.to_thread(server.stop))
+    assert await asyncio.to_thread(join_started.wait, 1)
+    start_task = asyncio.create_task(asyncio.to_thread(server.start))
+    await asyncio.sleep(0.02)
+
+    assert not start_task.done()
+
+    release_join.set()
+    await stop_task
+    await start_task
+
+    assert events == ["queue_closed", "queue_closed", "start_body"]
+
+
+def test_partial_speech_construction_stops_already_started_tts(monkeypatch):
+    events = []
+
+    class FakeServer:
+        def request_stop(self):
+            events.append("stop_requested")
+
+        def stop(self):
+            events.append("backend_stopped")
+
+    calls = 0
+
+    def init_module(_config):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("second TTS failed")
+        return SimpleNamespace(tts_server=FakeServer())
+
+    monkeypatch.setattr(speech_module, "init_tts_module", init_module)
+
+    with pytest.raises(RuntimeError, match="second TTS failed"):
+        SpeechCapability({"first": {}, "second": {}})
+
+    assert events == ["stop_requested", "backend_stopped"]
+
+
+def test_tts_module_factory_stops_server_when_module_construction_fails(monkeypatch):
+    events = []
+
+    class FakeServer:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            events.append("server_started")
+
+        def stop(self):
+            events.append("server_stopped")
+
+    class FailingModule:
+        def __init__(self, **_kwargs):
+            raise RuntimeError("module failed")
+
+    monkeypatch.setattr(tts_module_module, "TTSServer", FakeServer)
+    monkeypatch.setattr(tts_module_module, "TTSModule", FailingModule)
+
+    with pytest.raises(RuntimeError, match="module failed"):
+        tts_module_module.init_tts_module({})
+
+    assert events == ["server_started", "server_stopped"]
+
+
+def test_tts_module_factory_rolls_back_server_start_failure(monkeypatch):
+    events = []
+
+    class FakeServer:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            events.append("server_start_attempted")
+            raise RuntimeError("server start failed")
+
+        def stop(self):
+            events.append("server_stopped")
+
+    monkeypatch.setattr(tts_module_module, "TTSServer", FakeServer)
+
+    with pytest.raises(RuntimeError, match="server start failed"):
+        tts_module_module.init_tts_module({})
+
+    assert events == ["server_start_attempted", "server_stopped"]
+
+
+def test_capability_construction_failure_rolls_back_speech(monkeypatch):
+    events = []
+
+    class FakeSpeech:
+        def __init__(self, _config):
+            events.append("speech_started")
+
+        def _abort_initialization(self):
+            events.append("speech_stopped")
+
+    class FailingSinging:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("singing failed")
+
+    monkeypatch.setattr(capability_manager_module, "SpeechCapability", FakeSpeech)
+    monkeypatch.setattr(capability_manager_module, "SingingCapability", FailingSinging)
+
+    with pytest.raises(RuntimeError, match="singing failed"):
+        capability_manager_module.CapabilityManager({}, object())
+
+    assert events == ["speech_started", "speech_stopped"]
+
+
+@pytest.mark.asyncio
+async def test_speaking_worker_stop_waits_for_owned_singing_thread():
+    started = threading.Event()
+    release = threading.Event()
+
+    class FakeSpeech:
+        def request_stop(self):
+            pass
+
+    class FakeSinging:
+        def sing(self, _character, _song, _segment):
+            started.set()
+            release.wait(timeout=2)
+            return b"audio"
+
+    worker = GlobalSpeakingWorker({})
+    worker.set_capabilities(SimpleNamespace(speech=FakeSpeech(), singing=FakeSinging()))
+
+    async def send_reply(_response):
+        pass
+
+    await worker.enqueue(
+        SpeakingJob(
+            send_reply_callback=send_reply,
+            job_content=SongSegmentChat(song="song", lyrics="lyrics", segment="segment"),
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+
+    stop_task = asyncio.create_task(worker.stop())
+    await asyncio.sleep(0.02)
+    assert not stop_task.done()
+
+    release.set()
+    await stop_task
+    assert worker.worker_task is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_send_retries_until_callback_accepts_once():
+    attempts = 0
+    accepted = []
+
+    class FakeSpeech:
+        def request_stop(self):
+            pass
+
+    worker = GlobalSpeakingWorker(
+        {
+            "terminal_send_max_attempts": 2,
+            "terminal_send_retry_delay_seconds": 0,
+        }
+    )
+    worker.set_capabilities(SimpleNamespace(speech=FakeSpeech()))
+    content = OneSentenceChat(content="text", expression="smile")
+    content.sound_content = ""
+
+    async def flaky_send(response):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary send failure")
+        accepted.append(response)
+
+    await worker.enqueue(SpeakingJob(send_reply_callback=flaky_send, job_content=content))
+    await asyncio.wait_for(worker.queue.join(), timeout=1)
+    await worker.stop()
+
+    assert attempts == 2
+    assert len(accepted) == 1
+    assert accepted[0].is_final_package is True
+    assert accepted[0].text == "text"

--- a/server/tests/test_tts_lifecycle.py
+++ b/server/tests/test_tts_lifecycle.py
@@ -1,0 +1,218 @@
+import asyncio
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+server_root = str(Path(__file__).resolve().parent.parent)
+if server_root not in sys.path:
+    sys.path.insert(0, server_root)
+
+from src.capabilities.capability_manager import CapabilityManager
+from src.capabilities.speech.speech import SpeechCapability
+from src.capabilities.speech.tts_server import TTSServer
+
+
+def make_speech(modules):
+    speech = object.__new__(SpeechCapability)
+    speech.tts_config = {}
+    speech.tts_module = modules
+    speech._stop_lock = asyncio.Lock()
+    speech._stopped_server_ids = set()
+    speech._stop_signaled_server_ids = set()
+    speech._stop_tasks = {}
+    speech.stop_timeout_seconds = 30.0
+    return speech
+
+
+class RecordingServer:
+    def __init__(self, failures=0):
+        self.failures = failures
+        self.stop_calls = 0
+        self.stop_thread_ids = []
+
+    def stop(self):
+        self.stop_calls += 1
+        self.stop_thread_ids.append(threading.get_ident())
+        if self.stop_calls <= self.failures:
+            raise RuntimeError("stop failed")
+
+
+@pytest.mark.asyncio
+async def test_shared_tts_server_is_stopped_once_in_worker_thread():
+    server = RecordingServer()
+    speech = make_speech(
+        {
+            "luotianyi": SimpleNamespace(tts_server=server),
+            "yanhe": SimpleNamespace(tts_server=server),
+        }
+    )
+    event_loop_thread_id = threading.get_ident()
+
+    await speech.stop()
+    await speech.stop()
+
+    assert server.stop_calls == 1
+    assert len(server.stop_thread_ids) == 1
+    assert server.stop_thread_ids[0] != event_loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_tts_stop_retries_only_failed_servers_and_preserves_shared_ownership():
+    healthy_server = RecordingServer()
+    flaky_server = RecordingServer(failures=1)
+    speech = make_speech(
+        {
+            "luotianyi": SimpleNamespace(tts_server=healthy_server),
+            "yanhe": SimpleNamespace(tts_server=flaky_server),
+            "yuezhengling": SimpleNamespace(tts_server=flaky_server),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="TTS shutdown failed"):
+        await speech.stop()
+
+    assert healthy_server.stop_calls == 1
+    assert flaky_server.stop_calls == 1
+
+    await speech.stop()
+    await speech.stop()
+
+    assert healthy_server.stop_calls == 1
+    assert flaky_server.stop_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_capability_manager_stop_is_idempotent_and_retryable():
+    class FlakySpeech:
+        def __init__(self):
+            self.stop_calls = 0
+
+        async def stop(self):
+            self.stop_calls += 1
+            if self.stop_calls == 1:
+                raise RuntimeError("speech stop failed")
+
+    manager = object.__new__(CapabilityManager)
+    manager.speech = FlakySpeech()
+    manager._stop_lock = asyncio.Lock()
+    manager._stopped = False
+
+    with pytest.raises(RuntimeError, match="speech stop failed"):
+        await manager.stop()
+    await manager.stop()
+    await manager.stop()
+
+    assert manager.speech.stop_calls == 2
+    assert manager._stopped is True
+
+
+@pytest.mark.asyncio
+async def test_speech_stop_cancellation_waits_for_owned_thread():
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingServer:
+        def __init__(self):
+            self.stop_calls = 0
+
+        def request_stop(self):
+            pass
+
+        def stop(self):
+            self.stop_calls += 1
+            started.set()
+            release.wait(timeout=2)
+
+    server = BlockingServer()
+    speech = make_speech({"luotianyi": SimpleNamespace(tts_server=server)})
+    stop_task = asyncio.create_task(speech.stop())
+    assert await asyncio.to_thread(started.wait, 1)
+
+    stop_task.cancel()
+    await asyncio.sleep(0.02)
+    assert not stop_task.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    await speech.stop()
+    assert server.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_speech_stop_timeout_retains_backend_task_for_retry():
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingServer:
+        def __init__(self):
+            self.stop_calls = 0
+
+        def request_stop(self):
+            pass
+
+        def stop(self):
+            self.stop_calls += 1
+            started.set()
+            release.wait(timeout=2)
+
+    server = BlockingServer()
+    speech = make_speech({"luotianyi": SimpleNamespace(tts_server=server)})
+    speech.stop_timeout_seconds = 0.02
+
+    with pytest.raises(RuntimeError, match="still running"):
+        await speech.stop()
+
+    assert started.is_set()
+    assert server.stop_calls == 1
+
+    release.set()
+    await speech.stop()
+
+    assert server.stop_calls == 1
+    assert speech._stop_tasks == {}
+
+
+def test_tts_server_retains_handles_when_process_cannot_be_stopped(tmp_path):
+    class StubbornProcess:
+        def __init__(self):
+            self.terminate_calls = 0
+
+        def is_alive(self):
+            return True
+
+        def join(self, timeout):
+            _ = timeout
+
+        def terminate(self):
+            self.terminate_calls += 1
+
+    class FakeQueue:
+        def close(self):
+            raise AssertionError("queues must remain available for a retry")
+
+    class FakeEvent:
+        def set(self):
+            pass
+
+    process = StubbornProcess()
+    request_queue = FakeQueue()
+    response_queue = FakeQueue()
+    server = TTSServer(str(tmp_path / "tts.yaml"))
+    server.server_process = process
+    server.request_queue = request_queue
+    server.response_queue = response_queue
+    server.stop_event = FakeEvent()
+
+    with pytest.raises(RuntimeError, match="still alive"):
+        server.stop(force=True)
+
+    assert process.terminate_calls == 1
+    assert server.server_process is process
+    assert server.request_queue is request_queue
+    assert server.response_queue is response_queue

--- a/server/tests/test_websocket_auth_limits.py
+++ b/server/tests/test_websocket_auth_limits.py
@@ -1,0 +1,142 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.system.user_interface.types import WSEventType, WSMessage
+from src.system.user_interface.websocket_service import WebSocketConnection, WebSocketService
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+        self.close_codes = []
+
+    async def send_json(self, event):
+        self.sent.append(event)
+
+    async def close(self, code):
+        self.close_codes.append(code)
+
+    async def accept(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_websocket_auth_times_out_and_closes_connection(monkeypatch):
+    service = WebSocketService()
+    websocket = FakeWebSocket()
+    connection = WebSocketConnection(websocket, user_uuid=None, user_name=None)
+
+    async def never_receive(_connection):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(service, "try_recv_client_msg", never_receive)
+
+    result = await connection.auth(service, object(), timeout_seconds=0.01)
+
+    assert result is False
+    assert websocket.close_codes == [1008]
+    assert websocket.sent[-1]["payload"]["code"] == "AUTH_TIMEOUT"
+
+
+@pytest.mark.asyncio
+async def test_websocket_auth_counts_non_auth_frames(monkeypatch):
+    service = WebSocketService()
+    websocket = FakeWebSocket()
+    connection = WebSocketConnection(websocket, user_uuid=None, user_name=None)
+    attempts = 0
+
+    async def receive_non_auth(_connection):
+        nonlocal attempts
+        attempts += 1
+        return WSMessage(event_type=WSEventType.HB_PING.value, payload={})
+
+    monkeypatch.setattr(service, "try_recv_client_msg", receive_non_auth)
+
+    result = await connection.auth(service, object(), timeout_seconds=1, max_attempts=3)
+
+    assert result is False
+    assert attempts == 3
+    assert websocket.close_codes == [1008]
+    assert websocket.sent[-1]["payload"]["code"] == "AUTH_ATTEMPTS_EXCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_websocket_auth_succeeds_within_attempt_limit(monkeypatch):
+    service = WebSocketService()
+    websocket = FakeWebSocket()
+    connection = WebSocketConnection(websocket, user_uuid=None, user_name=None)
+    auth_event = WSMessage(
+        event_type=WSEventType.USER_AUTH.value,
+        payload={"username": "alice", "token": "valid-token"},
+    )
+
+    async def receive_auth(_connection):
+        return auth_event
+
+    async def accept_auth(_connection, _database, _event):
+        connection.set_user("user-1", "alice")
+        return True
+
+    monkeypatch.setattr(service, "try_recv_client_msg", receive_auth)
+    monkeypatch.setattr(service, "handle_auth_event", accept_auth)
+
+    result = await connection.auth(service, object(), timeout_seconds=1, max_attempts=2)
+
+    assert result is True
+    assert connection.user_uuid == "user-1"
+    assert websocket.close_codes == []
+
+
+@pytest.mark.asyncio
+async def test_auth_negotiates_negative_ack_capability():
+    service = WebSocketService()
+    websocket = FakeWebSocket()
+    connection = WebSocketConnection(websocket, user_uuid=None, user_name=None)
+    database = SimpleNamespace(
+        check_message_token=lambda _username, _token: (True, "user-1"),
+    )
+    event = WSMessage(
+        event_type=WSEventType.USER_AUTH.value,
+        payload={
+            "username": "alice",
+            "token": "valid-token",
+            "capabilities": ["negative_ack_v1", "unknown"],
+        },
+        client_msg_id="auth-1",
+    )
+
+    assert await service.handle_auth_event(connection, database, event) is True
+    assert connection.capabilities == {"negative_ack_v1"}
+    assert websocket.sent[-1]["payload"]["capabilities"] == ["negative_ack_v1"]
+
+
+@pytest.mark.asyncio
+async def test_chat_route_does_not_register_stream_after_auth_rejection(monkeypatch):
+    import server_main
+
+    registrations = []
+    runtime = SimpleNamespace(
+        websocket_service=SimpleNamespace(
+            send_system_ready_event=lambda _websocket: asyncio.sleep(0),
+        ),
+        gcsm=SimpleNamespace(
+            get_or_register_chat_stream=lambda *_args, **_kwargs: registrations.append(True),
+        ),
+        database_manager=object(),
+    )
+    monkeypatch.setattr(
+        server_main,
+        "get_admin_shell",
+        lambda: SimpleNamespace(runtime_supervisor=SimpleNamespace(runtime=runtime)),
+    )
+
+    async def reject_auth(self, _service, _database):
+        return False
+
+    monkeypatch.setattr(WebSocketConnection, "auth", reject_auth)
+
+    await server_main.chat_ws(FakeWebSocket())
+
+    assert registrations == []

--- a/server/tests/test_websocket_delivery.py
+++ b/server/tests/test_websocket_delivery.py
@@ -1,0 +1,233 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.agent_runtime.character_registry import CharacterRegistry
+from src.system.user_interface.types import WSEventType, WSMessage
+from src.system.user_interface.websocket_service import (
+    ChatEventAcceptance,
+    WebSocketConnection,
+    WebSocketService,
+)
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_json(self, event):
+        self.sent.append(event)
+
+
+class CapacityStream:
+    def __init__(self, capacity: int, *, character_id="luotianyi", system_runtime=None):
+        self.capacity = capacity
+        self.events = []
+        self.character_id = character_id
+        self.system_runtime = system_runtime
+
+    def try_feed_event(self, event):
+        if len(self.events) >= self.capacity:
+            return False
+        self.events.append(event)
+        return True
+
+
+def _message(client_msg_id="msg-1"):
+    return WSMessage(
+        event_type=WSEventType.USER_TEXT.value,
+        payload={"message": "hello"},
+        client_msg_id=client_msg_id,
+    )
+
+
+def _connection(*, negative_ack=False):
+    connection = WebSocketConnection(
+        FakeWebSocket(),
+        user_uuid="user-1",
+        user_name="alice",
+    )
+    if negative_ack:
+        connection.capabilities.add("negative_ack_v1")
+    return connection
+
+
+def test_successful_acceptance_is_marked_only_after_enqueue():
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(capacity=1)
+    event = _message()
+
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.ACCEPTED
+    assert len(stream.events) == 1
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.DUPLICATE
+    assert len(stream.events) == 1
+
+
+def test_overload_is_not_marked_and_same_id_can_retry():
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(capacity=0)
+    event = _message()
+
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.OVERLOADED
+    assert service.is_duplicate_client_message(connection, event) is False
+
+    stream.capacity = 1
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.ACCEPTED
+    assert len(stream.events) == 1
+
+
+def test_bad_message_is_not_marked(monkeypatch):
+    service = WebSocketService()
+    connection = _connection()
+    event = _message()
+
+    def fail_conversion(*_args, **_kwargs):
+        raise ValueError("bad payload")
+
+    monkeypatch.setattr(service, "convert_to_chat_input_event", fail_conversion)
+
+    assert service.try_accept_chat_event(connection, event, CapacityStream(1)) == ChatEventAcceptance.BAD_MESSAGE
+    assert service.is_duplicate_client_message(connection, event) is False
+
+
+def test_missing_or_oversized_client_message_id_is_rejected():
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(1)
+
+    assert service.try_accept_chat_event(connection, _message(None), stream) == ChatEventAcceptance.BAD_MESSAGE
+    assert service.try_accept_chat_event(connection, _message("x" * 129), stream) == ChatEventAcceptance.BAD_MESSAGE
+    assert stream.events == []
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload"),
+    [
+        (WSEventType.USER_TEXT.value, {}),
+        (WSEventType.USER_TEXT.value, {"message": "   "}),
+        (WSEventType.USER_IMAGE.value, {"image_base64": "%%%", "mime_type": "image/png"}),
+        (WSEventType.USER_IMAGE.value, {"image_base64": "aGVsbG8="}),
+        (WSEventType.USER_TYPING.value, {}),
+        (WSEventType.USER_TYPING.value, {"text_length": True}),
+        (WSEventType.USER_TOUCH.value, {}),
+        (WSEventType.USER_IMAGE_SELECTING.value, []),
+    ],
+)
+def test_real_invalid_payloads_are_rejected_before_mark(event_type, payload):
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(1)
+    event = WSMessage(event_type=event_type, payload=payload, client_msg_id="bad-1")
+
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.BAD_MESSAGE
+    assert service.is_duplicate_client_message(connection, event) is False
+    assert stream.events == []
+
+
+def test_corrected_payload_can_reuse_id_after_schema_rejection():
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(1)
+    event = WSMessage(
+        event_type=WSEventType.USER_TEXT.value,
+        payload={"message": ""},
+        client_msg_id="corrected-1",
+    )
+
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.BAD_MESSAGE
+    event.payload = {"message": "hello"}
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.ACCEPTED
+
+
+def test_default_target_uses_stream_character_and_invalid_targets_fail_fast():
+    registry = CharacterRegistry(
+        {
+            "characters": {
+                "miku": {"enabled": True, "default_target": True},
+                "disabled": {"enabled": False},
+            }
+        }
+    )
+    runtime = SimpleNamespace(
+        agent_runtime=SimpleNamespace(character_registry=registry),
+    )
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(3, character_id="miku", system_runtime=runtime)
+
+    assert service.try_accept_chat_event(connection, _message("default-1"), stream) == ChatEventAcceptance.ACCEPTED
+    assert stream.events[0].payload["target_character_ids"] == ["miku"]
+
+    for target in ("unknown", "disabled"):
+        event = WSMessage(
+            event_type=WSEventType.USER_TEXT.value,
+            payload={"message": "hello", "target_character_id": target},
+            client_msg_id=f"target-{target}",
+        )
+        assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.BAD_MESSAGE
+        assert service.is_duplicate_client_message(connection, event) is False
+
+
+def test_single_string_target_is_normalized_before_registry_validation():
+    registry = CharacterRegistry(
+        {"characters": {"miku": {"enabled": True, "default_target": True}}}
+    )
+    runtime = SimpleNamespace(
+        agent_runtime=SimpleNamespace(character_registry=registry),
+    )
+    service = WebSocketService()
+    connection = _connection()
+    stream = CapacityStream(1, character_id="miku", system_runtime=runtime)
+    event = WSMessage(
+        event_type=WSEventType.USER_TEXT.value,
+        payload={"message": "hello", "target_character_ids": "miku"},
+        client_msg_id="string-target-1",
+    )
+
+    assert service.try_accept_chat_event(connection, event, stream) == ChatEventAcceptance.ACCEPTED
+    assert stream.events[0].payload["target_character_ids"] == ["miku"]
+
+
+@pytest.mark.asyncio
+async def test_positive_and_overload_ack_payloads_are_explicit():
+    service = WebSocketService()
+    connection = _connection(negative_ack=True)
+    event = _message()
+
+    await service.send_ack_event(connection, event)
+    await service.send_nack_event(
+        connection,
+        event,
+        code="OVERLOADED",
+        message="chat ingress queue is full",
+        retryable=True,
+    )
+
+    assert connection.websocket.sent[0]["payload"]["ok"] is True
+    assert connection.websocket.sent[1]["payload"] == {
+        "ok": False,
+        "received_event_type": WSEventType.USER_TEXT.value,
+        "code": "OVERLOADED",
+        "message": "chat ingress queue is full",
+        "retryable": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_legacy_client_receives_server_error_instead_of_negative_ack():
+    service = WebSocketService()
+    connection = _connection()
+    event = _message()
+
+    await service.send_nack_event(
+        connection,
+        event,
+        code="OVERLOADED",
+        message="chat ingress queue is full",
+        retryable=True,
+    )
+
+    assert connection.websocket.sent[0]["type"] == WSEventType.SERVER_ERROR.value
+    assert "ok" not in connection.websocket.sent[0]["payload"]

--- a/server/tests/test_websocket_idempotency.py
+++ b/server/tests/test_websocket_idempotency.py
@@ -33,6 +33,8 @@ def test_websocket_service_deduplicates_recent_client_message_per_user():
     connection = WebSocketConnection(FakeWebSocket(), user_uuid="user-a", user_name="alice")
 
     assert service.is_duplicate_client_message(connection, _message("msg-1")) is False
+    assert service.is_duplicate_client_message(connection, _message("msg-1")) is False
+    assert service.mark_client_message_accepted(connection, _message("msg-1")) is True
     assert service.is_duplicate_client_message(connection, _message("msg-1")) is True
     assert service.is_duplicate_client_message(connection, _message("msg-2")) is False
 
@@ -42,8 +44,8 @@ def test_websocket_service_dedup_cache_is_scoped_by_user():
     user_a = WebSocketConnection(FakeWebSocket(), user_uuid="user-a", user_name="alice")
     user_b = WebSocketConnection(FakeWebSocket(), user_uuid="user-b", user_name="bob")
 
-    assert service.is_duplicate_client_message(user_a, _message("same-id")) is False
-    assert service.is_duplicate_client_message(user_b, _message("same-id")) is False
+    assert service.mark_client_message_accepted(user_a, _message("same-id")) is True
+    assert service.mark_client_message_accepted(user_b, _message("same-id")) is True
     assert service.is_duplicate_client_message(user_a, _message("same-id")) is True
     assert service.is_duplicate_client_message(user_b, _message("same-id")) is True
 
@@ -61,6 +63,7 @@ async def test_duplicate_ack_marks_duplicate_payload():
             "type": WSEventType.SERVER_ACK.value,
             "ts": websocket.sent[0]["ts"],
             "payload": {
+                "ok": True,
                 "received_event_type": WSEventType.USER_TEXT.value,
                 "duplicate": True,
             },

--- a/server/tests/test_world_runtime_config.py
+++ b/server/tests/test_world_runtime_config.py
@@ -2,11 +2,14 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 server_root = str(Path(__file__).resolve().parent.parent)
 if server_root not in sys.path:
     sys.path.insert(0, server_root)
 
 import src.world.world_runtime as world_runtime_module
+from src.agent_runtime.character_registry import CharacterRegistry
 from src.world.world_runtime import WorldRuntime
 
 
@@ -168,3 +171,47 @@ def test_world_runtime_registers_clock_actions_from_task_clock_config():
         ("interval_task",),
         {"interval_seconds": 120, "action": interval_task.run_once, "run_immediately": True},
     ) in runtime.world_clock.actions
+
+
+def test_character_registry_rejects_missing_default_character():
+    with pytest.raises(ValueError, match="Default character 'luotianyi' is not configured"):
+        CharacterRegistry(
+            {
+                "characters": {
+                    "miku": {
+                        "display_name": "Hatsune Miku",
+                        "enabled": True,
+                    }
+                }
+            }
+        )
+
+
+def test_character_registry_rejects_disabled_default_character():
+    with pytest.raises(ValueError, match="Default character 'luotianyi' must be enabled"):
+        CharacterRegistry(
+            {
+                "characters": {
+                    "luotianyi": {
+                        "display_name": "Luo Tianyi",
+                        "enabled": False,
+                    },
+                    "miku": {
+                        "display_name": "Hatsune Miku",
+                        "enabled": True,
+                    },
+                }
+            }
+        )
+
+
+def test_character_registry_rejects_multiple_default_characters():
+    with pytest.raises(ValueError, match="Multiple default characters"):
+        CharacterRegistry(
+            {
+                "characters": {
+                    "luotianyi": {"enabled": True, "default_target": True},
+                    "miku": {"enabled": True, "default_target": True},
+                }
+            }
+        )

--- a/tools/check-merge-gate.ps1
+++ b/tools/check-merge-gate.ps1
@@ -1,0 +1,186 @@
+<#
+.SYNOPSIS
+Checks whether candidate commits can be merged from an exact target baseline.
+
+.EXAMPLE
+pwsh -File tools/check-merge-gate.ps1 dev feature/one feature/two
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Target,
+
+    [Parameter(Mandatory = $true, Position = 1, ValueFromRemainingArguments = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string[]]$Candidate
+)
+
+Set-StrictMode -Version Latest
+if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Resolve-GitCommit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Reference
+    )
+
+    $resolved = @(
+        & git -C $repoRoot rev-parse --verify --quiet --end-of-options "${Reference}^{commit}" 2>$null
+    )
+    if ($LASTEXITCODE -ne 0 -or $resolved.Count -ne 1) {
+        return $null
+    }
+
+    return $resolved[0].Trim()
+}
+
+function Format-ShortCommit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Commit
+    )
+
+    return $Commit.Substring(0, [Math]::Min(12, $Commit.Length))
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Output "[FAIL] git is not available on PATH."
+    exit 2
+}
+
+$targetCommit = Resolve-GitCommit -Reference $Target
+if (-not $targetCommit) {
+    Write-Output "[FAIL] Target '$Target' does not resolve to a commit."
+    exit 2
+}
+
+if ($Candidate.Count -eq 0) {
+    Write-Output "[FAIL] At least one candidate is required."
+    exit 2
+}
+
+$targetShort = Format-ShortCommit -Commit $targetCommit
+Write-Output "Merge gate target: $Target ($targetShort)"
+
+$passed = 0
+$failed = 0
+$resolvedCandidates = [System.Collections.Generic.List[object]]::new()
+
+foreach ($candidateReference in $Candidate) {
+    $candidateCommit = Resolve-GitCommit -Reference $candidateReference
+    if (-not $candidateCommit) {
+        Write-Output "[FAIL] $candidateReference | does not resolve to a commit"
+        $failed++
+        continue
+    }
+
+    [void]$resolvedCandidates.Add([PSCustomObject]@{
+        Reference = $candidateReference
+        Commit = $candidateCommit
+    })
+
+    & git -C $repoRoot merge-base --is-ancestor $targetCommit $candidateCommit *> $null
+    $ancestorExitCode = $LASTEXITCODE
+
+    # Git for Windows 2.55 can access-violate on a conflicted merge when
+    # --quiet is invoked from PowerShell. The messages/name-only form has the
+    # same exit-code contract and preserves useful conflict details.
+    $mergeTreeOutput = @(
+        & git -C $repoRoot merge-tree --write-tree --messages --name-only $targetCommit $candidateCommit 2>&1
+    )
+    $mergeTreeExitCode = $LASTEXITCODE
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if ($ancestorExitCode -eq 1) {
+        [void]$reasons.Add("target is not an ancestor")
+    }
+    elseif ($ancestorExitCode -ne 0) {
+        [void]$reasons.Add("ancestor check failed with exit code $ancestorExitCode")
+    }
+
+    $mergeTreeDetail = ($mergeTreeOutput | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ }) -join "; "
+    if ($mergeTreeExitCode -eq 1) {
+        $conflictReason = "merge tree has content conflicts"
+        if ($mergeTreeDetail) {
+            $conflictReason += ": $mergeTreeDetail"
+        }
+        [void]$reasons.Add($conflictReason)
+    }
+    elseif ($mergeTreeExitCode -ne 0) {
+        $detail = $mergeTreeDetail
+        if ($detail) {
+            [void]$reasons.Add("merge-tree failed with exit code ${mergeTreeExitCode}: $detail")
+        }
+        else {
+            [void]$reasons.Add("merge-tree failed with exit code $mergeTreeExitCode")
+        }
+    }
+
+    $candidateShort = Format-ShortCommit -Commit $candidateCommit
+    if ($reasons.Count -eq 0) {
+        Write-Output "[PASS] $candidateReference ($candidateShort) | target is an ancestor; merge tree is clean"
+        $passed++
+    }
+    else {
+        Write-Output "[FAIL] $candidateReference ($candidateShort) | $($reasons -join '; ')"
+        $failed++
+    }
+}
+
+$orderPassed = 0
+$orderFailed = 0
+
+for ($leftIndex = 0; $leftIndex -lt $resolvedCandidates.Count; $leftIndex++) {
+    for ($rightIndex = $leftIndex + 1; $rightIndex -lt $resolvedCandidates.Count; $rightIndex++) {
+        $left = $resolvedCandidates[$leftIndex]
+        $right = $resolvedCandidates[$rightIndex]
+
+        & git -C $repoRoot merge-base --is-ancestor $left.Commit $right.Commit *> $null
+        $leftBeforeRight = $LASTEXITCODE
+        & git -C $repoRoot merge-base --is-ancestor $right.Commit $left.Commit *> $null
+        $rightBeforeLeft = $LASTEXITCODE
+
+        if ($leftBeforeRight -eq 0 -or $rightBeforeLeft -eq 0) {
+            $direction = if ($leftBeforeRight -eq 0) {
+                "$($left.Reference) <= $($right.Reference)"
+            }
+            else {
+                "$($right.Reference) <= $($left.Reference)"
+            }
+            Write-Output "[PASS] order | $direction"
+            $orderPassed++
+            continue
+        }
+
+        if ($leftBeforeRight -notin @(0, 1) -or $rightBeforeLeft -notin @(0, 1)) {
+            Write-Output (
+                "[FAIL] order | ancestor check failed for " +
+                "$($left.Reference) and $($right.Reference)"
+            )
+        }
+        else {
+            Write-Output (
+                "[FAIL] order | $($left.Reference) and $($right.Reference) " +
+                "are divergent; arbitrary PR merge order is not structurally guaranteed"
+            )
+        }
+        $orderFailed++
+    }
+}
+
+$failed += $orderFailed
+Write-Output (
+    "Summary: $passed candidate checks passed, $orderPassed order checks passed, " +
+    "$failed failed"
+)
+
+if ($failed -gt 0) {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
## 背景/问题

本地歌曲或缓存回复音频回放与服务端流式 TTS 使用不同播放器，切换时若停播尚未完成或 WebView 队列仍有分片，两路声音可能重叠，界面也可能继续显示错误的播放状态。修复 head 为 `573c9f7`。

## 本 PR 重点改动

服务端音频到达且本地音频正在播放时，先 `await stopLocalTts()`，等待 stop、unload 和本地状态通知全部完成，再处理服务端分片；切换本地条目同样等待旧条目停止。本地回放会检查服务端播放标志，并防御性调用 `stopServerAudio()`：WebView 停止全部 active source、清空排队起点及等待/播放字段，再发送 `audio_stopped`。RN 收到后调用 `onServerAudioFinished()`，同步清除 `serverAudioPlaying` 并释放完成等待者。

## 修复链与合并说明

本 head 属于累计线性修复链。标准 merge commit 门禁覆盖 20 个候选、190 种两两顺序，0 conflict；当前 GitHub 为 `MERGEABLE/CLEAN`。请保持标准 merge commit；squash/rebase 会改变已验证祖先关系，必须逐次重跑门禁。

## 验证

最终累计树通过 App 10 suites / 78 tests、Server 162 passed / 1 deselected、Desktop 18 passed。该结果属于累计集成验收，不表示 `573c9f7` 单 head 独立运行了同一范围。本轮未运行 compile、build、typecheck。

## 发布前剩余验证

仍需在真机快速交替点击本地回放与服务端 TTS，并覆盖连续分片、切后台、音频路由切换、停播异常和完成事件延迟，确认始终单路发声、队列清空且按钮状态最终一致。
