### PR TITLE
fix(ci): 支持堆叠 Agent PR 审查

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -41,15 +41,18 @@ pinned head and can merge only into that parent; a root is reviewed relative to
 tree before inspecting or testing it. The prompt and JSON schema define the
 Codex-facing contract. The publishing job independently validates the complete
 output contract, uses the trusted event marker, and validates the head SHA,
-issue set, test evidence, current-head human change requests, and both pinned
-SHAs before it performs any GitHub write. If the target branch advances during
-review, the publisher dispatches a fresh review instead of merging stale evidence.
+issue set, test evidence, current-head change requests, every parent current-head
+approval, and both pinned SHAs before it performs any merge. If the target branch
+advances during review, the publisher dispatches a fresh review instead of
+merging stale evidence.
 
 Verdicts have these effects:
 
-- `PASS`: approve and squash merge only when every recorded test is `PASS`, no
-  P0/P1 finding remains, the phase is not Red, and no human's latest review on
-  the current head requests changes;
+- `PASS`: approve and squash merge only when at least one test or static check
+  passed, no test is `FAIL`/`EXPECTED_RED`, no P0/P1 finding remains, the phase
+  is not Red, and no human's latest review on the current head requests changes.
+  A non-required long external check may be `NOT_RUN` only when its reason and
+  unverified scope are recorded;
 - `CHANGES_REQUESTED`: publish a request-changes review and do not merge;
 - `WAITING`: publish a comment describing the external condition and do not
   merge. A later authorized human reply or PR update creates a fresh review;
@@ -58,9 +61,12 @@ Verdicts have these effects:
 
 ## Acceptance checks
 
-- Events unrelated to an open `refactor/agent` PR explicitly related only to
-  issue #60-#89, or to a valid stacked child whose open parent chain terminates
-  at such a root PR, are ignored before any paid model call.
+- Events unrelated to a PR explicitly related only to issue #60-#89 are ignored
+  before any paid model call. A related PR with an invalid target or stack is
+  rejected with an actionable flow comment instead of being silently ignored.
+- A stacked child enters review only while every parent current head has a
+  trusted current-head approval and no trusted current-head change request;
+  the publisher checks this gate again immediately before merging.
 - External forks, untrusted actors, bot replies, duplicate events, and stale
   head results cannot publish or merge.
 - PR conversation replies and inline review replies are both included in the

--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -51,8 +51,10 @@ Verdicts have these effects:
 - `PASS`: approve and squash merge only when at least one test or static check
   passed, no test is `FAIL`/`EXPECTED_RED`, no P0/P1 finding remains, the phase
   is not Red, and no human's latest review on the current head requests changes.
-  A non-required long external check may be `NOT_RUN` only when its reason and
-  unverified scope are recorded;
+  A non-required long external check may be `NOT_RUN` only with
+  `required: false`, a structured `skip_reason` (`slow`, `live`, `external`, or
+  `real_llm`), and its unverified scope recorded; a required check cannot be
+  skipped;
 - `CHANGES_REQUESTED`: publish a request-changes review and do not merge;
 - `WAITING`: publish a comment describing the external condition and do not
   merge. A later authorized human reply or PR update creates a fresh review;

--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -1,7 +1,8 @@
 # Agent refactor PR review automation
 
-This automation reviews pull requests targeting `refactor/agent` and linked to
-Issue #60-#89. It reacts to new/updated/ready/reopened/retargeted PRs, review
+This automation reviews root pull requests targeting `refactor/agent` and
+their same-repository stacked child PRs when they are linked to Issue #60-#89.
+It reacts to new/updated/ready/reopened/retargeted PRs, review
 submissions/edits/dismissals, PR conversation comments, and inline review
 comments. A successful non-Draft review is squash merged; other verdicts are
 published as a GitHub review.
@@ -32,8 +33,12 @@ branch, issue-range, and current-SHA gates before a new paid review starts.
 ## Review contract
 
 The workflow accepts one eligible PR event and produces exactly one structured
-verdict for a pinned target-base and PR-head pair. The review job constructs
-that exact candidate integration tree before inspecting or testing it. The prompt and JSON schema define the
+verdict for a pinned immediate-base and PR-head pair. Before spending a model
+call it resolves an acyclic chain of open, same-repository PRs whose root base
+is `refactor/agent`. A stacked child is reviewed relative to its direct parent's
+pinned head and can merge only into that parent; a root is reviewed relative to
+`refactor/agent`. The review job constructs that exact candidate integration
+tree before inspecting or testing it. The prompt and JSON schema define the
 Codex-facing contract. The publishing job independently validates the complete
 output contract, uses the trusted event marker, and validates the head SHA,
 issue set, test evidence, current-head human change requests, and both pinned
@@ -54,14 +59,21 @@ Verdicts have these effects:
 ## Acceptance checks
 
 - Events unrelated to an open `refactor/agent` PR explicitly related only to
-  issue #60-#89 are ignored before any paid model call.
+  issue #60-#89, or to a valid stacked child whose open parent chain terminates
+  at such a root PR, are ignored before any paid model call.
 - External forks, untrusted actors, bot replies, duplicate events, and stale
   head results cannot publish or merge.
 - PR conversation replies and inline review replies are both included in the
   review context and create distinct review events.
 - A `PASS` without at least one successful test record cannot merge.
-- A merge uses GitHub's squash method and targets `refactor/agent`; the workflow
-  never merges to `dev`.
+- A merge uses GitHub's squash method. A child targets only its direct parent
+  branch; a root targets only `refactor/agent`. The workflow never merges to
+  `dev`, `main`, or `master`.
+- Merging a child changes the parent head and therefore requires a fresh parent
+  review; a child PASS is never treated as approval of the complete root diff.
+- Black-box review uses focused and affected-module offline tests. Real song
+  learning, live Bilibili/VCPedia fetches, and other `slow`/`live`/`external`/
+  `real_llm` paths are skipped by default and reported as unverified.
 
 ## Repository configuration
 

--- a/.github/codex/prompts/agent-refactor-review.md
+++ b/.github/codex/prompts/agent-refactor-review.md
@@ -70,9 +70,12 @@ fallback, enum member, payload field, or behavior.
      by the Issue/SPEC and the smallest relevant regression set;
    - do not run an unfiltered Server full suite when it can start real song
      learning, live Bilibili/VCPedia fetching, or other long-running external
-     work. Skip `slow`, `live`, `external`, and `real_llm` tests by default;
-     precisely deselect known unmarked live nodes while retaining Fake/offline
-     tests in the same file, and record every skipped path as `NOT_RUN`;
+      work. Skip `slow`, `live`, `external`, and `real_llm` tests by default;
+      precisely deselect known unmarked live nodes while retaining Fake/offline
+      tests in the same file. Each test record must set `required: true` when
+      the Issue/SPEC requires that evidence. `NOT_RUN` is valid only with
+      `required: false` and a structured `skip_reason` of `slow`, `live`,
+      `external`, or `real_llm`; all completed records use `skip_reason: null`;
    - for design, validate links/format/diff consistency; product tests may be
      omitted only when they cannot observe a documentation-only change;
    - never report an interrupted, uncollected, or environment-blocked test as

--- a/.github/codex/prompts/agent-refactor-review.md
+++ b/.github/codex/prompts/agent-refactor-review.md
@@ -56,8 +56,9 @@ fallback, enum member, payload field, or behavior.
    - a child PR may merge only into its direct parent branch. After that merge,
      the parent is a new candidate and must update its phase/progress, rerun its
      full candidate verification, and receive a new review before it can merge;
-   - the PR must implement only its linked Issue #60-#89 scope and blockers must
-     already be merged;
+   - the PR must implement only its linked Issue #60-#89 scope; blockers must
+     already be merged into the fixed point, or appear in the explicitly
+     approved and traceable parent chain described above;
    - requirements and interface design must precede tests; a genuine failing
      test and recorded Red evidence must precede implementation;
    - progress documentation and PR claims must match facts in the diff, commit

--- a/.github/codex/prompts/agent-refactor-review.md
+++ b/.github/codex/prompts/agent-refactor-review.md
@@ -43,9 +43,19 @@ fallback, enum member, payload field, or behavior.
    `git log <base_sha>..<head_sha> --oneline`. The current working tree is the
    candidate integration of those exact commits; run black-box tests there. If
    `candidate_merge_clean` is false, inspect the conflicts and require changes.
+   Read `pull_request_chain` from the runtime context. Its first entry is the
+   current PR and its final entry must be the root PR targeting
+   `refactor/agent`. A child PR uses its direct parent's pinned head as
+   `base_sha`; a root PR uses `refactor/agent` as its base.
 2. Classify the PR as `design`, `red_test`, `implementation`, or `acceptance`.
 3. Perform the flow/TDD review:
-   - the target must be exactly `refactor/agent`;
+   - a root PR must target `refactor/agent`; a stacked child may target the head
+     branch of its direct open parent, provided the acyclic chain terminates at
+     that root PR and the parent current head was explicitly approved for the
+     next slice;
+   - a child PR may merge only into its direct parent branch. After that merge,
+     the parent is a new candidate and must update its phase/progress, rerun its
+     full candidate verification, and receive a new review before it can merge;
    - the PR must implement only its linked Issue #60-#89 scope and blockers must
      already be merged;
    - requirements and interface design must precede tests; a genuine failing
@@ -57,6 +67,11 @@ fallback, enum member, payload field, or behavior.
 4. Perform black-box verification:
    - for implementation or acceptance, run the focused test commands required
      by the Issue/SPEC and the smallest relevant regression set;
+   - do not run an unfiltered Server full suite when it can start real song
+     learning, live Bilibili/VCPedia fetching, or other long-running external
+     work. Skip `slow`, `live`, `external`, and `real_llm` tests by default;
+     precisely deselect known unmarked live nodes while retaining Fake/offline
+     tests in the same file, and record every skipped path as `NOT_RUN`;
    - for design, validate links/format/diff consistency; product tests may be
      omitted only when they cannot observe a documentation-only change;
    - never report an interrupted, uncollected, or environment-blocked test as
@@ -66,9 +81,10 @@ fallback, enum member, payload field, or behavior.
    `.review-automation/.github/codex/skills/code-review/SKILL.md`. Run the
    Standards and Spec tracks independently and in parallel, then preserve them
    as separate finding arrays. Do not let one axis mask the other.
-6. Inspect for out-of-scope files and changes, target-branch mistakes, stale
-   base assumptions, missing cleanup required by the Issue, and any attempt to
-   merge to `dev` or `master` instead of `refactor/agent`.
+6. Inspect for out-of-scope files and changes, invalid or stale parent-chain
+   assumptions, missing cleanup required by the Issue, and any attempt to merge
+   a root anywhere except `refactor/agent` or a child anywhere except its
+   direct parent. Never permit a merge to `dev`, `main`, or `master`.
 
 ## Verdict rules
 
@@ -85,5 +101,6 @@ fallback, enum member, payload field, or behavior.
 Every finding must be actionable and tied to evidence. Use `P0`/`P1` for
 blocking correctness or governance failures, `P2`/`P3` for lower-severity
 findings. Return only JSON that satisfies the supplied output schema. Set
-`head_sha`, `target_branch`, and `issue_numbers` exactly from the runtime
-context.
+`head_sha` and `issue_numbers` exactly from the runtime context. Set
+`target_branch` to `refactor/agent`, which is the final integration branch even
+when the current PR is a stacked child whose immediate base is its parent PR.

--- a/.github/codex/review-output.schema.json
+++ b/.github/codex/review-output.schema.json
@@ -59,7 +59,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["command", "status", "details"],
+        "required": ["command", "status", "details", "required", "skip_reason"],
         "properties": {
           "command": {
             "type": "string",
@@ -72,8 +72,32 @@
           "details": {
             "type": "string",
             "minLength": 1
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "skip_reason": {
+            "type": ["string", "null"],
+            "enum": ["slow", "live", "external", "real_llm", null]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {"status": {"const": "NOT_RUN"}},
+              "required": ["status"]
+            },
+            "then": {
+              "properties": {
+                "required": {"const": false},
+                "skip_reason": {"type": "string"}
+              }
+            },
+            "else": {
+              "properties": {"skip_reason": {"const": null}}
+            }
+          }
+        ]
       }
     }
   },

--- a/.github/codex/scripts/review-policy.js
+++ b/.github/codex/scripts/review-policy.js
@@ -2,6 +2,7 @@
 
 const RELATIONSHIP_PATTERN =
   /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|implement(?:s|ed)?|part\s+of)\s+(?:#(\d+)|https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/issues\/(\d+))/gi;
+const ISSUE_LABEL_PATTERN = /\bissue\s+#(\d+)\b/gi;
 
 const RESULT_KEYS = [
   "flow_findings",
@@ -40,7 +41,76 @@ function collectRelatedIssueNumbers(title, body, closingIssues = [], repository 
       numbers.add(Number(match[3]));
     }
   }
+  for (const match of text.matchAll(ISSUE_LABEL_PATTERN)) {
+    numbers.add(Number(match[1]));
+  }
   return [...numbers].sort((left, right) => left - right);
+}
+
+function pullChainEntry(pull) {
+  return {
+    number: pull.number,
+    state: pull.state,
+    base_ref: pull.base?.ref,
+    base_sha: pull.base?.sha,
+    head_ref: pull.head?.ref,
+    head_sha: pull.head?.sha,
+    head_repository: pull.head?.repo?.full_name,
+  };
+}
+
+async function resolvePullChain(
+  startPull,
+  loadOpenParentsByHead,
+  repository,
+  integrationBranch = "refactor/agent",
+) {
+  if (typeof loadOpenParentsByHead !== "function") {
+    throw new Error("a parent PR loader is required");
+  }
+
+  const chain = [];
+  const seenNumbers = new Set();
+  const seenHeads = new Set();
+  let pull = startPull;
+
+  for (let depth = 0; depth < 20; depth += 1) {
+    const entry = pullChainEntry(pull);
+    if (entry.state !== "open") throw new Error(`PR #${entry.number} is not open`);
+    if (entry.head_repository !== repository) {
+      throw new Error(`PR #${entry.number} head must be in the same repository`);
+    }
+    if (!entry.head_ref || !entry.base_ref || !entry.head_sha || !entry.base_sha) {
+      throw new Error(`PR #${entry.number} has an incomplete branch identity`);
+    }
+    if (seenNumbers.has(entry.number) || seenHeads.has(entry.head_ref)) {
+      throw new Error(`pull-request chain contains a cycle at PR #${entry.number}`);
+    }
+
+    seenNumbers.add(entry.number);
+    seenHeads.add(entry.head_ref);
+    chain.push(entry);
+
+    if (entry.base_ref === integrationBranch) {
+      return chain.map((item, index) => ({
+        ...item,
+        role: index === chain.length - 1 ? "root" : "child",
+      }));
+    }
+    if (new Set(["dev", "main", "master"]).has(entry.base_ref)) {
+      throw new Error(`stacked PRs cannot target protected branch ${entry.base_ref}`);
+    }
+
+    const parents = await loadOpenParentsByHead(entry.base_ref);
+    if (!Array.isArray(parents) || parents.length !== 1) {
+      throw new Error(
+        `base ${entry.base_ref} must be the head of exactly one open parent PR`,
+      );
+    }
+    [pull] = parents;
+  }
+
+  throw new Error("pull-request chain exceeds the maximum depth");
 }
 
 function buildEventKey(eventName, payload, baseSha, headSha) {
@@ -137,4 +207,5 @@ module.exports = {
   collectRelatedIssueNumbers,
   latestHumanChangeRequest,
   passViolation,
+  resolvePullChain,
 };

--- a/.github/codex/scripts/review-policy.js
+++ b/.github/codex/scripts/review-policy.js
@@ -18,6 +18,11 @@ const RESULT_KEYS = [
 ];
 const FINDING_KEYS = ["detail", "file", "line", "required_change", "severity", "title"];
 const TEST_KEYS = ["command", "details", "status"];
+const TRUSTED_REVIEW_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const TRUSTED_REVIEW_BOTS = new Set([
+  "github-actions[bot]",
+  "chatgpt-codex-connector[bot]",
+]);
 
 function sameKeys(value, expected) {
   return (
@@ -45,6 +50,16 @@ function collectRelatedIssueNumbers(title, body, closingIssues = [], repository 
     numbers.add(Number(match[1]));
   }
   return [...numbers].sort((left, right) => left - right);
+}
+
+function isAgentIssueSet(issueNumbers, minimum = 60, maximum = 89) {
+  return (
+    Array.isArray(issueNumbers) &&
+    issueNumbers.length > 0 &&
+    issueNumbers.every(
+      (number) => Number.isInteger(number) && number >= minimum && number <= maximum,
+    )
+  );
 }
 
 function pullChainEntry(pull) {
@@ -111,6 +126,27 @@ async function resolvePullChain(
   }
 
   throw new Error("pull-request chain exceeds the maximum depth");
+}
+
+function parentApprovalViolation(reviews, headSha) {
+  const latestByReviewer = new Map();
+  for (const review of reviews) {
+    const login = review.user?.login;
+    const trusted =
+      TRUSTED_REVIEW_ASSOCIATIONS.has(review.author_association) ||
+      TRUSTED_REVIEW_BOTS.has(login);
+    if (trusted && login && review.commit_id === headSha) {
+      latestByReviewer.set(login, review);
+    }
+  }
+  const current = [...latestByReviewer.values()];
+  if (current.some((review) => review.state === "CHANGES_REQUESTED")) {
+    return "a trusted reviewer has changes requested on the parent current head";
+  }
+  if (!current.some((review) => review.state === "APPROVED")) {
+    return "the parent has no trusted current-head approval";
+  }
+  return null;
 }
 
 function buildEventKey(eventName, payload, baseSha, headSha) {
@@ -184,9 +220,11 @@ function passViolation(result) {
   if (findings.some((finding) => finding.severity === "P0" || finding.severity === "P1")) {
     return "a PASS result cannot contain P0/P1 findings";
   }
-  if (result.tests.length === 0) return "a PASS result must contain test evidence";
-  if (result.tests.some((test) => test.status !== "PASS")) {
-    return "every test record in a PASS result must pass";
+  if (result.tests.some((test) => new Set(["FAIL", "EXPECTED_RED"]).has(test.status))) {
+    return "a PASS result cannot contain a test that failed or remained Red";
+  }
+  if (!result.tests.some((test) => test.status === "PASS")) {
+    return "a PASS result must contain passing test evidence";
   }
   return null;
 }
@@ -205,7 +243,9 @@ module.exports = {
   assertValidReviewResult,
   buildEventKey,
   collectRelatedIssueNumbers,
+  isAgentIssueSet,
   latestHumanChangeRequest,
+  parentApprovalViolation,
   passViolation,
   resolvePullChain,
 };

--- a/.github/codex/scripts/review-policy.js
+++ b/.github/codex/scripts/review-policy.js
@@ -17,7 +17,8 @@ const RESULT_KEYS = [
   "verdict",
 ];
 const FINDING_KEYS = ["detail", "file", "line", "required_change", "severity", "title"];
-const TEST_KEYS = ["command", "details", "status"];
+const TEST_KEYS = ["command", "details", "required", "skip_reason", "status"];
+const TEST_SKIP_REASONS = new Set(["slow", "live", "external", "real_llm"]);
 const TRUSTED_REVIEW_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const TRUSTED_REVIEW_BOTS = new Set([
   "github-actions[bot]",
@@ -202,9 +203,18 @@ function assertValidReviewResult(result) {
     if (
       !nonEmptyString(test.command) ||
       !nonEmptyString(test.details) ||
+      typeof test.required !== "boolean" ||
       !new Set(["PASS", "FAIL", "EXPECTED_RED", "NOT_RUN"]).has(test.status)
     ) {
       throw new Error("invalid test record");
+    }
+    if (test.status === "NOT_RUN") {
+      if (test.required) throw new Error("a required test cannot be NOT_RUN");
+      if (!TEST_SKIP_REASONS.has(test.skip_reason)) {
+        throw new Error("a NOT_RUN test must have an allowed skip reason");
+      }
+    } else if (test.skip_reason !== null) {
+      throw new Error("a completed test must have a null skip reason");
     }
   }
 }
@@ -222,6 +232,9 @@ function passViolation(result) {
   }
   if (result.tests.some((test) => new Set(["FAIL", "EXPECTED_RED"]).has(test.status))) {
     return "a PASS result cannot contain a test that failed or remained Red";
+  }
+  if (result.tests.some((test) => test.required && test.status === "NOT_RUN")) {
+    return "a PASS result cannot skip a required test";
   }
   if (!result.tests.some((test) => test.status === "PASS")) {
     return "a PASS result must contain passing test evidence";

--- a/.github/codex/tests/review-policy.test.js
+++ b/.github/codex/tests/review-policy.test.js
@@ -16,6 +16,17 @@ const {
 const SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
 
+function testRecord(overrides = {}) {
+  return {
+    command: "pytest",
+    status: "PASS",
+    details: "passed",
+    required: true,
+    skip_reason: null,
+    ...overrides,
+  };
+}
+
 function validResult(overrides = {}) {
   return {
     phase: "implementation",
@@ -27,7 +38,7 @@ function validResult(overrides = {}) {
     flow_findings: [],
     standards_findings: [],
     spec_findings: [],
-    tests: [{command: "pytest", status: "PASS", details: "passed"}],
+    tests: [testRecord()],
     ...overrides,
   };
 }
@@ -213,6 +224,18 @@ test("validates the complete result contract", () => {
     () => assertValidReviewResult(validResult({target_branch: "dev"})),
     /target branch/,
   );
+  assert.throws(
+    () => assertValidReviewResult(validResult({
+      tests: [testRecord({status: "NOT_RUN", required: true, skip_reason: "external"})],
+    })),
+    /required test cannot be NOT_RUN/,
+  );
+  assert.throws(
+    () => assertValidReviewResult(validResult({
+      tests: [testRecord({status: "NOT_RUN", required: false, skip_reason: null})],
+    })),
+    /skip reason/,
+  );
 });
 
 test("PASS rejects failures but permits explicitly skipped non-required external checks", () => {
@@ -223,18 +246,31 @@ test("PASS rejects failures but permits explicitly skipped non-required external
   );
   assert.match(passViolation(validResult({tests: []})), /test evidence/);
   assert.match(
-    passViolation(validResult({tests: [{command: "pytest", status: "EXPECTED_RED"}]})),
+    passViolation(validResult({tests: [testRecord({status: "EXPECTED_RED"})]})),
     /failed or remained Red/,
   );
   assert.match(
-    passViolation(validResult({tests: [{command: "live crawler", status: "NOT_RUN"}]})),
+    passViolation(validResult({
+      tests: [testRecord({
+        command: "live crawler",
+        status: "NOT_RUN",
+        required: false,
+        skip_reason: "live",
+      })],
+    })),
     /passing test evidence/,
   );
   assert.equal(
     passViolation(validResult({
       tests: [
-        {command: "pytest focused", status: "PASS", details: "passed"},
-        {command: "live crawler", status: "NOT_RUN", details: "not required; external"},
+        testRecord({command: "pytest focused"}),
+        testRecord({
+          command: "live crawler",
+          status: "NOT_RUN",
+          details: "not required; external",
+          required: false,
+          skip_reason: "external",
+        }),
       ],
     })),
     null,

--- a/.github/codex/tests/review-policy.test.js
+++ b/.github/codex/tests/review-policy.test.js
@@ -6,7 +6,9 @@ const {
   assertValidReviewResult,
   buildEventKey,
   collectRelatedIssueNumbers,
+  isAgentIssueSet,
   latestHumanChangeRequest,
+  parentApprovalViolation,
   passViolation,
   resolvePullChain,
 } = require("../scripts/review-policy");
@@ -47,6 +49,13 @@ test("recognizes an explicit Issue label without treating casual mentions as rel
     collectRelatedIssueNumbers("Green slice", "- Issue #60\n- Mentions #61 for context", [], "a/b"),
     [60],
   );
+});
+
+test("only a non-empty set wholly inside the Agent issue range is eligible", () => {
+  assert.equal(isAgentIssueSet([60, 89]), true);
+  assert.equal(isAgentIssueSet([]), false);
+  assert.equal(isAgentIssueSet([59, 60]), false);
+  assert.equal(isAgentIssueSet([89, 90]), false);
 });
 
 function pull(number, headRef, baseRef, overrides = {}) {
@@ -138,6 +147,43 @@ test("rejects foreign, closed, and cyclic PR chains", async () => {
   );
 });
 
+test("requires a current-head trusted approval for every stacked parent", () => {
+  const review = (login, state, commitId = SHA, association = "OWNER") => ({
+    user: {login, type: login.endsWith("[bot]") ? "Bot" : "User"},
+    author_association: association,
+    commit_id: commitId,
+    state,
+  });
+
+  assert.equal(parentApprovalViolation([review("alice", "APPROVED")], SHA), null);
+  assert.equal(
+    parentApprovalViolation([review("github-actions[bot]", "APPROVED", SHA, "NONE")], SHA),
+    null,
+  );
+  assert.match(
+    parentApprovalViolation([review("alice", "APPROVED", BASE_SHA)], SHA),
+    /current-head approval/,
+  );
+  assert.match(
+    parentApprovalViolation(
+      [review("alice", "APPROVED"), review("alice", "DISMISSED")],
+      SHA,
+    ),
+    /current-head approval/,
+  );
+  assert.match(
+    parentApprovalViolation(
+      [review("alice", "APPROVED"), review("bob", "CHANGES_REQUESTED")],
+      SHA,
+    ),
+    /changes requested/,
+  );
+  assert.match(
+    parentApprovalViolation([review("outsider", "APPROVED", SHA, "NONE")], SHA),
+    /current-head approval/,
+  );
+});
+
 test("event keys distinguish lifecycle actions and individual replies", () => {
   assert.notEqual(
     buildEventKey("pull_request_target", {action: "ready_for_review"}, BASE_SHA, SHA),
@@ -169,7 +215,7 @@ test("validates the complete result contract", () => {
   );
 });
 
-test("PASS is rejected for Red, blocking findings, or incomplete test evidence", () => {
+test("PASS rejects failures but permits explicitly skipped non-required external checks", () => {
   assert.match(passViolation(validResult({phase: "red_test"})), /Red-stage/);
   assert.match(
     passViolation(validResult({flow_findings: [{severity: "P1"}]})),
@@ -178,7 +224,20 @@ test("PASS is rejected for Red, blocking findings, or incomplete test evidence",
   assert.match(passViolation(validResult({tests: []})), /test evidence/);
   assert.match(
     passViolation(validResult({tests: [{command: "pytest", status: "EXPECTED_RED"}]})),
-    /must pass/,
+    /failed or remained Red/,
+  );
+  assert.match(
+    passViolation(validResult({tests: [{command: "live crawler", status: "NOT_RUN"}]})),
+    /passing test evidence/,
+  );
+  assert.equal(
+    passViolation(validResult({
+      tests: [
+        {command: "pytest focused", status: "PASS", details: "passed"},
+        {command: "live crawler", status: "NOT_RUN", details: "not required; external"},
+      ],
+    })),
+    null,
   );
   assert.equal(
     passViolation(validResult({standards_findings: [{severity: "P2"}]})),

--- a/.github/codex/tests/review-policy.test.js
+++ b/.github/codex/tests/review-policy.test.js
@@ -8,6 +8,7 @@ const {
   collectRelatedIssueNumbers,
   latestHumanChangeRequest,
   passViolation,
+  resolvePullChain,
 } = require("../scripts/review-policy");
 
 const SHA = "a".repeat(40);
@@ -38,6 +39,102 @@ test("collects only explicit issue relationships and preserves out-of-range link
       "a/b",
     ),
     [60, 62, 63, 100],
+  );
+});
+
+test("recognizes an explicit Issue label without treating casual mentions as relationships", () => {
+  assert.deepEqual(
+    collectRelatedIssueNumbers("Green slice", "- Issue #60\n- Mentions #61 for context", [], "a/b"),
+    [60],
+  );
+});
+
+function pull(number, headRef, baseRef, overrides = {}) {
+  return {
+    number,
+    state: "open",
+    base: {ref: baseRef, sha: `${number}`.padStart(40, "b").slice(-40)},
+    head: {
+      ref: headRef,
+      sha: `${number}`.padStart(40, "a").slice(-40),
+      repo: {full_name: "a/b"},
+    },
+    ...overrides,
+  };
+}
+
+test("resolves a root PR directly targeting the integration branch", async () => {
+  const root = pull(90, "test/contract", "refactor/agent");
+  const chain = await resolvePullChain(root, async () => [], "a/b", "refactor/agent");
+
+  assert.deepEqual(chain.map((item) => item.number), [90]);
+  assert.equal(chain[0].role, "root");
+});
+
+test("resolves a stacked child through its open parent PR", async () => {
+  const parent = pull(90, "test/contract", "refactor/agent");
+  const child = pull(94, "impl/green", "test/contract");
+  const chain = await resolvePullChain(
+    child,
+    async (headRef) => (headRef === "test/contract" ? [parent] : []),
+    "a/b",
+    "refactor/agent",
+  );
+
+  assert.deepEqual(chain.map((item) => [item.number, item.role]), [
+    [94, "child"],
+    [90, "root"],
+  ]);
+});
+
+test("rejects a stacked chain with no unique open parent or wrong final branch", async () => {
+  const child = pull(94, "impl/green", "test/contract");
+  await assert.rejects(
+    resolvePullChain(child, async () => [], "a/b", "refactor/agent"),
+    /exactly one open parent/,
+  );
+
+  const wrongRoot = pull(90, "test/contract", "dev");
+  await assert.rejects(
+    resolvePullChain(
+      child,
+      async (headRef) => (headRef === "test/contract" ? [wrongRoot] : []),
+      "a/b",
+      "refactor/agent",
+    ),
+    /protected branch dev/,
+  );
+});
+
+test("rejects foreign, closed, and cyclic PR chains", async () => {
+  const child = pull(94, "impl/green", "test/contract");
+  const foreignParent = pull(90, "test/contract", "refactor/agent", {
+    head: {ref: "test/contract", sha: "c".repeat(40), repo: {full_name: "fork/repo"}},
+  });
+  await assert.rejects(
+    resolvePullChain(child, async () => [foreignParent], "a/b", "refactor/agent"),
+    /same repository/,
+  );
+
+  const closedParent = pull(90, "test/contract", "refactor/agent", {state: "closed"});
+  await assert.rejects(
+    resolvePullChain(child, async () => [closedParent], "a/b", "refactor/agent"),
+    /open/,
+  );
+
+  const cycleParent = pull(90, "test/contract", "impl/green");
+  await assert.rejects(
+    resolvePullChain(
+      child,
+      async (headRef) => {
+        if (headRef === "test/contract") return [cycleParent];
+        if (headRef === "impl/green") return [child];
+        return [];
+      },
+      "a/b",
+      "refactor/agent",
+    ),
+    /cycle/,
   );
 });
 

--- a/.github/workflows/agent-refactor-review.yml
+++ b/.github/workflows/agent-refactor-review.yml
@@ -2,8 +2,6 @@ name: Agent refactor PR review
 
 'on':
   pull_request_target:
-    branches:
-      - refactor/agent
     types:
       - opened
       - synchronize
@@ -60,6 +58,7 @@ jobs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       issue_numbers: ${{ steps.resolve.outputs.issue_numbers }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
+      stack_chain: ${{ steps.resolve.outputs.stack_chain }}
     steps:
       - name: Check out trusted review policy
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -112,14 +111,23 @@ jobs:
               repo: context.repo.repo,
               pull_number: prNumber,
             });
-            if (pull.base.ref !== "refactor/agent" || pull.state !== "open") {
-              core.notice(`Ignoring PR #${prNumber}: base=${pull.base.ref}, state=${pull.state}.`);
-              core.setOutput("eligible", "false");
-              return;
-            }
             const repositoryName = `${context.repo.owner}/${context.repo.repo}`;
-            if (pull.head.repo?.full_name !== repositoryName) {
-              core.notice(`Ignoring PR #${prNumber}: external fork branches are not trusted.`);
+            let stackChain;
+            try {
+              stackChain = await policy.resolvePullChain(
+                pull,
+                async (headRef) => github.paginate(github.rest.pulls.list, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                  head: `${context.repo.owner}:${headRef}`,
+                  per_page: 100,
+                }),
+                repositoryName,
+                "refactor/agent",
+              );
+            } catch (error) {
+              core.notice(`Ignoring PR #${prNumber}: ${error.message}.`);
               core.setOutput("eligible", "false");
               return;
             }
@@ -189,6 +197,7 @@ jobs:
             core.setOutput("head_sha", pull.head.sha);
             core.setOutput("issue_numbers", JSON.stringify(issueNumbers));
             core.setOutput("pr_number", String(prNumber));
+            core.setOutput("stack_chain", JSON.stringify(stackChain));
 
   review:
     needs: resolve
@@ -244,12 +253,14 @@ jobs:
           ISSUE_NUMBERS: ${{ needs.resolve.outputs.issue_numbers }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           REVIEW_EVENT_KEY: ${{ needs.resolve.outputs.event_key }}
+          STACK_CHAIN: ${{ needs.resolve.outputs.stack_chain }}
         with:
           script: |
             const fs = require("fs");
             const path = require("path");
             const prNumber = Number(process.env.PR_NUMBER);
             const issueNumbers = JSON.parse(process.env.ISSUE_NUMBERS);
+            const stackChain = JSON.parse(process.env.STACK_CHAIN);
             const [pullResponse, files, commits, comments, reviews, reviewComments] = await Promise.all([
               github.rest.pulls.get({
                 owner: context.repo.owner,
@@ -308,6 +319,35 @@ jobs:
               });
             }
             const pull = pullResponse.data;
+            const pullRequestChain = await Promise.all(stackChain.map(async (entry) => {
+              const [{data: chainPull}, chainReviews] = await Promise.all([
+                github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: entry.number,
+                }),
+                github.paginate(github.rest.pulls.listReviews, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: entry.number,
+                  per_page: 100,
+                }),
+              ]);
+              return {
+                ...entry,
+                title: chainPull.title,
+                body: chainPull.body,
+                draft: chainPull.draft,
+                reviews: chainReviews.slice(-50).map((review) => ({
+                  author: review.user?.login,
+                  association: review.author_association,
+                  submitted_at: review.submitted_at,
+                  state: review.state,
+                  commit_id: review.commit_id,
+                  body: review.body,
+                })),
+              };
+            }));
             const reviewContext = {
               repository: `${context.repo.owner}/${context.repo.repo}`,
               event_name: context.eventName,
@@ -327,6 +367,7 @@ jobs:
                 candidate_merge_clean: process.env.CANDIDATE_MERGE_CLEAN === "true",
               },
               issues,
+              pull_request_chain: pullRequestChain,
               files: files.map((file) => ({
                 filename: file.filename,
                 status: file.status,
@@ -445,6 +486,7 @@ jobs:
           EXPECTED_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
           EXPECTED_ISSUE_NUMBERS: ${{ needs.resolve.outputs.issue_numbers }}
+          EXPECTED_STACK_CHAIN: ${{ needs.resolve.outputs.stack_chain }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           REVIEW_EVENT_KEY: ${{ needs.resolve.outputs.event_key }}
           REVIEW_RESULT: ${{ needs.review.outputs.final_message }}
@@ -495,8 +537,34 @@ jobs:
               });
               return;
             }
-            if (pull.base.ref !== "refactor/agent" || pull.state !== "open") {
-              core.setFailed("The PR target or state changed after review.");
+            let currentStackChain;
+            try {
+              currentStackChain = await policy.resolvePullChain(
+                pull,
+                async (headRef) => github.paginate(github.rest.pulls.list, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                  head: `${context.repo.owner}:${headRef}`,
+                  per_page: 100,
+                }),
+                `${context.repo.owner}/${context.repo.repo}`,
+                "refactor/agent",
+              );
+            } catch (error) {
+              core.setFailed(`The PR stack is no longer valid: ${error.message}`);
+              return;
+            }
+            const expectedStackChain = JSON.parse(process.env.EXPECTED_STACK_CHAIN);
+            if (JSON.stringify(currentStackChain) !== JSON.stringify(expectedStackChain)) {
+              core.notice("The PR stack changed after review; dispatching a fresh review.");
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "agent-refactor-review.yml",
+                ref: "master",
+                inputs: {pr_number: String(prNumber)},
+              });
               return;
             }
 

--- a/.github/workflows/agent-refactor-review.yml
+++ b/.github/workflows/agent-refactor-review.yml
@@ -661,9 +661,11 @@ jobs:
               return lines.join("\n");
             };
             const tests = result.tests.length
-              ? result.tests.map((test) =>
-                  `- \`${test.command}\` → **${test.status}**：${test.details}`,
-                ).join("\n")
+              ? result.tests.map((test) => {
+                  const requirement = test.required ? "required" : "optional";
+                  const skip = test.skip_reason ? `，skip_reason=${test.skip_reason}` : "";
+                  return `- \`${test.command}\` → **${test.status}**（${requirement}${skip}）：${test.details}`;
+                }).join("\n")
               : "- 未记录验证命令。";
             let body = [
               marker,

--- a/.github/workflows/agent-refactor-review.yml
+++ b/.github/workflows/agent-refactor-review.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: read
+      issues: write
       pull-requests: read
     outputs:
       duplicate: ${{ steps.resolve.outputs.duplicate }}
@@ -112,25 +112,6 @@ jobs:
               pull_number: prNumber,
             });
             const repositoryName = `${context.repo.owner}/${context.repo.repo}`;
-            let stackChain;
-            try {
-              stackChain = await policy.resolvePullChain(
-                pull,
-                async (headRef) => github.paginate(github.rest.pulls.list, {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  state: "open",
-                  head: `${context.repo.owner}:${headRef}`,
-                  per_page: 100,
-                }),
-                repositoryName,
-                "refactor/agent",
-              );
-            } catch (error) {
-              core.notice(`Ignoring PR #${prNumber}: ${error.message}.`);
-              core.setOutput("eligible", "false");
-              return;
-            }
             let closingIssues = [];
             try {
               const graph = await github.graphql(
@@ -153,15 +134,91 @@ jobs:
               closingIssues,
               repositoryName,
             );
-            if (
-              issueNumbers.length === 0 ||
-              issueNumbers.some((number) => number < 60 || number > 89)
-            ) {
+            if (!policy.isAgentIssueSet(issueNumbers)) {
               core.notice(
                 `Ignoring PR #${prNumber}: explicit issue relationships must refer only to #60-#89.`,
               );
               core.setOutput("eligible", "false");
               return;
+            }
+            let stackChain;
+            try {
+              stackChain = await policy.resolvePullChain(
+                pull,
+                async (headRef) => github.paginate(github.rest.pulls.list, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                  head: `${context.repo.owner}:${headRef}`,
+                  per_page: 100,
+                }),
+                repositoryName,
+                "refactor/agent",
+              );
+            } catch (error) {
+              const marker = `<!-- agent-refactor-invalid-stack:${pull.base.sha}:${pull.head.sha} -->`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+              if (!comments.some((comment) => (comment.body || "").includes(marker))) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: [
+                    marker,
+                    "结论：**CHANGES_REQUESTED（流程）**",
+                    "",
+                    `当前 PR 无法解析为终止于 \`refactor/agent\` 的可信堆叠链：${error.message}。`,
+                    "请将根 PR 的 base 修正为 `refactor/agent`；子 PR 必须以同仓库唯一开放父 PR 的 head 分支为 base，并保持父链开放、无环且可追溯。",
+                  ].join("\n"),
+                });
+              }
+              core.notice(`Rejected PR #${prNumber}: ${error.message}.`);
+              core.setOutput("eligible", "false");
+              return;
+            }
+
+            for (const parent of stackChain.slice(1)) {
+              const parentReviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parent.number,
+                per_page: 100,
+              });
+              const violation = policy.parentApprovalViolation(
+                parentReviews,
+                parent.head_sha,
+              );
+              if (violation) {
+                const marker = `<!-- agent-refactor-parent-unapproved:${parent.number}:${parent.head_sha} -->`;
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 100,
+                });
+                if (!comments.some((comment) => (comment.body || "").includes(marker))) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: [
+                      marker,
+                      "结论：**CHANGES_REQUESTED（流程）**",
+                      "",
+                      `父 PR #${parent.number} 的当前 head \`${parent.head_sha}\` 尚未形成有效批准：${violation}。`,
+                      "请先让父层当前 head 通过审核；旧 SHA 的批准、已撤销批准或当前修改请求均不能授权本层继续。",
+                    ].join("\n"),
+                  });
+                }
+                core.notice(`Rejected PR #${prNumber}: parent #${parent.number} is not approved.`);
+                core.setOutput("eligible", "false");
+                return;
+              }
             }
 
             const eventKey = policy.buildEventKey(
@@ -568,6 +625,24 @@ jobs:
               return;
             }
 
+            let parentApprovalIssue = null;
+            for (const parent of currentStackChain.slice(1)) {
+              const parentReviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parent.number,
+                per_page: 100,
+              });
+              const violation = policy.parentApprovalViolation(
+                parentReviews,
+                parent.head_sha,
+              );
+              if (violation) {
+                parentApprovalIssue = `父 PR #${parent.number} 的当前 head 不再满足批准门禁：${violation}`;
+                break;
+              }
+            }
+
             const marker = `<!-- agent-refactor-review-key:${process.env.REVIEW_EVENT_KEY} -->`;
             const findingSection = (title, findings) => {
               const lines = [`## ${title}`, ""];
@@ -608,6 +683,10 @@ jobs:
             if (passViolation) {
               result.verdict = "CHANGES_REQUESTED";
               body += `\n\n工作流保护：${passViolation}；已拒绝合并。`;
+            }
+            if (parentApprovalIssue) {
+              result.verdict = "CHANGES_REQUESTED";
+              body += `\n\n工作流保护：${parentApprovalIssue}；已拒绝合并。`;
             }
 
             if (result.verdict === "PASS" && !pull.draft) {

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -4,7 +4,16 @@
 
 ## 目标
 
-在默认分支部署事件驱动的审查工作流，审查目标为 `refactor/agent`、且显式关联 Agent 深模块重构工单 #60-#89 的同仓库 PR。审查覆盖流程/TDD、黑盒验证、Standards 和 Spec；失败时请求修改，通过时 squash merge 到 `refactor/agent`。
+在默认分支部署事件驱动的审查工作流，审查以 `refactor/agent` 为最终集成分支、且显式关联 Agent 深模块重构工单 #60-#89 的同仓库根 PR 与合法堆叠子 PR。审查覆盖流程/TDD、黑盒验证、Standards 和 Spec；失败时请求修改，通过时将子 PR squash merge 到直接父分支，或将根 PR squash merge 到 `refactor/agent`。
+
+## 本 PR
+
+- PR：待创建（分支 `codex/stacked-pr-review-workflow`，目标 `master`）
+- 目标：让事件审查器识别并安全处理最终终止于 `refactor/agent` 的堆叠 PR 链。
+- 范围：事件入口、堆叠链解析与固定、父 PR review 上下文、发布前链路复核、子/根 PR 合并目标、显式 `Issue #NN` 关联语法，以及长耗时外部测试的默认跳过规则。
+- 明确不包含：不启用 `AGENT_PR_REVIEW_ENABLED`，不配置或读取 `OPENAI_API_KEY`，不修改 Agent 产品代码或 #90/#94 分支。
+- Red：新增策略测试时 5 项失败，其中显式 Issue 关联未识别，且 `resolvePullChain` 尚不存在。
+- Green：`node --test .github/codex/tests/review-policy.test.js` 为 10 项通过；两个 JavaScript 文件 `node --check` 通过；Workflow YAML 使用 PyYAML 解析通过；`git diff --check` 通过。当前环境没有 `actionlint`，未复现该项。
 
 ## 已完成
 
@@ -16,10 +25,13 @@
 - 将核心合并策略提取到 `.github/codex/scripts/review-policy.js`，并增加 Node 内建测试。
 - 将第三方 Actions 固定到已核验的提交 SHA；同一次运行的三个 job 使用同一个 `github.workflow_sha` 读取可信策略。
 - 仓库已允许 GitHub Actions 创建 PR review；变量 `AGENT_PR_REVIEW_ENABLED` 已创建并保持为 `false`。
+- 支持根 PR 直接指向 `refactor/agent`，以及同仓库开放父 PR 组成、最终终止于该根 PR 的无环堆叠链。
+- 子 PR 使用直接父 PR 的固定 head 作为审查基线，只能合入父分支；父 PR 更新后必须触发新的完整候选审查。
+- 默认跳过真实学歌、B 站/VCPedia 实时抓取和其他长耗时外部测试，并把跳过项记录为未验证。
 
 ## 已验证
 
-- `node --test .github/codex/tests/review-policy.test.js`：5 项通过。
+- `node --test .github/codex/tests/review-policy.test.js`：原 5 项与本轮新增 5 项，共 10 项通过。
 - `actionlint .github/workflows/agent-refactor-review.yml`：通过。
 - Workflow YAML、三个 `actions/github-script` 脚本和 Draft 2020-12 JSON Schema 静态解析：通过。
 - `git diff --check`：通过。
@@ -30,7 +42,7 @@
 
 - 在 GitHub 仓库 Secret 中配置 project-scoped `OPENAI_API_KEY`。
 - 将 `AGENT_PR_REVIEW_ENABLED` 切换为 `true`。
-- 以一个真实、同仓库、目标为 `refactor/agent` 且关联 #60-#89 的 PR 验证：事件触发、Codex 审查、失败 review 或通过后的 squash merge。
+- 以真实根 PR 和堆叠子 PR 分别验证：事件触发、父链解析、Codex 增量/完整审查、子 PR 合入父分支，以及根 PR 最终 squash merge 到 `refactor/agent`。
 - 真实事件链路验收通过后，删除现有每 10 分钟轮询任务。
 
 在以上待完成项完成前，本功能状态为“已部署但禁用，等待密钥与端到端验收”，不得标记为完成。

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,12 +8,12 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `codex/stacked-pr-review-workflow`，目标 `master`）
+- PR：[#96](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/96)（分支 `codex/stacked-pr-review-workflow`，目标 `master`，Ready，等待复审）
 - 目标：让事件审查器识别并安全处理最终终止于 `refactor/agent` 的堆叠 PR 链。
 - 范围：事件入口、堆叠链解析与固定、父 PR review 上下文、发布前链路复核、子/根 PR 合并目标、显式 `Issue #NN` 关联语法，以及长耗时外部测试的默认跳过规则。
 - 明确不包含：不启用 `AGENT_PR_REVIEW_ENABLED`，不配置或读取 `OPENAI_API_KEY`，不修改 Agent 产品代码或 #90/#94 分支。
-- Red：新增策略测试时 5 项失败，其中显式 Issue 关联未识别，且 `resolvePullChain` 尚不存在。
-- Green：`node --test .github/codex/tests/review-policy.test.js` 为 10 项通过；两个 JavaScript 文件 `node --check` 通过；Workflow YAML 使用 PyYAML 解析通过；`git diff --check` 通过。当前环境没有 `actionlint`，未复现该项。
+- Red：首轮新增策略测试时 5 项失败，其中显式 Issue 关联未识别，且 `resolvePullChain` 尚不存在；复审新增父层批准和 `NOT_RUN` 门禁测试时 2 项失败，分别证明批准门禁尚不存在、合法外部测试跳过会被误拒。
+- Green：`node --test .github/codex/tests/review-policy.test.js` 为 12 项通过；两个 JavaScript 文件 `node --check` 通过；Workflow YAML 使用 PyYAML 解析通过；`git diff --check` 通过。当前环境没有 `actionlint`，该项未运行。
 
 ## 已完成
 
@@ -28,11 +28,13 @@
 - 支持根 PR 直接指向 `refactor/agent`，以及同仓库开放父 PR 组成、最终终止于该根 PR 的无环堆叠链。
 - 子 PR 使用直接父 PR 的固定 head 作为审查基线，只能合入父分支；父 PR 更新后必须触发新的完整候选审查。
 - 默认跳过真实学歌、B 站/VCPedia 实时抓取和其他长耗时外部测试，并把跳过项记录为未验证。
+- 只有父链每一层的当前 head 都具有可信审核者的有效批准、且没有当前修改请求时，子 PR 才能进入审查；发布前会重新检查，旧 SHA、已撤销批准和新增修改请求都会阻止合并。
+- 显式关联 #60-#89 但目标分支或堆叠拓扑非法的 PR 会收到可操作的流程修改评论，不再被静默忽略。
 
 ## 已验证
 
-- `node --test .github/codex/tests/review-policy.test.js`：原 5 项与本轮新增 5 项，共 10 项通过。
-- `actionlint .github/workflows/agent-refactor-review.yml`：通过。
+- `node --test .github/codex/tests/review-policy.test.js`：共 12 项通过。
+- `actionlint .github/workflows/agent-refactor-review.yml`：未运行；当前环境未安装 `actionlint`。
 - Workflow YAML、三个 `actions/github-script` 脚本和 Draft 2020-12 JSON Schema 静态解析：通过。
 - `git diff --check`：通过。
 

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -13,7 +13,7 @@
 - 范围：事件入口、堆叠链解析与固定、父 PR review 上下文、发布前链路复核、子/根 PR 合并目标、显式 `Issue #NN` 关联语法，以及长耗时外部测试的默认跳过规则。
 - 明确不包含：不启用 `AGENT_PR_REVIEW_ENABLED`，不配置或读取 `OPENAI_API_KEY`，不修改 Agent 产品代码或 #90/#94 分支。
 - Red：首轮新增策略测试时 5 项失败，其中显式 Issue 关联未识别，且 `resolvePullChain` 尚不存在；复审新增父层批准和 `NOT_RUN` 门禁测试时 2 项失败，分别证明批准门禁尚不存在、合法外部测试跳过会被误拒。
-- Green：`node --test .github/codex/tests/review-policy.test.js` 为 12 项通过；两个 JavaScript 文件 `node --check` 通过；Workflow YAML 使用 PyYAML 解析通过；`git diff --check` 通过。当前环境没有 `actionlint`，该项未运行。
+- Green：`node --test .github/codex/tests/review-policy.test.js` 为 12 项通过；策略 JavaScript 与三个 `actions/github-script` 块通过语法解析；Workflow YAML 使用 PyYAML 解析通过；`git diff --check` 通过；固定版本 `actionlint` 通过。
 
 ## 已完成
 
@@ -27,14 +27,14 @@
 - 仓库已允许 GitHub Actions 创建 PR review；变量 `AGENT_PR_REVIEW_ENABLED` 已创建并保持为 `false`。
 - 支持根 PR 直接指向 `refactor/agent`，以及同仓库开放父 PR 组成、最终终止于该根 PR 的无环堆叠链。
 - 子 PR 使用直接父 PR 的固定 head 作为审查基线，只能合入父分支；父 PR 更新后必须触发新的完整候选审查。
-- 默认跳过真实学歌、B 站/VCPedia 实时抓取和其他长耗时外部测试，并把跳过项记录为未验证。
+- 默认跳过真实学歌、B 站/VCPedia 实时抓取和其他长耗时外部测试；仅非必需检查可用结构化 `skip_reason` 标成 `NOT_RUN`，必需测试不能靠静态检查通过来绕过。
 - 只有父链每一层的当前 head 都具有可信审核者的有效批准、且没有当前修改请求时，子 PR 才能进入审查；发布前会重新检查，旧 SHA、已撤销批准和新增修改请求都会阻止合并。
 - 显式关联 #60-#89 但目标分支或堆叠拓扑非法的 PR 会收到可操作的流程修改评论，不再被静默忽略。
 
 ## 已验证
 
 - `node --test .github/codex/tests/review-policy.test.js`：共 12 项通过。
-- `actionlint .github/workflows/agent-refactor-review.yml`：未运行；当前环境未安装 `actionlint`。
+- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/agent-refactor-review.yml`：通过。
 - Workflow YAML、三个 `actions/github-script` 脚本和 Draft 2020-12 JSON Schema 静态解析：通过。
 - `git diff --check`：通过。
 


### PR DESCRIPTION
## 目标

让 Agent PR 事件审查器支持以 refactor/agent 为最终集成分支的可信堆叠 PR，不再把 #94 这类合法子 PR当成目标分支错误。

Related to #93。

## 行为

- pull_request_target 接收所有 base 的事件，但在付费模型调用前解析同仓库开放 PR 链；
- 根 PR 必须以 refactor/agent 为 base；子 PR 的 base 必须唯一对应直接父 PR head，整条链无环且最终到达根 PR；
- dev/main/master 不能作为子 PR 的合并目标；
- 审查上下文包含父链及每层 review，便于确认父 head 已获批准；
- 发布前重新校验固定的完整 PR 链；子 PR只 squash merge 到父分支，根 PR只 squash merge 到 refactor/agent；
- 显式 “Issue #60” 记法可被识别为工单关系；
- 默认跳过真实学歌、B站/VCPedia抓取和其他长耗时外部测试并记录未验证。

## TDD

Red：新增 5 个测试后，显式 Issue 关联未识别且 resolvePullChain 不存在，5 项失败。

Green：

- node --test .github/codex/tests/review-policy.test.js：10 passed；
- node --check 两个策略/测试 JavaScript：通过；
- Workflow YAML：PyYAML 解析通过；
- 三个 actions/github-script 内嵌脚本：包装后 node --check 通过；
- git diff --check：通过。

当前环境未安装 actionlint，因此没有复现该项；工作流仍保持 AGENT_PR_REVIEW_ENABLED=false，不会产生付费调用。实际 GitHub 事件链需要配置 project-scoped OPENAI_API_KEY 后再验收。