### PR TITLE
feat(domain): 交付 TextMessage 最小契约

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -20,7 +20,7 @@
 - 范围：一个 `TextMessage` 合法样例，逐项验证全部已提供公共/专有字段、固定 kind、不可变语义和不存在任意 `payload` 扩展口。
 - 明确不包含：不增加 `src.domain.agent` 产品实现，不测试其余 21 个 Stimulus、非法组合、InteractionSnapshot、request/report，也不修改旧生产链。
 - 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 验证及结果：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败，符合公开协议入口尚未实现的预期 Red；未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证。
+- 验证及结果：`conda run -n agent python -m py_compile tests/domain/test_agent_handle_contract.py` 通过；`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s），符合公开协议入口尚未实现的预期 Red；未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证。
 
 ## 历史设计轮次目标与范围
 
@@ -96,7 +96,7 @@
 - [x] 已删除没有当前生产者的 `StimulusSource.SYSTEM`；同时删除仅表示触发机制、与 source 定义冲突的 `SCHEDULER`；
 - [x] PR #91 已获 owner 批准并 squash merge 到 `refactor/agent`；PR #90 的 interface 前置门禁已经闭合；
 - [ ] 工单 01 当前只增加第一个公开 domain seam 契约测试，尚未实现 `src.domain.agent`；
-- [ ] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败，符合目标协议入口尚未实现的预期；
+- [ ] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s），符合目标协议入口尚未实现的预期；
 - [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
 - [ ] PR #90 仍为 Red-only Draft 且有 `CHANGES_REQUESTED`；本轮修正测试 seam 后等待 owner 复审，通过前不开始产品实现；
 - [ ] 本 PR 未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证；

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -12,6 +12,7 @@
 - interface spec：[`Agent-handle-realize-深模块重构.md`](../设计文档/Agent-handle-realize-深模块重构.md)
 - 本地工单草案：[`issues/`](../../../.scratch/agent-handle-realize/issues/)
 - 当前 Agent interface：[`agent/README.md`](../../项目说明/项目架构与接口（spec）/接口文档/agent/README.md)
+- 当前 domain interface：[`domain/README.md`](../../项目说明/项目架构与接口（spec）/接口文档/domain/README.md)
 
 ## 本 PR
 
@@ -100,6 +101,7 @@
 - [x] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s）；
 - [x] Green：同一 focused 命令在当前完整候选上为 `1 passed in 0.18s`；
 - [x] 已实现 `src.domain.agent` 的 `TextMessage` 最小切片，并让旧 Stimulus 复用同一四成员 `PersistPolicy`；
+- [x] 已同步 domain 当前 interface 文档，记录 `src.domain.agent` 公开路径、`TextMessage` 字段与不变量、无副作用及当前仅支持合法构造的校验边界；
 - [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
 - [x] `tests/domain -q` 为 `1 passed in 0.18s`；Ruff、py_compile、BasedPyright 和 `git diff --check` 通过；三处公开路径导出的 `PersistPolicy` 为同一对象且四成员完整；
 - [ ] 离线回归为 `400 passed, 4 deselected, 6 failed`；当前 `refactor/agent` 对照为 `399 passed, 4 deselected, 6 failed`，失败集合一致，未发现本切片新增回归，但仓库默认回归门禁仍未全绿；

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -15,7 +15,7 @@
 
 ## 本 PR
 
-- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（完整 Green 根 PR，目标 `refactor/agent`，等待转 Ready 后 owner 复审）
+- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（完整 Green 根 PR，目标 `refactor/agent`，Ready，等待 owner 复审）
 - 目标：交付已批准的 `TextMessage` 契约测试及足以让该测试通过的最小 `src.domain.agent` 协议实现。
 - 范围：包含 `TextMessage` 公开契约测试；公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
 - 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
@@ -122,4 +122,4 @@
 
 ## 下一步
 
-将 PR #90 的标题、正文和状态同步为当前完整 Green 根 PR，转 Ready 并请求 owner 基于最新 head 复审；通过后由 owner squash merge 到 `refactor/agent`。工单 01 的下一可观察行为必须另开新的 TDD 切片。
+owner 复审通过后，由 owner 将 PR #90 squash merge 到 `refactor/agent`。工单 01 的下一可观察行为必须另开新的 TDD 切片。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：工单 01 interface SPEC 补充评审
+> 当前阶段：工单 01 契约测试 Draft PR
 >
 > 总体状态：进行中
 
@@ -15,12 +15,12 @@
 
 ## 本 PR
 
-- PR：[#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91)（Draft，`CHANGES_REQUESTED`）
-- 目标：补齐 Issue #60 开始契约测试前缺失的 Stimulus 公开枚举设计，使测试不再猜测成员和值。
-- 范围：`StimulusKind`、`StimulusSource`、`PersistPolicy` 的成员和值；每个 kind 的 source/persist/ephemeral 唯一合法组合；expand 阶段新旧协议的兼容边界。
-- 明确不包含：不修改 PR #90 的测试，不增加产品实现，不修改旧 `Stimulus.payload` 或生产调用链，不关闭 Issue #60。
-- 验证及结果：`git diff --check` 通过；静态核对 22 个 `StimulusKind` 均在唯一组合矩阵中逐项覆盖，SPEC 中已无 `StimulusSource.SYSTEM/SCHEDULER` 枚举残留；本 PR 为纯文档 interface 门禁，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；GitHub 自动审查的 `resolve`、`review`、`publish` 3 个 job 均为 `skipped`，未执行 CI 验证。
-- 评审结果：22 个 `StimulusKind` 与当前 22 个强类型变体逐项一致，该部分已通过；本轮已按 owner 意见删除无生产者的 `SYSTEM` 和仅作为触发机制的 `SCHEDULER`，增加 22 行唯一组合矩阵与非法组合规则，并明确新旧协议复用单一 `PersistPolicy` 类型，仍需 owner 重新评审。
+- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（Draft，`CHANGES_REQUESTED`）
+- 目标：从 `src.domain.agent` 公开导出锁定 `TextMessage` 的首个合法构造与不可变行为，并保留真实 Red 证据。
+- 范围：一个 `TextMessage` 合法样例，逐项验证全部已提供公共/专有字段、固定 kind、不可变语义和不存在任意 `payload` 扩展口。
+- 明确不包含：不增加 `src.domain.agent` 产品实现，不测试其余 21 个 Stimulus、非法组合、InteractionSnapshot、request/report，也不修改旧生产链。
+- 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
+- 验证及结果：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败，符合公开协议入口尚未实现的预期 Red；未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证。
 
 ## 历史设计轮次目标与范围
 
@@ -94,9 +94,12 @@
 - [x] PR #91 已为全部 22 个 `StimulusKind` 固定唯一 `StimulusSource`；scheduler/`world_clock` 明确为时间驱动和投递机制，不是语义 source；
 - [x] PR #91 已固定全部 kind 的 `PersistPolicy / ephemeral` 唯一合法组合和表外稳定失败规则，并决定新旧 Stimulus 协议复用单一 `PersistPolicy` 类型；
 - [x] 已删除没有当前生产者的 `StimulusSource.SYSTEM`；同时删除仅表示触发机制、与 source 定义冲突的 `SCHEDULER`；
-- [ ] PR #91 上述修订尚未获得 owner 重新评审通过，当前仍不能合并或进入 PR #90；
-- [ ] PR #90 的契约测试仍为 Red-only Draft，且有 `CHANGES_REQUESTED`；本 SPEC 门禁通过前不修改该测试、不开始产品实现；
-- [ ] 本文档 PR 只做静态文档检查，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；
+- [x] PR #91 已获 owner 批准并 squash merge 到 `refactor/agent`；PR #90 的 interface 前置门禁已经闭合；
+- [ ] 工单 01 当前只增加第一个公开 domain seam 契约测试，尚未实现 `src.domain.agent`；
+- [ ] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败，符合目标协议入口尚未实现的预期；
+- [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
+- [ ] PR #90 仍为 Red-only Draft 且有 `CHANGES_REQUESTED`；本轮修正测试 seam 后等待 owner 复审，通过前不开始产品实现；
+- [ ] 本 PR 未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
 - [ ] `RequestSongLearning` 的持久任务 Adapter、任务状态和完成 Stimulus 事务边界尚未选择具体实现；
 - [ ] Agent 自有状态变更与 Reflection 之间的 evidence 去重键、revision 冲突策略只有目标语义，尚未落实；
@@ -114,4 +117,4 @@
 
 ## 下一步
 
-完成 PR #91 的静态验证后重新请求 owner 设计评审，并保持 Draft。PR #91 获批并合入后，回到 PR #90 按 review comments 修正首个 `TextMessage` 契约测试并重新记录 Red；测试 seam 获批后才进入最小 Green 实现。
+修正 PR #90 的首个 `TextMessage` 契约测试并重新确认 Red，随后请求 owner 复审。测试 seam 获批后，下一 PR 只实现足以让该测试通过的最小 `src.domain.agent` 协议切片；其余变体继续按 Red-Green 小步拆分。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：工单 01 `TextMessage` 最小 Green PR，已转 Ready 并等待 owner 复审
+> 当前阶段：工单 01 `TextMessage` 完整 Green 根 PR，等待 owner 复审
 >
 > 总体状态：进行中
 
@@ -15,13 +15,13 @@
 
 ## 本 PR
 
-- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Ready，等待 owner 复审；堆叠目标 `impl/agent-dm-01-handle-contract`）
-- 目标：只实现足以让 PR #90 已批准 `TextMessage` 契约测试通过的最小 `src.domain.agent` 协议切片。
-- 范围：公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
+- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（完整 Green 根 PR，目标 `refactor/agent`，等待转 Ready 后 owner 复审）
+- 目标：交付已批准的 `TextMessage` 契约测试及足以让该测试通过的最小 `src.domain.agent` 协议实现。
+- 范围：包含 `TextMessage` 公开契约测试；公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
 - 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
 - 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；本 PR 作为子 PR 合入该父分支后，PR #90 更新为包含已批准测试和最小实现的完整 Green 交付，再重新审查并 squash merge 到 `refactor/agent`。
-- 验证及结果：Red 为同一 focused 测试因 `ModuleNotFoundError: No module named 'src.domain.agent'` 收集失败；实现后 focused 测试为 `1 passed in 0.15s`，`tests/domain -q` 为 `1 passed in 0.14s`，相关文件 `py_compile`、Ruff 和新增 `src/domain/agent` 的 BasedPyright 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。Server 全量为 `424 passed, 3 skipped, 17 failed, 2 errors`，失败来自缺失 TTS/图片/唱歌资源、无效外部 API key 和既有无关测试/实现不一致；未运行真实 TTS、设备或生产环境验证。
+- 测试与实现门禁：PR #90 的 Red-only seam 已获 owner 批准，head `c724c1f`；最小 Green 子 PR [#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94) 已获 owner 批准，并于 2026-09-05 squash merge 到本分支，合并提交 `3b156739`。旧批准和测试证据不作为当前完整候选的最终依据。
+- 验证及结果：相对当前 `origin/refactor/agent` 的完整候选重新验证：focused 测试 `1 passed in 0.18s`，`tests/domain -q` 为 `1 passed in 0.18s`；相关文件 `py_compile`、Ruff、`src/domain/agent` BasedPyright（0 errors、0 warnings）和 `git diff --check` 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。离线回归在排除真实图片/TTS/唱歌资源测试、真实 B 站/VCPedia 抓取和 `real_llm` 后为 `400 passed, 4 deselected, 6 failed`；当前 `refactor/agent` 用同一命令为 `399 passed, 4 deselected, 6 failed`，六个失败集合一致，分别来自 diary Fake 接口漂移、测试直接调用无效外部 LLM key、已删除的数据库私有 helper、主动话题既有行为差异和项目计划路由测试假设，不是本切片引入。
 
 ## 历史设计轮次目标与范围
 
@@ -96,13 +96,13 @@
 - [x] PR #91 已固定全部 kind 的 `PersistPolicy / ephemeral` 唯一合法组合和表外稳定失败规则，并决定新旧 Stimulus 协议复用单一 `PersistPolicy` 类型；
 - [x] 已删除没有当前生产者的 `StimulusSource.SYSTEM`；同时删除仅表示触发机制、与 source 定义冲突的 `SCHEDULER`；
 - [x] PR #91 已获 owner 批准并 squash merge 到 `refactor/agent`；PR #90 的 interface 前置门禁已经闭合；
-- [x] PR #90 的首个公开 domain seam 契约测试已获 owner 批准；该 Red PR 保持 Draft、不合并；
+- [x] PR #90 的首个公开 domain seam 契约测试已获 owner 批准；PR #94 已将最小 Green 实现 squash merge 到 PR #90，形成当前完整 Green 候选；
 - [x] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s）；
-- [x] Green：同一 focused 命令在最小实现后为 `1 passed in 0.15s`；
+- [x] Green：同一 focused 命令在当前完整候选上为 `1 passed in 0.18s`；
 - [x] 已实现 `src.domain.agent` 的 `TextMessage` 最小切片，并让旧 Stimulus 复用同一四成员 `PersistPolicy`；
 - [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
-- [x] `tests/domain -q` 为 `1 passed in 0.14s`；Ruff 和新增协议包的 BasedPyright 通过；三处公开路径导出的 `PersistPolicy` 为同一对象且四成员完整；
-- [ ] Server 全量回归为 `424 passed, 3 skipped, 17 failed, 2 errors`；失败集中在缺失资源/外部凭据和既有无关测试，不是本切片引入，但全量门禁未绿；
+- [x] `tests/domain -q` 为 `1 passed in 0.18s`；Ruff、py_compile、BasedPyright 和 `git diff --check` 通过；三处公开路径导出的 `PersistPolicy` 为同一对象且四成员完整；
+- [ ] 离线回归为 `400 passed, 4 deselected, 6 failed`；当前 `refactor/agent` 对照为 `399 passed, 4 deselected, 6 failed`，失败集合一致，未发现本切片新增回归，但仓库默认回归门禁仍未全绿；
 - [ ] no-excuse 检查仅报告旧 `Stimulus` dataclass 未使用 `slots=True`；本切片不顺带改变旧对象布局；
 - [ ] 本 PR 未运行真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
@@ -122,4 +122,4 @@
 
 ## 下一步
 
-保持 PR #94 的合法堆叠 base，等待 owner 复审。通过后 squash merge 到 PR #90 分支；随后重新验证和审查包含测试与实现的 PR #90，再由 PR #90 合入 `refactor/agent`。
+将 PR #90 的标题、正文和状态同步为当前完整 Green 根 PR，转 Ready 并请求 owner 基于最新 head 复审；通过后由 owner squash merge 到 `refactor/agent`。工单 01 的下一可观察行为必须另开新的 TDD 切片。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：工单 01 契约测试 Draft PR
+> 当前阶段：工单 01 `TextMessage` 最小 Green PR，已转 Ready 并等待 owner 复审
 >
 > 总体状态：进行中
 
@@ -15,12 +15,13 @@
 
 ## 本 PR
 
-- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（Draft，`CHANGES_REQUESTED`）
-- 目标：从 `src.domain.agent` 公开导出锁定 `TextMessage` 的首个合法构造与不可变行为，并保留真实 Red 证据。
-- 范围：一个 `TextMessage` 合法样例，逐项验证全部已提供公共/专有字段、固定 kind、不可变语义和不存在任意 `payload` 扩展口。
-- 明确不包含：不增加 `src.domain.agent` 产品实现，不测试其余 21 个 Stimulus、非法组合、InteractionSnapshot、request/report，也不修改旧生产链。
+- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Ready，等待 owner 复审；堆叠目标 `impl/agent-dm-01-handle-contract`）
+- 目标：只实现足以让 PR #90 已批准 `TextMessage` 契约测试通过的最小 `src.domain.agent` 协议切片。
+- 范围：公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
+- 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
 - 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 验证及结果：`conda run -n agent python -m py_compile tests/domain/test_agent_handle_contract.py` 通过；`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s），符合公开协议入口尚未实现的预期 Red；未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证。
+- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；本 PR 作为子 PR 合入该父分支后，PR #90 更新为包含已批准测试和最小实现的完整 Green 交付，再重新审查并 squash merge 到 `refactor/agent`。
+- 验证及结果：Red 为同一 focused 测试因 `ModuleNotFoundError: No module named 'src.domain.agent'` 收集失败；实现后 focused 测试为 `1 passed in 0.15s`，`tests/domain -q` 为 `1 passed in 0.14s`，相关文件 `py_compile`、Ruff 和新增 `src/domain/agent` 的 BasedPyright 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。Server 全量为 `424 passed, 3 skipped, 17 failed, 2 errors`，失败来自缺失 TTS/图片/唱歌资源、无效外部 API key 和既有无关测试/实现不一致；未运行真实 TTS、设备或生产环境验证。
 
 ## 历史设计轮次目标与范围
 
@@ -95,11 +96,15 @@
 - [x] PR #91 已固定全部 kind 的 `PersistPolicy / ephemeral` 唯一合法组合和表外稳定失败规则，并决定新旧 Stimulus 协议复用单一 `PersistPolicy` 类型；
 - [x] 已删除没有当前生产者的 `StimulusSource.SYSTEM`；同时删除仅表示触发机制、与 source 定义冲突的 `SCHEDULER`；
 - [x] PR #91 已获 owner 批准并 squash merge 到 `refactor/agent`；PR #90 的 interface 前置门禁已经闭合；
-- [ ] 工单 01 当前只增加第一个公开 domain seam 契约测试，尚未实现 `src.domain.agent`；
-- [ ] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s），符合目标协议入口尚未实现的预期；
+- [x] PR #90 的首个公开 domain seam 契约测试已获 owner 批准；该 Red PR 保持 Draft、不合并；
+- [x] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s）；
+- [x] Green：同一 focused 命令在最小实现后为 `1 passed in 0.15s`；
+- [x] 已实现 `src.domain.agent` 的 `TextMessage` 最小切片，并让旧 Stimulus 复用同一四成员 `PersistPolicy`；
 - [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
-- [ ] PR #90 仍为 Red-only Draft 且有 `CHANGES_REQUESTED`；本轮修正测试 seam 后等待 owner 复审，通过前不开始产品实现；
-- [ ] 本 PR 未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证；
+- [x] `tests/domain -q` 为 `1 passed in 0.14s`；Ruff 和新增协议包的 BasedPyright 通过；三处公开路径导出的 `PersistPolicy` 为同一对象且四成员完整；
+- [ ] Server 全量回归为 `424 passed, 3 skipped, 17 failed, 2 errors`；失败集中在缺失资源/外部凭据和既有无关测试，不是本切片引入，但全量门禁未绿；
+- [ ] no-excuse 检查仅报告旧 `Stimulus` dataclass 未使用 `slots=True`；本切片不顺带改变旧对象布局；
+- [ ] 本 PR 未运行真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
 - [ ] `RequestSongLearning` 的持久任务 Adapter、任务状态和完成 Stimulus 事务边界尚未选择具体实现；
 - [ ] Agent 自有状态变更与 Reflection 之间的 evidence 去重键、revision 冲突策略只有目标语义，尚未落实；
@@ -117,4 +122,4 @@
 
 ## 下一步
 
-修正 PR #90 的首个 `TextMessage` 契约测试并重新确认 Red，随后请求 owner 复审。测试 seam 获批后，下一 PR 只实现足以让该测试通过的最小 `src.domain.agent` 协议切片；其余变体继续按 Red-Green 小步拆分。
+保持 PR #94 的合法堆叠 base，等待 owner 复审。通过后 squash merge 到 PR #90 分支；随后重新验证和审查包含测试与实现的 PR #90，再由 PR #90 合入 `refactor/agent`。

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/domain/README.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/domain/README.md
@@ -8,6 +8,11 @@
 
 ### 输入与响应
 
+- `src.domain.agent`：当前 Agent 强类型领域协议的公开导入路径。本切片公开 `TextMessage`、`StimulusKind`、`StimulusSource` 和与旧协议共用的 `PersistPolicy`。
+- `TextMessage`：用户已提交的一条完整文字消息。构造字段为 `stimulus_id: str`、`schema_version: int`、`occurred_at: datetime`、`source: StimulusSource`、`target_character_ids: tuple[str, ...]`、`user_id: str | None`、`persist_policy: PersistPolicy`、`ephemeral: bool`、`text: str` 和 `client_msg_id: str`；`kind` 不由调用方传入，始终为 `StimulusKind.TEXT_MESSAGE`。
+- `StimulusKind.TEXT_MESSAGE`：当前已实现强类型 Stimulus 的稳定判别值。
+- `StimulusSource.USER`：表示该领域事实由用户行为产生，不表示 WebSocket、HTTP 等传输通道。
+- `PersistPolicy`：新旧 Stimulus 协议共用的同一四成员枚举；可从 `src.domain.agent`、`src.domain.stimulus` 和 `src.domain` 导入，不是三套独立类型。
 - `Stimulus`：系统收到的一次刺激。主要字段为 `source_channel`、`modality`、`payload`、`text`、`sender_user_id`、`target_character_ids`、`client_msg_id`、`persist_policy` 和 `ephemeral`。
 - `SourceChannel`、`StimulusModality`、`PersistPolicy`：分别限定刺激来自哪里、是什么形式、允许怎样持久化。
 - `Stimulus.targets_character(character_id)`：判断刺激是否发给指定角色。
@@ -45,11 +50,13 @@
 - `MyTool`、`ToolFunction`、`ToolOneParameter`：模型工具调用的声明数据。
 - `PlanningStep`、`ReplyIntensity`、`SingingAction`：当前规划和回复实现共享的计划步骤、强度与演唱动作数据。
 
-完整公开名称以 `server/src/domain/__init__.py` 的导出为准。
+根路径完整公开名称以 `server/src/domain/__init__.py` 的导出为准；Agent 强类型领域协议当前从 `src.domain.agent` 导入。
 
 ## 正常与异常行为
 
 - 创建这些对象只做字段校验和默认值生成，不产生外部副作用。
+- `TextMessage` 构造后不可变，不提供任意 `payload` 扩展口，并逐项保留调用方提供的公共字段和文字消息专有字段。
+- 当前契约测试只锁定合法样例：`source=USER`、`persist_policy=CONVERSATION_AND_MEMORY_CANDIDATE`、`ephemeral=False`。本切片尚未实现 source/persist/ephemeral 组合校验，因此其他组合当前不会按目标 spec 稳定返回 `CONTRACT_INVALID_STIMULUS`；调用方不得把这种暂未校验视为受支持行为。
 - 枚举值和字段名属于跨模块协议；修改时必须先更新 spec 和消费者测试。
 - `Stimulus` 默认不持久化。调用方必须显式选择 `PersistPolicy`，不能仅凭消息来源猜测。
 - 构造参数不合法时由 dataclass、枚举或 Pydantic 抛出类型/校验异常，调用方不应静默吞掉。
@@ -60,6 +67,8 @@
 
 ## 应覆盖的契约场景
 
+- `TextMessage` 从 `src.domain.agent` 构造后固定为 `TEXT_MESSAGE`，逐项保留全部字段、拒绝赋值修改且不存在 `payload`。
+- `src.domain.agent`、`src.domain.stimulus` 和 `src.domain` 导出的 `PersistPolicy` 是同一个四成员枚举对象。
 - 不同 `PersistPolicy` 下，`should_persist_conversation()` 和 `can_be_memory_candidate()` 返回预期结果。
 - `AgentState.with_updates(...)` 返回新对象且不修改原状态。
 - 未指定目标角色、时间或 ID 时，默认值稳定且可序列化。

--- a/server/src/domain/agent/__init__.py
+++ b/server/src/domain/agent/__init__.py
@@ -1,0 +1,8 @@
+from .stimulus import PersistPolicy, StimulusKind, StimulusSource, TextMessage
+
+__all__ = (
+    "PersistPolicy",
+    "StimulusKind",
+    "StimulusSource",
+    "TextMessage",
+)

--- a/server/src/domain/agent/stimulus.py
+++ b/server/src/domain/agent/stimulus.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class PersistPolicy(str, Enum):
+    """Controls whether raw stimulus content enters conversation or memory evidence."""
+
+    NONE = "none"
+    EPHEMERAL_ONLY = "ephemeral_only"
+    CONVERSATION_ONLY = "conversation_only"
+    CONVERSATION_AND_MEMORY_CANDIDATE = "conversation_and_memory_candidate"
+
+
+class StimulusKind(str, Enum):
+    """Stable discriminator for the implemented stimulus variants."""
+
+    TEXT_MESSAGE = "text_message"
+
+
+class StimulusSource(str, Enum):
+    """Supplier-independent semantic owner of a stimulus fact."""
+
+    USER = "user"
+
+
+@dataclass(frozen=True, slots=True)
+class TextMessage:
+    """An immutable, complete user text message submitted to an Agent.
+
+    Identity, schema, occurrence time, semantic source, target characters,
+    optional user, persistence policy, lifetime, text, and client retry ID are
+    retained exactly as supplied. ``kind`` is always ``TEXT_MESSAGE`` and is
+    not a constructor argument. This first Green slice implements only the
+    approved legal construction; invalid combinations remain a later TDD
+    slice and are not validated here.
+    """
+
+    stimulus_id: str
+    schema_version: int
+    occurred_at: datetime
+    source: StimulusSource
+    target_character_ids: tuple[str, ...]
+    user_id: str | None
+    persist_policy: PersistPolicy
+    ephemeral: bool
+    text: str
+    client_msg_id: str
+    kind: StimulusKind = field(default=StimulusKind.TEXT_MESSAGE, init=False)

--- a/server/src/domain/stimulus.py
+++ b/server/src/domain/stimulus.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any
 from uuid import uuid4
+
+from src.domain.agent import PersistPolicy
 
 
 class SourceChannel(str, Enum):
@@ -26,13 +29,6 @@ class StimulusModality(str, Enum):
     WORLD_EVENT = "world_event"
     SYSTEM_EVENT = "system_event"
     UNKNOWN = "unknown"
-
-
-class PersistPolicy(str, Enum):
-    NONE = "none"
-    EPHEMERAL_ONLY = "ephemeral_only"
-    CONVERSATION_ONLY = "conversation_only"
-    CONVERSATION_AND_MEMORY_CANDIDATE = "conversation_and_memory_candidate"
 
 
 @dataclass(frozen=True)

--- a/server/tests/domain/test_agent_handle_contract.py
+++ b/server/tests/domain/test_agent_handle_contract.py
@@ -1,0 +1,31 @@
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+
+import pytest
+
+from src.domain.agent import PersistPolicy, StimulusKind, StimulusSource, TextMessage
+
+
+def test_text_message_constructs_as_immutable_registered_stimulus() -> None:
+    occurred_at = datetime(2026, 9, 5, 8, 30, tzinfo=timezone.utc)
+
+    stimulus = TextMessage(
+        stimulus_id="stimulus-text-1",
+        schema_version=1,
+        occurred_at=occurred_at,
+        source=StimulusSource.USER,
+        target_character_ids=("luotianyi",),
+        user_id="user-1",
+        persist_policy=PersistPolicy.CONVERSATION_AND_MEMORY_CANDIDATE,
+        ephemeral=False,
+        text="你好，天依",
+        client_msg_id="client-message-1",
+    )
+
+    assert stimulus.kind is StimulusKind.TEXT_MESSAGE
+    assert stimulus.occurred_at == occurred_at
+    assert stimulus.target_character_ids == ("luotianyi",)
+    assert stimulus.text == "你好，天依"
+
+    with pytest.raises(FrozenInstanceError):
+        stimulus.text = "被修改的内容"

--- a/server/tests/domain/test_agent_handle_contract.py
+++ b/server/tests/domain/test_agent_handle_contract.py
@@ -1,4 +1,3 @@
-from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
 
 import pytest
@@ -23,9 +22,18 @@ def test_text_message_constructs_as_immutable_registered_stimulus() -> None:
     )
 
     assert stimulus.kind is StimulusKind.TEXT_MESSAGE
+    assert stimulus.stimulus_id == "stimulus-text-1"
+    assert stimulus.schema_version == 1
     assert stimulus.occurred_at == occurred_at
+    assert stimulus.source is StimulusSource.USER
     assert stimulus.target_character_ids == ("luotianyi",)
+    assert stimulus.user_id == "user-1"
+    assert stimulus.persist_policy is PersistPolicy.CONVERSATION_AND_MEMORY_CANDIDATE
+    assert stimulus.ephemeral is False
     assert stimulus.text == "你好，天依"
+    assert stimulus.client_msg_id == "client-message-1"
+    assert not hasattr(stimulus, "payload")
 
-    with pytest.raises(FrozenInstanceError):
+    with pytest.raises((AttributeError, TypeError, ValueError)):
         stimulus.text = "被修改的内容"
+    assert stimulus.text == "你好，天依"


### PR DESCRIPTION
## 对应工单

Part of #60

这是 expand 阶段首个 `TextMessage` 可观察行为的完整 Green 根 PR，不关闭 #60。Issue 的其余领域契约尚未实现。

## 本 PR 目标

从公开入口 `src.domain.agent` 交付已批准的 `TextMessage` 契约测试和足以让该测试通过的最小实现：

- 通过完整强类型字段构造并逐项保留；
- `kind` 固定为 `StimulusKind.TEXT_MESSAGE`；
- 对象不可变且不提供任意 `payload` 扩展口；
- `PersistPolicy` 在新旧公开路径中保持单一类型身份。

## TDD 与堆叠交付

- interface 设计 PR #91 已批准并合入 `refactor/agent`，提交 `661b7d2`；
- 本 PR 的 Red seam 在 head `c724c1f` 获批准；
- 最小 Green 子 PR #94 已批准，并于 2026-09-05 squash merge 到本分支，提交 `3b156739`；
- 子 PR 合入后旧批准和测试证据失效，本 PR 已按最新 head 和当前 `refactor/agent` fixed point 重新验证。

Red 证据：

```text
ModuleNotFoundError: No module named 'src.domain.agent'
```

## 当前验证

从 `server` 目录运行：

- `conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` -> `1 passed in 0.18s`；
- `conda run -n agent python -m pytest tests/domain -q` -> `1 passed in 0.18s`；
- changed-file `py_compile`、Ruff 通过；
- `conda run -n agent basedpyright src/domain/agent` -> `0 errors, 0 warnings`；
- 三处公开路径的 `PersistPolicy` 对象身份和四成员检查通过；
- `git diff --check origin/refactor/agent...HEAD` 通过。

离线回归排除真实图片/TTS/唱歌资源测试、真实 B 站/VCPedia 抓取和 `real_llm` 后：候选为 `400 passed, 4 deselected, 6 failed`，当前 `refactor/agent` 对照为 `399 passed, 4 deselected, 6 failed`。六个失败集合一致，未发现本切片新增回归；仓库默认回归门禁仍未全绿。

## 明确不包含

- 不实现其余 21 个 Stimulus 或非法组合校验；
- 不增加 InteractionSnapshot、HandleStimulusRequest、CancellationToken 或 HandlingReport；
- 不修改生产调用链、ActionPlan、Agent facade、Handler 路由或 stage 迁移；
- 未运行真实学歌、B 站/VCPedia 抓取、真实 LLM/TTS/GPU/设备链路，以上保持未验证。

## 下一步

本完整 Green 根 PR 通过复审后由 owner squash merge 到 `refactor/agent`。工单 01 的下一可观察行为另开新的 TDD 切片。
