### PR TITLE
feat(domain): 实现 TextMessage 最小契约

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -15,12 +15,12 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `impl/agent-dm-01-text-message-green`，堆叠目标 `impl/agent-dm-01-handle-contract`）
+- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Draft，目标分支 `refactor/agent`）
 - 目标：只实现足以让 PR #90 已批准 `TextMessage` 契约测试通过的最小 `src.domain.agent` 协议切片。
 - 范围：公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
 - 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
 - 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；该 PR 保持 Draft、不合并。
+- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；该 PR 保持 Draft、不单独合并，其测试提交由本 PR 吸收并随 Green 实现一起合回 `refactor/agent`。
 - 验证及结果：Red 为同一 focused 测试因 `ModuleNotFoundError: No module named 'src.domain.agent'` 收集失败；实现后 focused 测试为 `1 passed in 0.15s`，`tests/domain -q` 为 `1 passed in 0.14s`，相关文件 `py_compile`、Ruff 和新增 `src/domain/agent` 的 BasedPyright 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。Server 全量为 `424 passed, 3 skipped, 17 failed, 2 errors`，失败来自缺失 TTS/图片/唱歌资源、无效外部 API key 和既有无关测试/实现不一致；未运行真实 TTS、设备或生产环境验证。
 
 ## 历史设计轮次目标与范围
@@ -122,4 +122,4 @@
 
 ## 下一步
 
-创建 `TextMessage` 最小 Green 切片的堆叠 Draft PR 并等待 owner 审查。通过后，下一 PR 从公开 domain seam 增加一个新的失败契约场景；其余变体继续按 Red-Green 小步拆分。
+完成 PR #94 retarget 后完整 diff 的验证并等待 owner 复审。通过并合入 `refactor/agent` 后关闭已被吸收的 PR #90；下一 PR 再从公开 domain seam 增加一个新的失败契约场景。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：工单 01 `TextMessage` 最小 Green Draft PR
+> 当前阶段：工单 01 `TextMessage` 最小 Green PR，已转 Ready 并等待 owner 复审
 >
 > 总体状态：进行中
 
@@ -15,7 +15,7 @@
 
 ## 本 PR
 
-- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Draft，堆叠目标 `impl/agent-dm-01-handle-contract`）
+- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Ready，等待 owner 复审；堆叠目标 `impl/agent-dm-01-handle-contract`）
 - 目标：只实现足以让 PR #90 已批准 `TextMessage` 契约测试通过的最小 `src.domain.agent` 协议切片。
 - 范围：公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
 - 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
@@ -122,4 +122,4 @@
 
 ## 下一步
 
-保持 PR #94 的合法堆叠 base，转 Ready 并等待 owner 复审。通过后 squash merge 到 PR #90 分支；随后重新验证和审查包含测试与实现的 PR #90，再由 PR #90 合入 `refactor/agent`。
+保持 PR #94 的合法堆叠 base，等待 owner 复审。通过后 squash merge 到 PR #90 分支；随后重新验证和审查包含测试与实现的 PR #90，再由 PR #90 合入 `refactor/agent`。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：工单 01 契约测试 Draft PR
+> 当前阶段：工单 01 `TextMessage` 最小 Green Draft PR
 >
 > 总体状态：进行中
 
@@ -15,12 +15,13 @@
 
 ## 本 PR
 
-- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（Draft，`CHANGES_REQUESTED`）
-- 目标：从 `src.domain.agent` 公开导出锁定 `TextMessage` 的首个合法构造与不可变行为，并保留真实 Red 证据。
-- 范围：一个 `TextMessage` 合法样例，逐项验证全部已提供公共/专有字段、固定 kind、不可变语义和不存在任意 `payload` 扩展口。
-- 明确不包含：不增加 `src.domain.agent` 产品实现，不测试其余 21 个 Stimulus、非法组合、InteractionSnapshot、request/report，也不修改旧生产链。
+- PR：待创建（分支 `impl/agent-dm-01-text-message-green`，堆叠目标 `impl/agent-dm-01-handle-contract`）
+- 目标：只实现足以让 PR #90 已批准 `TextMessage` 契约测试通过的最小 `src.domain.agent` 协议切片。
+- 范围：公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
+- 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
 - 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 验证及结果：`conda run -n agent python -m py_compile tests/domain/test_agent_handle_contract.py` 通过；`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s），符合公开协议入口尚未实现的预期 Red；未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证。
+- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；该 PR 保持 Draft、不合并。
+- 验证及结果：Red 为同一 focused 测试因 `ModuleNotFoundError: No module named 'src.domain.agent'` 收集失败；实现后 focused 测试为 `1 passed in 0.15s`，`tests/domain -q` 为 `1 passed in 0.14s`，相关文件 `py_compile`、Ruff 和新增 `src/domain/agent` 的 BasedPyright 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。Server 全量为 `424 passed, 3 skipped, 17 failed, 2 errors`，失败来自缺失 TTS/图片/唱歌资源、无效外部 API key 和既有无关测试/实现不一致；未运行真实 TTS、设备或生产环境验证。
 
 ## 历史设计轮次目标与范围
 
@@ -95,11 +96,15 @@
 - [x] PR #91 已固定全部 kind 的 `PersistPolicy / ephemeral` 唯一合法组合和表外稳定失败规则，并决定新旧 Stimulus 协议复用单一 `PersistPolicy` 类型；
 - [x] 已删除没有当前生产者的 `StimulusSource.SYSTEM`；同时删除仅表示触发机制、与 source 定义冲突的 `SCHEDULER`；
 - [x] PR #91 已获 owner 批准并 squash merge 到 `refactor/agent`；PR #90 的 interface 前置门禁已经闭合；
-- [ ] 工单 01 当前只增加第一个公开 domain seam 契约测试，尚未实现 `src.domain.agent`；
-- [ ] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s），符合目标协议入口尚未实现的预期；
+- [x] PR #90 的首个公开 domain seam 契约测试已获 owner 批准；该 Red PR 保持 Draft、不合并；
+- [x] Red：`conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q` 因 `ModuleNotFoundError: No module named 'src.domain.agent'` 在收集阶段失败（1 error，0.77s）；
+- [x] Green：同一 focused 命令在最小实现后为 `1 passed in 0.15s`；
+- [x] 已实现 `src.domain.agent` 的 `TextMessage` 最小切片，并让旧 Stimulus 复用同一四成员 `PersistPolicy`；
 - [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
-- [ ] PR #90 仍为 Red-only Draft 且有 `CHANGES_REQUESTED`；本轮修正测试 seam 后等待 owner 复审，通过前不开始产品实现；
-- [ ] 本 PR 未运行领域回归、全量 pytest、真实 LLM、TTS、设备或生产环境验证；
+- [x] `tests/domain -q` 为 `1 passed in 0.14s`；Ruff 和新增协议包的 BasedPyright 通过；三处公开路径导出的 `PersistPolicy` 为同一对象且四成员完整；
+- [ ] Server 全量回归为 `424 passed, 3 skipped, 17 failed, 2 errors`；失败集中在缺失资源/外部凭据和既有无关测试，不是本切片引入，但全量门禁未绿；
+- [ ] no-excuse 检查仅报告旧 `Stimulus` dataclass 未使用 `slots=True`；本切片不顺带改变旧对象布局；
+- [ ] 本 PR 未运行真实 LLM、TTS、设备或生产环境验证；
 - [ ] `ImageSelectionClosed` 与图片消息到达顺序需要在后续测试/实现讨论中确认；关闭信号本身不携带图片内容；
 - [ ] `RequestSongLearning` 的持久任务 Adapter、任务状态和完成 Stimulus 事务边界尚未选择具体实现；
 - [ ] Agent 自有状态变更与 Reflection 之间的 evidence 去重键、revision 冲突策略只有目标语义，尚未落实；
@@ -117,4 +122,4 @@
 
 ## 下一步
 
-修正 PR #90 的首个 `TextMessage` 契约测试并重新确认 Red，随后请求 owner 复审。测试 seam 获批后，下一 PR 只实现足以让该测试通过的最小 `src.domain.agent` 协议切片；其余变体继续按 Red-Green 小步拆分。
+创建 `TextMessage` 最小 Green 切片的堆叠 Draft PR 并等待 owner 审查。通过后，下一 PR 从公开 domain seam 增加一个新的失败契约场景；其余变体继续按 Red-Green 小步拆分。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -15,12 +15,12 @@
 
 ## 本 PR
 
-- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Draft，目标分支 `refactor/agent`）
+- PR：[#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94)（Draft，堆叠目标 `impl/agent-dm-01-handle-contract`）
 - 目标：只实现足以让 PR #90 已批准 `TextMessage` 契约测试通过的最小 `src.domain.agent` 协议切片。
 - 范围：公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
 - 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
 - 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；该 PR 保持 Draft、不单独合并，其测试提交由本 PR 吸收并随 Green 实现一起合回 `refactor/agent`。
+- 测试门禁：PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 的 Red-only seam 已获 owner 批准，head `c724c1f`；本 PR 作为子 PR 合入该父分支后，PR #90 更新为包含已批准测试和最小实现的完整 Green 交付，再重新审查并 squash merge 到 `refactor/agent`。
 - 验证及结果：Red 为同一 focused 测试因 `ModuleNotFoundError: No module named 'src.domain.agent'` 收集失败；实现后 focused 测试为 `1 passed in 0.15s`，`tests/domain -q` 为 `1 passed in 0.14s`，相关文件 `py_compile`、Ruff 和新增 `src/domain/agent` 的 BasedPyright 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。Server 全量为 `424 passed, 3 skipped, 17 failed, 2 errors`，失败来自缺失 TTS/图片/唱歌资源、无效外部 API key 和既有无关测试/实现不一致；未运行真实 TTS、设备或生产环境验证。
 
 ## 历史设计轮次目标与范围
@@ -122,4 +122,4 @@
 
 ## 下一步
 
-完成 PR #94 retarget 后完整 diff 的验证并等待 owner 复审。通过并合入 `refactor/agent` 后关闭已被吸收的 PR #90；下一 PR 再从公开 domain seam 增加一个新的失败契约场景。
+保持 PR #94 的合法堆叠 base，转 Ready 并等待 owner 复审。通过后 squash merge 到 PR #90 分支；随后重新验证和审查包含测试与实现的 PR #90，再由 PR #90 合入 `refactor/agent`。

--- a/server/src/domain/agent/__init__.py
+++ b/server/src/domain/agent/__init__.py
@@ -1,0 +1,8 @@
+from .stimulus import PersistPolicy, StimulusKind, StimulusSource, TextMessage
+
+__all__ = (
+    "PersistPolicy",
+    "StimulusKind",
+    "StimulusSource",
+    "TextMessage",
+)

--- a/server/src/domain/agent/stimulus.py
+++ b/server/src/domain/agent/stimulus.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 
 class PersistPolicy(str, Enum):
+    """Controls whether raw stimulus content enters conversation or memory evidence."""
+
     NONE = "none"
     EPHEMERAL_ONLY = "ephemeral_only"
     CONVERSATION_ONLY = "conversation_only"
@@ -13,15 +15,29 @@ class PersistPolicy(str, Enum):
 
 
 class StimulusKind(str, Enum):
+    """Stable discriminator for the implemented stimulus variants."""
+
     TEXT_MESSAGE = "text_message"
 
 
 class StimulusSource(str, Enum):
+    """Supplier-independent semantic owner of a stimulus fact."""
+
     USER = "user"
 
 
 @dataclass(frozen=True, slots=True)
 class TextMessage:
+    """An immutable, complete user text message submitted to an Agent.
+
+    Identity, schema, occurrence time, semantic source, target characters,
+    optional user, persistence policy, lifetime, text, and client retry ID are
+    retained exactly as supplied. ``kind`` is always ``TEXT_MESSAGE`` and is
+    not a constructor argument. This first Green slice implements only the
+    approved legal construction; invalid combinations remain a later TDD
+    slice and are not validated here.
+    """
+
     stimulus_id: str
     schema_version: int
     occurred_at: datetime

--- a/server/src/domain/agent/stimulus.py
+++ b/server/src/domain/agent/stimulus.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class PersistPolicy(str, Enum):
+    NONE = "none"
+    EPHEMERAL_ONLY = "ephemeral_only"
+    CONVERSATION_ONLY = "conversation_only"
+    CONVERSATION_AND_MEMORY_CANDIDATE = "conversation_and_memory_candidate"
+
+
+class StimulusKind(str, Enum):
+    TEXT_MESSAGE = "text_message"
+
+
+class StimulusSource(str, Enum):
+    USER = "user"
+
+
+@dataclass(frozen=True, slots=True)
+class TextMessage:
+    stimulus_id: str
+    schema_version: int
+    occurred_at: datetime
+    source: StimulusSource
+    target_character_ids: tuple[str, ...]
+    user_id: str | None
+    persist_policy: PersistPolicy
+    ephemeral: bool
+    text: str
+    client_msg_id: str
+    kind: StimulusKind = field(default=StimulusKind.TEXT_MESSAGE, init=False)

--- a/server/src/domain/stimulus.py
+++ b/server/src/domain/stimulus.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any
 from uuid import uuid4
+
+from src.domain.agent import PersistPolicy
 
 
 class SourceChannel(str, Enum):
@@ -26,13 +29,6 @@ class StimulusModality(str, Enum):
     WORLD_EVENT = "world_event"
     SYSTEM_EVENT = "system_event"
     UNKNOWN = "unknown"
-
-
-class PersistPolicy(str, Enum):
-    NONE = "none"
-    EPHEMERAL_ONLY = "ephemeral_only"
-    CONVERSATION_ONLY = "conversation_only"
-    CONVERSATION_AND_MEMORY_CANDIDATE = "conversation_and_memory_candidate"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 对应门禁

- Issue #60
- 前置 SPEC：PR #91 已合入 refactor/agent（661b7d2）
- 前置 Red seam：PR #90 已获 owner 批准，保持 Draft、不合并

## 目标

只实现足以让 PR #90 当前 TextMessage 契约测试 Green 的最小 src.domain.agent 协议切片。

## 范围

- 新增公开 TextMessage，使用 frozen + slots，保留全部契约字段且没有 payload。
- 仅实现当前测试需要的 StimulusKind.TEXT_MESSAGE 与 StimulusSource.USER。
- 将四成员 PersistPolicy 移到 src.domain.agent 作为单一类型；旧 src.domain.stimulus 导入并重导出同一对象，保持现有调用兼容。
- 同步开发进度文档。

## 明确不包含

不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。

## TDD 证据

- Red：PR #90 中 conda run -n agent python -m pytest tests/domain/test_agent_handle_contract.py -q 因 ModuleNotFoundError: No module named 'src.domain.agent' 收集失败。
- Green：同一 focused 命令为 1 passed in 0.16s。
- conda run -n agent python -m pytest tests/domain -q：1 passed in 0.14s。
- Ruff：通过。
- asedpyright src/domain/agent：0 errors / 0 warnings。
- 三处导入路径的 PersistPolicy 对象身份和四成员值检查：通过。
- git diff --check：通过。

## 全量回归与风险

conda run -n agent python -m pytest tests -q 结果为 424 passed, 3 skipped, 17 failed, 2 errors。失败来自缺失 TTS/图片/唱歌资源、无效外部 API key，以及既有无关测试/实现不一致；本切片相关 	ests/domain 全绿。未运行真实 TTS、设备或生产环境验证。