### PR TITLE
docs(agent): 固定 handle 刺激枚举协议

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -13,7 +13,16 @@
 - 本地工单草案：[`issues/`](../../../.scratch/agent-handle-realize/issues/)
 - 当前 Agent interface：[`agent/README.md`](../../项目说明/项目架构与接口（spec）/接口文档/agent/README.md)
 
-## 本轮目标与范围
+## 本 PR
+
+- PR：[#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91)（Draft，`CHANGES_REQUESTED`）
+- 目标：补齐 Issue #60 开始契约测试前缺失的 Stimulus 公开枚举设计，使测试不再猜测成员和值。
+- 范围：`StimulusKind`、`StimulusSource`、`PersistPolicy` 的成员和值，以及 expand 阶段新旧协议的兼容边界。
+- 明确不包含：不修改 PR #90 的测试，不增加产品实现，不修改旧 `Stimulus.payload` 或生产调用链，不关闭 Issue #60。
+- 验证及结果：`git diff --check origin/refactor/agent...HEAD` 通过；本 PR 为纯文档 interface 门禁，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；GitHub 无 CI checks。
+- 评审结果：22 个 `StimulusKind` 与当前 22 个强类型变体逐项一致，该部分通过；其余设计仍需修改后重新评审。
+
+## 历史设计轮次目标与范围
 
 - 把已形成的 Agent 深模块 PRD 转为可评审 interface spec，并按首轮评审意见收窄当前版本；
 - 分开描述 Agent 对外行为与 Agent 内部 Handler / Skill / Store / Ledger / Reflection 行为；
@@ -33,7 +42,7 @@
 - 明确 `agent/skills` 是角色语义层、既有 `capabilities` 是技术实现层，二者不一对一镜像，Handler 只能依赖强类型 Skill；
 - 把目录与依赖约束同步到实际承担相应迁移的本地工单和 GitHub Issue，使开发者只读单张工单也不会误建旁路。
 
-本轮只修改 SPEC、本地工单、对应 GitHub Issue 和进度文档；不修改产品代码、测试、客户端/网络协议或现有运行行为。
+该历史设计轮次只修改 SPEC、本地工单、对应 GitHub Issue 和进度文档；未修改产品代码、测试、客户端/网络协议或现有运行行为。
 
 ## 已完成
 
@@ -82,7 +91,9 @@
 
 ## 待评审与未验证
 
-- [ ] 工单 01 的 `StimulusKind`、`StimulusSource`、`PersistPolicy` 成员及序列化值已补入 interface SPEC，等待用户评审；
+- [ ] PR #91 已收到 owner 的 `CHANGES_REQUESTED`：需要为每个 `StimulusKind` 补充允许的 `StimulusSource` 矩阵，并明确 scheduler/WorldClock 只是触发机制还是语义 source；
+- [ ] PR #91 需要补充各 `StimulusKind` 的 `PersistPolicy` 与 `ephemeral` 合法组合，并决定目标协议复用现有 `PersistPolicy`，还是以明确语义差异建立新类型；
+- [ ] `StimulusSource.SYSTEM` 当前没有对应的 22 种 Stimulus 使用，需删除或提供当前范围内唯一、完整的使用规则；
 - [ ] PR #90 的契约测试仍为 Red-only Draft，且有 `CHANGES_REQUESTED`；本 SPEC 门禁通过前不修改该测试、不开始产品实现；
 - [ ] 本文档 PR 只做静态文档检查，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
@@ -102,4 +113,4 @@
 
 ## 下一步
 
-先评审工单 01 的三个公开枚举闭集和序列化值。评审通过后，回到 PR #90 按 review comments 修正首个 `TextMessage` 契约测试并重新记录 Red；测试 seam 获批后才进入最小 Green 实现。
+继续在 PR #91 内完成 source 矩阵、persist/ephemeral 组合矩阵和 `PersistPolicy` 单一类型决策，删除无实际使用者的 speculative source，并重新请求设计评审。PR #91 合入后，回到 PR #90 按 review comments 修正首个 `TextMessage` 契约测试并重新记录 Red；测试 seam 获批后才进入最小 Green 实现。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：实现工单及架构约束已更新，等待首批开发
+> 当前阶段：工单 01 interface SPEC 补充评审
 >
 > 总体状态：进行中
 
@@ -82,7 +82,9 @@
 
 ## 待评审与未验证
 
-- [ ] interface spec 尚未完成用户评审，不能据此开始产品实现；
+- [ ] 工单 01 的 `StimulusKind`、`StimulusSource`、`PersistPolicy` 成员及序列化值已补入 interface SPEC，等待用户评审；
+- [ ] PR #90 的契约测试仍为 Red-only Draft，且有 `CHANGES_REQUESTED`；本 SPEC 门禁通过前不修改该测试、不开始产品实现；
+- [ ] 本文档 PR 只做静态文档检查，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
 - [ ] `RequestSongLearning` 的持久任务 Adapter、任务状态和完成 Stimulus 事务边界尚未选择具体实现；
 - [ ] Agent 自有状态变更与 Reflection 之间的 evidence 去重键、revision 冲突策略只有目标语义，尚未落实；
@@ -96,8 +98,8 @@
 - [ ] `WorldClock` 九类链路来自当前源码和配置的静态盘点，尚未逐项运行真实网络、LLM、唱歌模型或数据库任务；
 - [ ] 当前歌曲抓取与学歌任务仍直接写数据、刷新库或发布动态，与目标 Stimulus 边界不同；
 - [ ] 当前 `Stimulus.payload` 和 `PlannedAction.payload` 仍是任意 Mapping，目标强类型联合尚未实现；
-- [ ] 本轮未运行 pytest、真实 LLM、TTS、设备或生产环境验证；只进行文档静态检查。
+- [ ] 先前整体 SPEC 编写轮次未运行真实 LLM、TTS、设备或生产环境验证；对应实现工单必须分别记录实际验证。
 
 ## 下一步
 
-SPEC、工单底稿、领域术语和进度已经补充目录/依赖/迁移约束，对应 GitHub Issue 已同步更新；本次提交推送后，下一步可并行开始无 blocker 的 #60（handle 输入与结算领域契约）和 #62（冻结 WorldClock 基线）。每张工单仍需独立遵守 TDD 与小 PR 门禁。
+先评审工单 01 的三个公开枚举闭集和序列化值。评审通过后，回到 PR #90 按 review comments 修正首个 `TextMessage` 契约测试并重新记录 Red；测试 seam 获批后才进入最小 Green 实现。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -17,10 +17,10 @@
 
 - PR：[#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91)（Draft，`CHANGES_REQUESTED`）
 - 目标：补齐 Issue #60 开始契约测试前缺失的 Stimulus 公开枚举设计，使测试不再猜测成员和值。
-- 范围：`StimulusKind`、`StimulusSource`、`PersistPolicy` 的成员和值，以及 expand 阶段新旧协议的兼容边界。
+- 范围：`StimulusKind`、`StimulusSource`、`PersistPolicy` 的成员和值；每个 kind 的 source/persist/ephemeral 唯一合法组合；expand 阶段新旧协议的兼容边界。
 - 明确不包含：不修改 PR #90 的测试，不增加产品实现，不修改旧 `Stimulus.payload` 或生产调用链，不关闭 Issue #60。
-- 验证及结果：`git diff --check origin/refactor/agent...HEAD` 通过；本 PR 为纯文档 interface 门禁，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；GitHub 无 CI checks。
-- 评审结果：22 个 `StimulusKind` 与当前 22 个强类型变体逐项一致，该部分通过；其余设计仍需修改后重新评审。
+- 验证及结果：`git diff --check` 通过；静态核对 22 个 `StimulusKind` 均在唯一组合矩阵中逐项覆盖，SPEC 中已无 `StimulusSource.SYSTEM/SCHEDULER` 枚举残留；本 PR 为纯文档 interface 门禁，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；GitHub 无 CI checks。
+- 评审结果：22 个 `StimulusKind` 与当前 22 个强类型变体逐项一致，该部分已通过；本轮已按 owner 意见删除无生产者的 `SYSTEM` 和仅作为触发机制的 `SCHEDULER`，增加 22 行唯一组合矩阵与非法组合规则，并明确新旧协议复用单一 `PersistPolicy` 类型，仍需 owner 重新评审。
 
 ## 历史设计轮次目标与范围
 
@@ -91,9 +91,10 @@
 
 ## 待评审与未验证
 
-- [ ] PR #91 已收到 owner 的 `CHANGES_REQUESTED`：需要为每个 `StimulusKind` 补充允许的 `StimulusSource` 矩阵，并明确 scheduler/WorldClock 只是触发机制还是语义 source；
-- [ ] PR #91 需要补充各 `StimulusKind` 的 `PersistPolicy` 与 `ephemeral` 合法组合，并决定目标协议复用现有 `PersistPolicy`，还是以明确语义差异建立新类型；
-- [ ] `StimulusSource.SYSTEM` 当前没有对应的 22 种 Stimulus 使用，需删除或提供当前范围内唯一、完整的使用规则；
+- [x] PR #91 已为全部 22 个 `StimulusKind` 固定唯一 `StimulusSource`；scheduler/`world_clock` 明确为时间驱动和投递机制，不是语义 source；
+- [x] PR #91 已固定全部 kind 的 `PersistPolicy / ephemeral` 唯一合法组合和表外稳定失败规则，并决定新旧 Stimulus 协议复用单一 `PersistPolicy` 类型；
+- [x] 已删除没有当前生产者的 `StimulusSource.SYSTEM`；同时删除仅表示触发机制、与 source 定义冲突的 `SCHEDULER`；
+- [ ] PR #91 上述修订尚未获得 owner 重新评审通过，当前仍不能合并或进入 PR #90；
 - [ ] PR #90 的契约测试仍为 Red-only Draft，且有 `CHANGES_REQUESTED`；本 SPEC 门禁通过前不修改该测试、不开始产品实现；
 - [ ] 本文档 PR 只做静态文档检查，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
@@ -113,4 +114,4 @@
 
 ## 下一步
 
-继续在 PR #91 内完成 source 矩阵、persist/ephemeral 组合矩阵和 `PersistPolicy` 单一类型决策，删除无实际使用者的 speculative source，并重新请求设计评审。PR #91 合入后，回到 PR #90 按 review comments 修正首个 `TextMessage` 契约测试并重新记录 Red；测试 seam 获批后才进入最小 Green 实现。
+完成 PR #91 的静态验证后重新请求 owner 设计评审，并保持 Draft。PR #91 获批并合入后，回到 PR #90 按 review comments 修正首个 `TextMessage` 契约测试并重新记录 Red；测试 seam 获批后才进入最小 Green 实现。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -19,7 +19,7 @@
 - 目标：补齐 Issue #60 开始契约测试前缺失的 Stimulus 公开枚举设计，使测试不再猜测成员和值。
 - 范围：`StimulusKind`、`StimulusSource`、`PersistPolicy` 的成员和值；每个 kind 的 source/persist/ephemeral 唯一合法组合；expand 阶段新旧协议的兼容边界。
 - 明确不包含：不修改 PR #90 的测试，不增加产品实现，不修改旧 `Stimulus.payload` 或生产调用链，不关闭 Issue #60。
-- 验证及结果：`git diff --check` 通过；静态核对 22 个 `StimulusKind` 均在唯一组合矩阵中逐项覆盖，SPEC 中已无 `StimulusSource.SYSTEM/SCHEDULER` 枚举残留；本 PR 为纯文档 interface 门禁，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；GitHub 无 CI checks。
+- 验证及结果：`git diff --check` 通过；静态核对 22 个 `StimulusKind` 均在唯一组合矩阵中逐项覆盖，SPEC 中已无 `StimulusSource.SYSTEM/SCHEDULER` 枚举残留；本 PR 为纯文档 interface 门禁，未运行 pytest、真实 LLM、TTS、设备或生产环境验证；GitHub 自动审查的 `resolve`、`review`、`publish` 3 个 job 均为 `skipped`，未执行 CI 验证。
 - 评审结果：22 个 `StimulusKind` 与当前 22 个强类型变体逐项一致，该部分已通过；本轮已按 owner 意见删除无生产者的 `SYSTEM` 和仅作为触发机制的 `SCHEDULER`，增加 22 行唯一组合矩阵与非法组合规则，并明确新旧协议复用单一 `PersistPolicy` 类型，仍需 owner 重新评审。
 
 ## 历史设计轮次目标与范围

--- a/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
@@ -154,7 +154,7 @@ WorldStage 不拥有权威 world/活动数据，也不解释抓取结果；权�
 | world 领域定时 | world 定义“每日规划”“活动到期”“抓取新歌”等事实为什么产生 | `world_clock` 只负责到时唤醒 | `WorldClock -> world task -> 强类型 Stimulus -> WorldStage -> Agent` |
 | stage 交互定时 | WorldStage 定义何时聚合完 pending、重试或重新判断 | WorldStage 自有 deadline/scheduler；不注册为 world 领域事件 | `WorldStage deadline -> InteractionDeadline -> handle_stimulus` |
 
-Agent 通过 `CreateSchedule` 创建的持久未来安排由 scheduler/world 保存。到期后，world 把它转换为强类型事实并投递给 WorldStage；`world_clock` 可以作为底层唤醒器，但不得直接构造角色回复或调用 Agent。
+Agent 通过 `CreateSchedule` 创建的持久未来安排由 scheduler/world 保存。`future_stimulus` 只允许使用来源矩阵中 `source=WORLD` 的 kind；其 source 在创建日程时确定，到期后 world 保留该语义来源并把强类型事实投递给 WorldStage，不因 scheduler 或 `world_clock` 执行了最后一跳而改写。`ProactivePromptDue` 和 `InteractionDeadline` 不能直接作为 `future_stimulus` 保存，必须由拥有目标 interaction、pending/claim 和输出路由的 stage 在收到到期事实后构造。`world_clock` 可以作为底层唤醒器，但不得直接构造角色回复或调用 Agent。
 
 ## 5. Agent 暴露给外部的行为
 
@@ -242,15 +242,13 @@ Agent 已由角色 ID 取得，请求不重复携带 `character_id`。请求不�
 | 成员 | 序列化值 | 使用边界 |
 | --- | --- | --- |
 | `USER` | `user` | 用户提交的消息、输入协调信号或触摸等用户行为 |
-| `DEVICE` | `device` | 设备聚合后的振动、连接和断开事实 |
+| `DEVICE` | `device` | 以设备本身为主体、并携带 `device_id` 的振动、连接和断开事实；设备转发的用户触摸仍为 `USER` |
 | `WORLD` | `world` | world 规范化的外部事实、活动事实、动态和歌曲事实 |
-| `SCHEDULER` | `scheduler` | 持久 scheduler 到期产生的主动提醒或领域日程事实 |
-| `STAGE` | `stage` | stage 为交互控制产生的 deadline 等协调事实 |
-| `SYSTEM` | `system` | 系统生命周期产生、且确实需要角色认知的事实 |
+| `STAGE` | `stage` | stage 为所拥有 interaction 产生的主动表达到期、deadline 等交互事实 |
 
-来源按事实的语义所有者选择，而不是按最后一跳调用者选择。例如 world task 被 `WorldClock` 唤醒后产生的观察仍为 `WORLD`；持久 scheduler 到期直接产生的 `ProactivePromptDue` 为 `SCHEDULER`；`InteractionDeadline` 为 `STAGE`。Adapter 只负责转换，不构成单独的 `ADAPTER` 来源。当前版本不提供 `UNKNOWN`，无法归类的来源必须在进入领域协议前失败。
+来源按事实的语义所有者选择，而不是按最后一跳调用者选择。scheduler 和 `world_clock` 只提供持久保存、到期唤醒和投递机制，不是语义来源，也不得在到期时改写已经确定的 `source`。例如 world task 被 `WorldClock` 唤醒后产生的观察仍为 `WORLD`；ChatStage 或 WorldStage 为自己拥有的 interaction 构造的 `ProactivePromptDue` 和 `InteractionDeadline` 为 `STAGE`。Adapter 只负责转换，不构成单独的 `ADAPTER` 来源。当前版本不提供 `UNKNOWN`；不能满足下方来源矩阵的输入必须在进入领域协议前以稳定 `CONTRACT_INVALID_STIMULUS` 错误失败。
 
-`PersistPolicy` 的成员和值沿用现有领域语义，目标协议重新声明为稳定闭集：
+`PersistPolicy` 是新旧 Stimulus 协议共用的单一领域枚举，不为目标协议复制第二个同义类型。其稳定闭集为：
 
 | 成员 | 序列化值 | 含义 |
 | --- | --- | --- |
@@ -259,7 +257,43 @@ Agent 已由角色 ID 取得，请求不重复携带 `character_id`。请求不�
 | `CONVERSATION_ONLY` | `conversation_only` | 进入会话记录，但不自动成为长期记忆证据候选 |
 | `CONVERSATION_AND_MEMORY_CANDIDATE` | `conversation_and_memory_candidate` | 进入会话记录，并允许成为长期记忆证据候选 |
 
-expand 阶段允许目标协议枚举与 `server/src/domain/stimulus.py` 中的旧枚举并存，但二者是不同协议类型，调用方不得依赖同名成员可隐式互换。迁移 Adapter 必须显式转换；旧 `SourceChannel` 和 `StimulusModality` 不能作为新协议的 `StimulusSource` 或 `StimulusKind` 使用。旧协议删除仍只由工单 29 负责。
+目标实现把该唯一类型归属到 `domain.agent` 公共协议；expand 阶段由 `server/src/domain/stimulus.py` 导入并重导出同一类型，使旧调用方保持源码兼容。工单 29 删除旧 Stimulus 时再删除该兼容导出。`StimulusKind` 和 `StimulusSource` 则与旧 `StimulusModality`、`SourceChannel` 语义不同，迁移 Adapter 必须显式转换，不能依赖同名成员隐式互换。
+
+每个 `StimulusKind` 当前只允许下表中的唯一 `source / persist_policy / ephemeral` 组合。公开构造入口必须逐项校验；表外组合以稳定 `CONTRACT_INVALID_STIMULUS` 错误失败：
+
+| `StimulusKind` | 唯一合法 `StimulusSource` | 唯一合法 `PersistPolicy` | `ephemeral` |
+| --- | --- | --- | --- |
+| `TEXT_MESSAGE` | `USER` | `CONVERSATION_AND_MEMORY_CANDIDATE` | `False` |
+| `IMAGE_MESSAGE` | `USER` | `CONVERSATION_AND_MEMORY_CANDIDATE` | `False` |
+| `VOICE_MESSAGE` | `USER` | `CONVERSATION_AND_MEMORY_CANDIDATE` | `False` |
+| `USER_TYPING` | `USER` | `EPHEMERAL_ONLY` | `True` |
+| `IMAGE_SELECTION_OPENED` | `USER` | `EPHEMERAL_ONLY` | `True` |
+| `IMAGE_SELECTION_CLOSED` | `USER` | `EPHEMERAL_ONLY` | `True` |
+| `TOUCH_INTERACTION` | `USER` | `EPHEMERAL_ONLY` | `True` |
+| `TOY_VIBRATION` | `DEVICE` | `NONE` | `True` |
+| `DEVICE_CONNECTED` | `DEVICE` | `NONE` | `True` |
+| `DEVICE_DISCONNECTED` | `DEVICE` | `NONE` | `True` |
+| `PROACTIVE_PROMPT_DUE` | `STAGE` | `NONE` | `True` |
+| `INTERACTION_DEADLINE` | `STAGE` | `NONE` | `True` |
+| `DYNAMIC_OBSERVED` | `WORLD` | `NONE` | `False` |
+| `DIARY_PLANNING_DUE` | `WORLD` | `NONE` | `False` |
+| `WORLD_OBSERVATION` | `WORLD` | `NONE` | `False` |
+| `DAILY_PLANNING_DUE` | `WORLD` | `NONE` | `False` |
+| `ACTIVITY_DUE` | `WORLD` | `NONE` | `False` |
+| `ACTIVITY_STARTED` | `WORLD` | `NONE` | `False` |
+| `ACTIVITY_OBSERVATION` | `WORLD` | `NONE` | `False` |
+| `ACTIVITY_ENDED` | `WORLD` | `NONE` | `False` |
+| `SONG_KNOWLEDGE_DISCOVERED` | `WORLD` | `NONE` | `False` |
+| `SONG_LEARNED` | `WORLD` | `NONE` | `False` |
+
+矩阵同时固定以下不变量：
+
+- `EPHEMERAL_ONLY` 必须搭配 `ephemeral=True`，用于原始内容只允许在当前 interaction 窗口复用的输入，例如输入长度、图片选择状态或触摸事实；
+- `ephemeral=False` 不得搭配 `EPHEMERAL_ONLY`；`NONE` 是否为 ephemeral 由逐 kind 矩阵确定；
+- `CONVERSATION_ONLY` 和 `CONVERSATION_AND_MEMORY_CANDIDATE` 必须搭配 `ephemeral=False`；
+- `NONE` 不进入会话记录；它可以搭配只在当前窗口有效的到期/振动事实，也可以搭配跨窗口仍有权威来源的设备或 world 事实；
+- `persist_policy` 只决定 Stimulus 原始内容是否进入会话记录和是否成为自动长期记忆候选。`DynamicObserved`、`SongLearned` 等 `NONE` 事实仍可按 Agent 内部状态变更或 Reflection 契约写入领域数据；
+- `CONVERSATION_ONLY` 在当前 22 个 kind 中没有生产者，但因复用现有唯一枚举而保留。任何 kind 改用该策略都属于需要先修改本矩阵的公开协议变更。
 
 #### 当前版本 Stimulus 强类型变体
 
@@ -277,7 +311,7 @@ expand 阶段允许目标协议枚举与 `server/src/domain/stimulus.py` 中的�
 | `ToyVibration` | 经过设备层聚合、可被角色感知的一次振动模式 | `device_id: str`：设备身份；`pattern: VibrationPattern`：模式；`intensity: float`：归一化强度；`duration_ms: int`：持续时间；`location: Optional[DeviceLocation]`：可选设备位置 | Toy |
 | `DeviceConnected` | 角色交互设备已经可用 | `device_id: str`：设备身份；`supported_inputs: frozenset[DeviceInputKind]`：设备可上报输入；`supported_outputs: frozenset[AgentOutputKind]`：设备可呈现输出 | Toy |
 | `DeviceDisconnected` | 角色交互设备已经断开 | `device_id: str`：设备身份；`disconnected_at: datetime`：断开时间；`reason: DeviceDisconnectReason`：规范化原因 | Toy |
-| `ProactivePromptDue` | 持久 scheduler 判定一次主动表达已到期 | `reason: ProactiveReason`：触发原因；`due_at: datetime`：到期时间；`dedup_key: str`：调度去重键；`fact_refs: tuple[EvidenceRef, ...]`：相关事实引用 | Chat 或 World |
+| `ProactivePromptDue` | 拥有当前 interaction 的 stage 判定一次主动表达已到期；持久 scheduler 只负责唤醒和投递 | `reason: ProactiveReason`：触发原因；`due_at: datetime`：到期时间；`dedup_key: str`：调度去重键；`fact_refs: tuple[EvidenceRef, ...]`：相关事实引用 | Chat 或 World |
 | `InteractionDeadline` | stage 为仍待判断的刺激触发一次定时重评 | `origin_request_id: str`：此前保留 pending 并建立本期限的请求；`pending_stimulus_ids: tuple[str, ...]`：需重评的内容刺激；`due_at: datetime`：到期时间；`dedup_key: str`：定时器去重键 | 对应原 Interaction |
 | `DynamicObserved` | world/Adapter 观察到一条对角色有意义的动态内容 | `dynamic_id: str`：平台无关身份；`author_ref: ActorRef`：作者引用；`text: str`：正文；`media_refs: tuple[MediaRef, ...]`：媒体；`revision: int`：内容版本 | World |
 | `DiaryPlanningDue` | 角色的日记规划时点到达 | `local_date: date`：日记归属日期；`timezone: ZoneInfo`：日期解释时区；`trigger_id: str`：调度触发身份 | World |
@@ -461,7 +495,7 @@ async def realize_action_plan(
 | `WriteDiary` | 持久化并按策略发布一篇已决定的日记 | `local_date: date`：归属日期；`title: str`：标题；`body: str`：正文；`visibility: Visibility`：可见范围；`dedup_key: str`：重复执行保护键 | 产生日记持久化/发布效果 |
 | `PublishDynamic` | 发布一条角色动态 | `body: str`：正文；`media_refs: tuple[MediaRef, ...]`：媒体；`visibility: Visibility`：可见范围；`dedup_key: str`：重复发布保护键 | 产生动态发布效果 |
 | `ReplyDynamic` | 对指定动态或评论发布角色回复 | `target_ref: DynamicReplyTarget`：目标动态/评论；`body: str`：回复正文；`dedup_key: str`：重复回复保护键 | 产生评论回复效果 |
-| `CreateSchedule` | 创建一个将来产生强类型 Stimulus 的持久日程 | `schedule_id: str`：日程身份；`due_at: datetime`：到期时间；`future_stimulus: Stimulus`：到期后提交的领域事实；`dedup_key: str`：重复创建保护键 | 提交持久 scheduler 记录 |
+| `CreateSchedule` | 创建一个将来产生强类型 Stimulus 的持久日程 | `schedule_id: str`：日程身份；`due_at: datetime`：到期时间；`future_stimulus: Stimulus`：到期后提交的 `source=WORLD` 领域事实，不允许 `ProactivePromptDue` 或 `InteractionDeadline`；`dedup_key: str`：重复创建保护键 | 提交持久 scheduler 记录 |
 | `CancelSchedule` | 幂等取消一个已有日程 | `schedule_id: str`：目标日程；`expected_schedule_revision: int`：并发保护修订；`reason: ScheduleCancellationReason`：取消原因 | scheduler Adapter 查询权威 revision 后提交状态变化 |
 | `RequestSongLearning` | 启动一个可恢复、跨进程的技术学歌任务 | `learning_job_id: str`：任务身份；`song_id: str`：目标歌曲；`priority: LearningPriority`：调度优先级；`dedup_key: str`：重复任务保护键 | 由 Action Handler 提交持久 world/capability 任务，不经过 output sink |
 
@@ -576,7 +610,7 @@ output sink 在创建时绑定 stage 和 interaction：
 - interaction、activity、schedule 等 revision 冲突返回各自稳定失败，不静默覆盖新状态；
 - 日志必须能由 `interaction_id / stimulus_id / request_id / plan_id / execution_id / action_id` 串联。
 
-稳定错误族至少包括：`CONTRACT_*`、`UNSUPPORTED_*`、`STALE_INTERACTION`、`STALE_ACTIVITY`、`STALE_SCHEDULE`、`SINK_CLOSED`、`BACKPRESSURE_TIMEOUT`、`DEPENDENCY_UNAVAILABLE`、`PROVIDER_TIMEOUT`、`CANCELLED` 和 `INTERNAL_ERROR`。调用方只根据稳定码和 `retryable` 决策，不解析异常字符串。
+稳定错误族至少包括：`CONTRACT_INVALID_STIMULUS`（Stimulus 字段、source/persist/ephemeral 组合或目标角色非法）、`CONTRACT_UNSUPPORTED_SCHEMA`、`CONTRACT_SNAPSHOT_MISMATCH`、`UNSUPPORTED_*`、`STALE_INTERACTION`、`STALE_ACTIVITY`、`STALE_SCHEDULE`、`SINK_CLOSED`、`BACKPRESSURE_TIMEOUT`、`DEPENDENCY_UNAVAILABLE`、`PROVIDER_TIMEOUT`、`CANCELLED` 和 `INTERNAL_ERROR`。调用方只根据稳定码和 `retryable` 决策，不解析异常字符串。
 
 本版本没有 5.5 Realtime 相邻接口。电话媒体上行、Realtime turn、通话打断和供应商会话引用留待电话版本单独设计。
 
@@ -1092,6 +1126,8 @@ ImportantDateReview 只能把用户明确表达且字段充分的日期标成 co
 28. `agent/context` 只保存 interaction-scoped 临时认知工作集和有来源/版本/TTL 的检索证据；stage pending、连接、长期记忆/画像和权威 world 状态不得迁入。
 29. 两个 façade 的跨模块协议归 `domain` 所有；Agent 包根只导出 façade 类型，内部包和 factory 不公开重导出；`SystemRuntime` 作为装配代码直接通过 factory 注入具体 Skill、Store、Ledger 和 Handler registry。
 30. 目录迁移必须按第 6.1.4 节渐进执行：先协议和 façade，后逐链迁移，最后统一删除 `agent/reflex`、旧 AgentRuntime/CharacterRuntime 业务代理和外部 `agent.main_chat` 类型依赖；不得永久双轨。
+31. `StimulusSource` 只包含 `USER / DEVICE / WORLD / STAGE` 四种有当前生产者的语义来源；scheduler 和 `world_clock` 只是时间驱动与投递机制，不能作为 source 或改写 source。
+32. `PersistPolicy` 在新旧 Stimulus 协议间只有一个领域类型；每个 `StimulusKind` 的 source、persist policy 和 ephemeral 值由 5.2 的唯一组合矩阵固定，表外组合稳定失败。
 
 ## 8. 验收标准
 
@@ -1333,5 +1369,7 @@ expand 阶段允许目标 interface 与旧实现暂时并存，但新调用方�
 18. 01—30 的粒度是否都能在一个新上下文和一个聚焦 PR 中完成，哪些仍需拆分或合并？
 19. 每条 Blocked by 是否真正在接口、行为或共享实现上阻止后续工单，而不是仅表示推荐顺序？
 20. 01/03 的初始 frontier 以及 Chat、Toy、World、纯机械 world task 的并行边界是否符合团队协作方式？
+21. 每个 `StimulusKind` 允许哪个 `StimulusSource`，scheduler 和 `world_clock` 为什么只是触发机制而不是语义来源？
+22. 每个 `StimulusKind` 允许哪组 `PersistPolicy / ephemeral`，表外组合怎样稳定失败？
 
 如果必须阅读内部实现才能回答这些问题，本 spec 仍不够清楚，不能进入后续测试与工单讨论。

--- a/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
@@ -210,6 +210,57 @@ Agent 已由角色 ID 取得，请求不重复携带 `character_id`。请求不�
 | `persist_policy` | `PersistPolicy` | 原始内容是否进入会话记录或成为记忆证据候选 | 由领域枚举表达，不能靠 Handler 猜测 |
 | `ephemeral` | `bool` | 是否只在当前交互窗口内有意义 | 只控制内容生命周期，不改变身份和幂等要求 |
 
+`StimulusKind` 是目标协议的稳定判别枚举。成员名和序列化值固定如下；新增、删除或改值都属于公开协议变更：
+
+| 成员 | 序列化值 | 对应变体 |
+| --- | --- | --- |
+| `TEXT_MESSAGE` | `text_message` | `TextMessage` |
+| `IMAGE_MESSAGE` | `image_message` | `ImageMessage` |
+| `VOICE_MESSAGE` | `voice_message` | `VoiceMessage` |
+| `USER_TYPING` | `user_typing` | `UserTyping` |
+| `IMAGE_SELECTION_OPENED` | `image_selection_opened` | `ImageSelectionOpened` |
+| `IMAGE_SELECTION_CLOSED` | `image_selection_closed` | `ImageSelectionClosed` |
+| `TOUCH_INTERACTION` | `touch_interaction` | `TouchInteraction` |
+| `TOY_VIBRATION` | `toy_vibration` | `ToyVibration` |
+| `DEVICE_CONNECTED` | `device_connected` | `DeviceConnected` |
+| `DEVICE_DISCONNECTED` | `device_disconnected` | `DeviceDisconnected` |
+| `PROACTIVE_PROMPT_DUE` | `proactive_prompt_due` | `ProactivePromptDue` |
+| `INTERACTION_DEADLINE` | `interaction_deadline` | `InteractionDeadline` |
+| `DYNAMIC_OBSERVED` | `dynamic_observed` | `DynamicObserved` |
+| `DIARY_PLANNING_DUE` | `diary_planning_due` | `DiaryPlanningDue` |
+| `WORLD_OBSERVATION` | `world_observation` | `WorldObservation` |
+| `DAILY_PLANNING_DUE` | `daily_planning_due` | `DailyPlanningDue` |
+| `ACTIVITY_DUE` | `activity_due` | `ActivityDue` |
+| `ACTIVITY_STARTED` | `activity_started` | `ActivityStarted` |
+| `ACTIVITY_OBSERVATION` | `activity_observation` | `ActivityObservation` |
+| `ACTIVITY_ENDED` | `activity_ended` | `ActivityEnded` |
+| `SONG_KNOWLEDGE_DISCOVERED` | `song_knowledge_discovered` | `SongKnowledgeDiscovered` |
+| `SONG_LEARNED` | `song_learned` | `SongLearned` |
+
+`StimulusSource` 表达产生领域事实的供应商无关语义来源，不表达 WebSocket、HTTP、蓝牙或具体平台等传输通道：
+
+| 成员 | 序列化值 | 使用边界 |
+| --- | --- | --- |
+| `USER` | `user` | 用户提交的消息、输入协调信号或触摸等用户行为 |
+| `DEVICE` | `device` | 设备聚合后的振动、连接和断开事实 |
+| `WORLD` | `world` | world 规范化的外部事实、活动事实、动态和歌曲事实 |
+| `SCHEDULER` | `scheduler` | 持久 scheduler 到期产生的主动提醒或领域日程事实 |
+| `STAGE` | `stage` | stage 为交互控制产生的 deadline 等协调事实 |
+| `SYSTEM` | `system` | 系统生命周期产生、且确实需要角色认知的事实 |
+
+来源按事实的语义所有者选择，而不是按最后一跳调用者选择。例如 world task 被 `WorldClock` 唤醒后产生的观察仍为 `WORLD`；持久 scheduler 到期直接产生的 `ProactivePromptDue` 为 `SCHEDULER`；`InteractionDeadline` 为 `STAGE`。Adapter 只负责转换，不构成单独的 `ADAPTER` 来源。当前版本不提供 `UNKNOWN`，无法归类的来源必须在进入领域协议前失败。
+
+`PersistPolicy` 的成员和值沿用现有领域语义，目标协议重新声明为稳定闭集：
+
+| 成员 | 序列化值 | 含义 |
+| --- | --- | --- |
+| `NONE` | `none` | 不进入会话记录，也不成为记忆证据候选 |
+| `EPHEMERAL_ONLY` | `ephemeral_only` | 仅允许当前交互窗口使用，不进入持久会话记录 |
+| `CONVERSATION_ONLY` | `conversation_only` | 进入会话记录，但不自动成为长期记忆证据候选 |
+| `CONVERSATION_AND_MEMORY_CANDIDATE` | `conversation_and_memory_candidate` | 进入会话记录，并允许成为长期记忆证据候选 |
+
+expand 阶段允许目标协议枚举与 `server/src/domain/stimulus.py` 中的旧枚举并存，但二者是不同协议类型，调用方不得依赖同名成员可隐式互换。迁移 Adapter 必须显式转换；旧 `SourceChannel` 和 `StimulusModality` 不能作为新协议的 `StimulusSource` 或 `StimulusKind` 使用。旧协议删除仍只由工单 29 负责。
+
 #### 当前版本 Stimulus 强类型变体
 
 当前版本不保留 `payload: Mapping` 作为扩展口。下表中的每个专有字段都给出类型和用途：


### PR DESCRIPTION
## 对应工单

Part of #60

这是 Issue #60 的前置 interface SPEC 修订，不关闭 Issue，也不包含测试或产品实现。

## 背景

PR #90 的 owner review 指出 `StimulusSource.USER` 及枚举序列化值未被权威 SPEC 定义，测试因此猜测了公开 API。按 `spec-tdd-pr-guard`，本 PR 回退到最早缺失的 interface 设计门禁。

## 本 PR 目标

- 固定当前 22 个 `StimulusKind` 成员、序列化值及对应变体；
- 固定 `StimulusSource` 的语义来源闭集：`USER/DEVICE/WORLD/SCHEDULER/STAGE/SYSTEM`；
- 固定 `PersistPolicy` 的四种成员和值；
- 明确 source 表达事实语义所有者，不表达 WebSocket、HTTP 或具体供应商通道；
- 明确 expand 阶段新旧枚举是不同协议类型，需要显式转换；
- 修正进度文档中 interface 评审阶段和 pytest 验证事实冲突。

## 明确不包含

- 不修改 PR #90 的测试；
- 不新增 `src.domain.agent` 产品代码；
- 不实现其他 Stimulus、Snapshot、Request 或 Report；
- 不修改旧 `Stimulus.payload` 或生产链；
- 不关闭 Issue #60。

## 验证

- 静态核对 `StimulusKind` 表与 SPEC 当前 22 个强类型变体一一对应；
- `git diff --check origin/refactor/agent...HEAD`：通过；
- 仅修改 SPEC 与开发进度文档；本 PR 未运行 pytest、真实 LLM、TTS、设备或生产环境验证。

## 原子提交

- `7bcb702 docs(agent): 固定 handle 刺激枚举协议`
- `77827db docs(agent): 回退工单 01 至设计评审门禁`

## 后续

本 SPEC PR 评审通过并合入后，回到 PR #90：按 owner review 改为语义不可变断言、补齐所有字段保持断言并确认无任意 `payload`，重新记录 Red。测试 seam 获批后才开始最小 Green 实现。
