### PR TITLE
fix: 历史消息按 uuid 去重（含批次内重复），缺 uuid 生成确定性 ID

### DIFF
--- a/app/__tests__/message_dedup.test.ts
+++ b/app/__tests__/message_dedup.test.ts
@@ -1,0 +1,66 @@
+import { ChatMessage } from '../types/chat';
+import { buildFallbackUuid, deduplicateMessages } from '../utils/message_dedup';
+
+const msg = (uuid: string, content = uuid): ChatMessage => ({
+  uuid,
+  type: 'text',
+  content,
+  isUser: false,
+  timestamp: 1,
+});
+
+describe('deduplicateMessages', () => {
+  it('同一批次重复 uuid 只保留第一条', () => {
+    const result = deduplicateMessages([], [msg('a'), msg('a'), msg('b')]);
+    expect(result.map((m) => m.uuid)).toEqual(['a', 'b']);
+  });
+
+  it('多条相同 unknown_id 只保留第一条（纯函数兜底）', () => {
+    const result = deduplicateMessages(
+      [],
+      [msg('unknown_id', '第一条'), msg('unknown_id', '第二条')],
+    );
+    expect(result.map((m) => m.uuid)).toEqual(['unknown_id']);
+  });
+
+  it('同时过滤已有列表重复和批次内重复', () => {
+    const existing = [msg('old-id')];
+    const incoming = [msg('new-id'), msg('new-id'), msg('old-id')];
+    const result = deduplicateMessages(existing, incoming);
+    expect(result.map((m) => m.uuid)).toEqual(['new-id']);
+  });
+
+  it('去重后保持批次内顺序', () => {
+    const result = deduplicateMessages([], [msg('b'), msg('a'), msg('c'), msg('a')]);
+    expect(result.map((m) => m.uuid)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('buildFallbackUuid', () => {
+  it('有 uuid 时原样返回', () => {
+    expect(buildFallbackUuid({ uuid: 'server-uuid' })).toBe('server-uuid');
+  });
+
+  it('不同内容的消息生成不同 ID，不再共用 unknown_id', () => {
+    const first = buildFallbackUuid({
+      source: 'user',
+      type: 'text',
+      timestamp: '2026-01-01 00:00:00',
+      content: '第一条',
+    });
+    const second = buildFallbackUuid({
+      source: 'user',
+      type: 'text',
+      timestamp: '2026-01-01 00:00:00',
+      content: '第二条',
+    });
+    expect(first).not.toBe(second);
+  });
+
+  it('相同内容的消息 ID 稳定，可被去重函数过滤', () => {
+    const input = { source: 'user', type: 'text', timestamp: '2026-01-01 00:00:00', content: '重复消息' };
+    const id = buildFallbackUuid(input);
+    const result = deduplicateMessages([], [msg(id), msg(id)]);
+    expect(result.map((m) => m.uuid)).toEqual([id]);
+  });
+});

--- a/app/hooks/useChatLogic.ts
+++ b/app/hooks/useChatLogic.ts
@@ -8,6 +8,7 @@ import { MessageProcessor } from '../utils/message_processor';
 import { NetworkClient } from '../utils/network_client';
 import { AgentMessagePayload, ChatMessage } from '../types/chat';
 import { addDebugTrace } from '../utils/debug_trace';
+import { deduplicateMessages } from '../utils/message_dedup';
 
 function createUuid(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -337,7 +338,8 @@ export const useChatLogic = (
 
     setMessages((prev) => {
       const nowScrollIndex = prev.length - 1;
-      const normalized = newMessages.map((msg) => ({
+      // 按 uuid 去重：已有列表、跨批次与批次内重复均只保留第一条，避免 FlatList key 冲突
+      const normalized = deduplicateMessages(prev, newMessages).map((msg) => ({
         ...msg,
         sendStatus: msg.isUser ? 'submitted' : msg.sendStatus,
         audioPlayState: msg.audioPlayState || 'idle',

--- a/app/utils/getHistory.ts
+++ b/app/utils/getHistory.ts
@@ -2,6 +2,7 @@ import * as FileSystem from 'expo-file-system/legacy';
 import { ChatMessage } from '../types/chat';
 import { server_config } from '../config';
 import { addDebugTrace } from './debug_trace';
+import { buildFallbackUuid } from './message_dedup';
 
 export interface HistoryResponse {
     messages: ChatMessage[];
@@ -16,7 +17,7 @@ export interface ImageResponse {
 
 async function attachLocalAudioIfExists(msg: any, baseMessage: ChatMessage): Promise<ChatMessage> {
     // 历史音频使用固定本地缓存路径，重启后按 uuid 回连。
-    if (baseMessage.isUser || baseMessage.type !== 'text' || !baseMessage.uuid || baseMessage.uuid === 'unknown_id') {
+    if (baseMessage.isUser || baseMessage.type !== 'text' || !baseMessage.uuid) {
         return baseMessage;
     }
 
@@ -66,7 +67,7 @@ export async function getHistory(username: string, token: string, count: number,
         
         const messages: ChatMessage[] = await Promise.all(data.history.map(async (msg: any) => {
             const baseMessage: ChatMessage = {
-                uuid: msg.uuid || "unknown_id",
+                uuid: buildFallbackUuid(msg),
                 content: msg.content,
                 isUser: msg.source === 'user',
                 type: msg.type,

--- a/app/utils/message_dedup.ts
+++ b/app/utils/message_dedup.ts
@@ -1,0 +1,49 @@
+import { ChatMessage } from '../types/chat';
+
+/**
+ * 按 uuid 对历史消息去重：
+ * - 过滤与已有消息 uuid 重复的批次内消息；
+ * - 同一批次内重复 uuid 只保留第一条；
+ * - 保持 incomingMessages 原始顺序。
+ */
+export const deduplicateMessages = (
+  existingMessages: ChatMessage[],
+  incomingMessages: ChatMessage[],
+): ChatMessage[] => {
+  const seen = new Set(existingMessages.map((message) => message.uuid));
+
+  return incomingMessages.filter((message) => {
+    if (seen.has(message.uuid)) {
+      return false;
+    }
+    seen.add(message.uuid);
+    return true;
+  });
+};
+
+/** 简单的字符串散列，用于为缺失 uuid 的历史消息生成确定性 ID。 */
+function hashString(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * 服务端历史消息缺失 uuid 时，基于稳定字段（source/type/timestamp/content）生成确定性 ID，
+ * 避免多条缺 uuid 消息共用固定 unknown_id 导致 FlatList key 冲突。
+ * 相同内容的消息重复拉取时 ID 保持一致，可被 deduplicateMessages 正确过滤。
+ * 注意：内容与时间戳完全相同的消息会得到相同 ID，这是缺失唯一标识时无法避免的极限情况。
+ */
+export const buildFallbackUuid = (msg: Record<string, unknown>): string => {
+  if (msg.uuid) {
+    return String(msg.uuid);
+  }
+  const source = String(msg.source || 'unknown');
+  const type = String(msg.type || 'text');
+  const timestamp = msg.timestamp == null ? '' : String(msg.timestamp);
+  const content =
+    typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? '');
+  return `history-${source}-${type}-${timestamp}-${hashString(content)}`;
+};

--- a/client/src/gui/main_ui.py
+++ b/client/src/gui/main_ui.py
@@ -20,6 +20,7 @@ from ..live2d import Live2dModel
 from .binder import AgentBinder
 from ..types import ConversationItem
 from .chat_bubble import ChatBubble, ChatTextBubble, ChatImageBubble, BubblePlaybackManager
+from ..utils.message_dedup import deduplicate_by_uuid
 from .preferences_dialog import PreferencesDialog
 from .dynamics_dialog import DynamicsDialog
 
@@ -740,6 +741,11 @@ class ChatWidget(QWidget):
         
         if start_index >=0:
             self.current_history_index = start_index
+
+        # 按 uuid 去重：过滤已渲染气泡与批次内重复，避免重复拉取/重推时重复渲染
+        history_list = deduplicate_by_uuid(self._rendered_bubble_uuids(), history_list)
+        if not history_list:
+            return
         
         # Save scroll position
         scrollbar = self.scroll_area.verticalScrollBar()
@@ -779,6 +785,15 @@ class ChatWidget(QWidget):
              QTimer.singleShot(5, lambda: scrollbar.setValue(old_value + scrollbar.maximum() - old_max))
         else:
             QTimer.singleShot(5, lambda: scrollbar.setValue(scrollbar.maximum() - old_max))
+
+    def _rendered_bubble_uuids(self) -> set[str]:
+        """收集当前已渲染气泡的 conv_uuid，用于历史消息去重。"""
+        uuids: set[str] = set()
+        for i in range(self.history_layout.count()):
+            widget = self.history_layout.itemAt(i).widget()
+            if isinstance(widget, ChatBubble) and widget.conv_uuid:
+                uuids.add(widget.conv_uuid)
+        return uuids
 
     def on_text_changed(self):
         text = self.input_box.toPlainText()

--- a/client/src/types/__init__.py
+++ b/client/src/types/__init__.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from ..utils.message_dedup import build_fallback_uuid
 
 @dataclass
 class ConversationItem:
@@ -8,6 +9,10 @@ class ConversationItem:
     type: str
     content: str
     uuid: str = None
+    def __post_init__(self) -> None:
+        # 服务端缺失 uuid 时生成确定性 ID，避免多条消息共享同一标识
+        if not self.uuid:
+            self.uuid = build_fallback_uuid(self.source, self.type, self.timestamp, self.content)
     def __repr__(self) -> str:
         elapsed_time: str = self._timestamp_to_elapsed_time()
         return f"[{elapsed_time}] {self.source} ({self.type}): {self.content}"

--- a/client/src/utils/message_dedup.py
+++ b/client/src/utils/message_dedup.py
@@ -1,0 +1,34 @@
+"""历史消息去重工具。
+
+与 app 端 app/utils/message_dedup.ts 对齐：
+- deduplicate_by_uuid：按 uuid 过滤与已有消息重复及批次内重复，保持原顺序；
+- build_fallback_uuid：服务端缺失 uuid 时生成确定性、文件名安全的 ID。
+"""
+
+import hashlib
+from typing import Iterable, List, Sequence, TypeVar
+
+T = TypeVar("T")
+
+
+def deduplicate_by_uuid(existing_uuids: Iterable[str], incoming: Sequence[T]) -> List[T]:
+    """过滤与 existing_uuids 重复以及批次内重复的消息，保持 incoming 顺序。"""
+    seen = set(existing_uuids)
+    result: List[T] = []
+    for item in incoming:
+        if item.uuid in seen:
+            continue
+        seen.add(item.uuid)
+        result.append(item)
+    return result
+
+
+def build_fallback_uuid(source: str, type_: str, timestamp: str, content: str) -> str:
+    """基于稳定字段生成确定性 ID。
+
+    相同内容重复拉取时 ID 一致，可被 deduplicate_by_uuid 过滤；
+    只包含 [a-z0-9-]，可安全用作本地音频缓存文件名。
+    """
+    fingerprint = f"{source}|{type_}|{timestamp}|{content}"
+    digest = hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:12]
+    return f"history-{source or 'unknown'}-{type_ or 'text'}-{digest}"

--- a/client/tests/test_message_dedup.py
+++ b/client/tests/test_message_dedup.py
@@ -1,0 +1,65 @@
+"""历史消息去重工具测试：批次内重复、缺 uuid 兜底 ID、已有列表 + 批次内重复、顺序保持。"""
+
+from src.types import ConversationItem
+from src.utils.message_dedup import build_fallback_uuid, deduplicate_by_uuid
+
+
+def _item(uuid_: str, content: str = "x"):
+    return ConversationItem(
+        timestamp="2026-01-01 00:00:00",
+        source="agent",
+        type="text",
+        content=content,
+        uuid=uuid_,
+    )
+
+
+def test_dedup_same_batch_duplicate_uuid_keeps_first():
+    items = [_item("a", "1"), _item("a", "2"), _item("b", "3")]
+    result = deduplicate_by_uuid([], items)
+    assert [i.uuid for i in result] == ["a", "b"]
+
+
+def test_dedup_filters_existing_and_in_batch_duplicates():
+    items = [_item("new-id", "1"), _item("new-id", "2"), _item("old-id", "3")]
+    result = deduplicate_by_uuid(["old-id"], items)
+    assert [i.uuid for i in result] == ["new-id"]
+
+
+def test_dedup_keeps_incoming_order():
+    items = [_item("b"), _item("a"), _item("c"), _item("a")]
+    result = deduplicate_by_uuid([], items)
+    assert [i.uuid for i in result] == ["b", "a", "c"]
+
+
+def test_fallback_uuid_is_deterministic_and_distinct():
+    first = build_fallback_uuid("user", "text", "2026-01-01 00:00:00", "第一条")
+    second = build_fallback_uuid("user", "text", "2026-01-01 00:00:00", "第二条")
+    assert first != second
+    assert build_fallback_uuid("user", "text", "2026-01-01 00:00:00", "第一条") == first
+
+
+def test_fallback_uuid_uses_safe_filename_characters():
+    result = build_fallback_uuid("user", "image", "2026-01-01 00:00:00", "路径/内容")
+    assert result == result.lower()
+    assert all(c.isalnum() or c == "-" for c in result)
+
+
+def test_conversation_item_fills_missing_uuid_deterministically():
+    item = ConversationItem(
+        timestamp="2026-01-01 00:00:00",
+        source="agent",
+        type="text",
+        content="你好",
+        uuid=None,
+    )
+    assert item.uuid
+    assert item.uuid.startswith("history-")
+    again = ConversationItem(
+        timestamp="2026-01-01 00:00:00",
+        source="agent",
+        type="text",
+        content="你好",
+        uuid=None,
+    )
+    assert again.uuid == item.uuid


### PR DESCRIPTION
## 背景

历史消息在加载/渲染时存在重复与标识缺失问题，app 端与桌面端 client 均有：

- **app 端（React Native）**：`addHistoryMessage` 去重只在 filter 阶段对比已有列表、不更新集合，同一批次内重复 uuid（包括多条缺 uuid 共用 `unknown_id`）会全部保留，导致 FlatList key 冲突、渲染复用错误与消息状态错位。
- **client 端（PySide6）**：`on_history_loaded` 加载历史零去重，重复拉取/重推会把整页历史再次渲染；`ConversationItem.uuid` 默认为 `None`，缺 uuid 时多条消息共享同一标识，`msg_to_bubble`/播放器状态会错位。

## 修复内容

**去重逻辑提取为纯函数（filter 阶段就地更新集合）**

- app：`app/utils/message_dedup.ts` → `deduplicateMessages(existing, incoming)`
- client：`client/src/utils/message_dedup.py` → `deduplicate_by_uuid(existing_uuids, incoming)`

同时覆盖：已有列表重复、跨批次重复（重复拉取/并发）、批次内重复，且保持批次顺序。

**缺 uuid 时生成确定性 ID，替代固定兜底标识**

- 基于 `source/type/timestamp/content` 生成确定性 ID，字符安全
- app：`getHistory` 不再填 `unknown_id`，使用 `buildFallbackUuid`
- client：`ConversationItem.__post_init__` 自动填充兜底 ID，全链路不再出现 `None` 标识

**渲染层接入**

- app：`addHistoryMessage` 先 `deduplicateMessages(prev, newMessages)` 再 normalize/reverse
- client：`on_history_loaded` 插入前按已渲染气泡的 conv_uuid 去重，整批重复时直接返回

## 测试

- app：新增 `app/__tests__/message_dedup.test.ts`（7 条：同批次重复、多条相同 `unknown_id` 兜底、已有 + 批次内重复、顺序保持、兜底 ID 稳定性）；全套 44 条 jest 通过
- client：新增 `client/tests/test_message_dedup.py`（6 条：同批次重复、已有 + 批次内重复、顺序保持、兜底 ID 确定性/字符安全、dataclass 自动填充）；全部通过

## 合并注意事项

本 PR 与 #38「同一句话重复显示两次并播放两次」在 `addHistoryMessage` 的去重点上重叠：#38 的做法是仅对已有列表去重（不覆盖批次内重复），本 PR 是其超集。两 PR 均基于 dev、会同时修改 `useChatLogic.ts` 与 `getHistory.ts`，合并时若遇冲突，取舍建议：`addHistoryMessage` 保留本 PR 的 `deduplicateMessages` 实现；`getHistory` 保留 #38 的唱歌（sing）音频回连逻辑，同时保留本 PR 的确定性兜底 ID。