### PR TITLE
feat(server): 多端接管会话时通知并关闭被替代的旧连接

### DIFF
--- a/server/src/chat_session/chat_pipeline/chat_stream.py
+++ b/server/src/chat_session/chat_pipeline/chat_stream.py
@@ -338,12 +338,37 @@ class ChatStream:
         """用户重连时调用，更新 WebSocket 连接"""
         if self._closing:
             raise RuntimeError("Chat stream is stopping and cannot reconnect")
+        replaced = self.ws_connection
         self.logger.info(f"User {self.user_name} reconnected")
         self.ws_connection = new_ws_connection
         self.user_name = new_ws_connection.user_name if new_ws_connection else self.user_name
         self.connection_lost_time = None
         self.state = self.STATE_WAITING
         await self.start_if_needed()
+        # 单账号多端轮流使用：新连接接管聊天流后，主动通知并关闭被替代的旧连接，
+        # 避免旧设备停留在收不到任何回复的“僵尸连接”。复用 auth_error 事件，
+        # 让各端走既有的“鉴权被拒 → 停止重连 → 提示用户”链路。
+        if replaced is not None and replaced is not new_ws_connection:
+            await self._dismiss_replaced_connection(replaced)
+
+    async def _dismiss_replaced_connection(self, old_connection: "WebSocketConnection") -> None:
+        """向被接管的旧连接发送 auth_error(SESSION_REPLACED) 并关闭它。"""
+        ws_service = self.system_runtime.websocket_service if self.system_runtime else None
+        try:
+            if ws_service is not None:
+                event = ws_service._make_event(
+                    WSEventType.AUTH_ERROR,
+                    {
+                        "code": "SESSION_REPLACED",
+                        "message": "账号已在其他设备登录，本机会话已断开",
+                    },
+                )
+                await old_connection.websocket.send_json(event)
+            await old_connection.websocket.close()
+            self.logger.info("Dismissed replaced connection after takeover")
+        except Exception as e:
+            # 旧连接可能已自行断开，关闭失败不影响新连接
+            self.logger.debug(f"Failed to dismiss replaced connection: {e}")
 
     def _worker_task_bindings(self):
         return (

--- a/server/tests/test_chat_stream_reconnect.py
+++ b/server/tests/test_chat_stream_reconnect.py
@@ -48,3 +48,46 @@ async def test_stale_disconnect_does_not_drop_replacement_connection():
     assert replacement_stream.connection_lost_time is None
     assert other_character_stream.ws_connection is None
     assert other_character_stream.connection_lost_time is not None
+
+
+@pytest.mark.asyncio
+async def test_replacement_dismisses_old_connection_with_session_replaced():
+    """新连接接管聊天流时，旧连接应收到 auth_error(SESSION_REPLACED) 并被关闭。"""
+    sent_events: list[dict] = []
+    closed: list[bool] = []
+
+    class FakeWebsocket:
+        async def send_json(self, event):
+            sent_events.append(event)
+
+        async def close(self):
+            closed.append(True)
+
+    old_connection = SimpleNamespace(
+        user_name="tester", user_uuid="user-1", websocket=FakeWebsocket()
+    )
+    replacement = SimpleNamespace(
+        user_name="tester", user_uuid="user-1", websocket=object()
+    )
+    stream = ChatStream({}, old_connection, character_id="luotianyi")
+    stream.system_runtime = SimpleNamespace(
+        websocket_service=SimpleNamespace(_make_event=None)
+    )
+
+    def make_event(event_type, payload, reply_to=None):
+        return {"type": event_type.value if hasattr(event_type, "value") else event_type,
+                "payload": payload}
+
+    stream.system_runtime.websocket_service._make_event = make_event
+
+    async def already_started():
+        return None
+
+    stream.start_if_needed = already_started
+    await stream.reconnect(replacement)
+
+    assert stream.ws_connection is replacement
+    assert len(sent_events) == 1
+    assert sent_events[0]["type"] == "auth_error"
+    assert sent_events[0]["payload"]["code"] == "SESSION_REPLACED"
+    assert closed == [True]


### PR DESCRIPTION
## 功能描述

单账号多端轮流使用场景下（PC exe / 安卓 / 鸿蒙 / Web），同一账号在第二台设备登录会接管聊天流（`ChatStreamManager.get_or_register_chat_stream` 走 `reconnect` 分支）。此前旧设备的 WebSocket 连接不会被关闭，变成"僵尸连接"：心跳正常、发消息也能入库，但天依的所有回复只会发给新设备，旧设备毫无感知地收不到任何回复。

本 PR 在新连接接管聊天流时，主动向被替代的旧连接发送一条 `auth_error(SESSION_REPLACED)` 事件并关闭连接，让旧设备立即收到"账号已在其他设备登录，本机会话已断开"的明确提示。

## 实现逻辑

- `ChatStream.reconnect()`：替换 `ws_connection` 后，若存在被替代的旧连接（非同一连接），调用新增的 `_dismiss_replaced_connection()`
- `_dismiss_replaced_connection()`：复用现有 `auth_error` 事件类型（code=`SESSION_REPLACED`，中文 message），随后关闭旧 WebSocket；关闭失败（旧连接可能已自行断开）仅记 debug 日志，不影响新连接
- **四端零改动**：app / PC / 鸿蒙 / Web 对 `auth_error` 均已实现"标记鉴权拒绝 → 停止重连 → onError 提示用户"链路，直接复用

## 涉及模块

- `server/src/chat_session/chat_pipeline/chat_stream.py`（+25 行）
- `server/tests/test_chat_stream_reconnect.py`（+43 行测试）

## 安全性说明

- 旧连接断开后，其 `server_main` 主循环 finally 触发 `gcsm.ws_lost_connection(old_conn)`——既有 `owns_connection` 保护确保不会误清新连接的活跃状态
- `client_llm_executor.clear_user(user, old_conn)` 按 owner 连接粒度清理，不会误失败新设备的挂起委托请求
- 正常断网重连场景：旧连接已 lost（`ws_connection is None`）→ 不触发 dismiss，行为与之前完全一致

## 单元测试

- 新增 `test_replacement_dismisses_old_connection_with_session_replaced`：验证接管后旧连接收到 auth_error(code=SESSION_REPLACED) 且被 close
- 回归通过：test_chat_stream_reconnect / test_chat_stream_lifecycle / test_websocket_delivery 共 25 passed
