### PR TITLE
fix(ci): 修复本机 Codex 审查的 checkout 兼容问题

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -21,6 +21,13 @@ All jobs load policy, prompt, schema, and publisher checks from the immutable
 `github.workflow_sha` for that run. A moving default branch therefore cannot
 change the contract between resolution, review, and publication.
 
+The workflow deliberately avoids `actions/checkout`. This repository contains
+a historical gitlink without a matching `.gitmodules` URL, which makes the
+action's credential-cleanup step fail even when submodules are disabled. The
+resolver and publisher fetch the single policy file through the GitHub API at
+the trusted workflow SHA. The local review job fetches only the pinned base,
+head, and workflow commits into a run-specific directory below `RUNNER_TEMP`.
+
 Only repository collaborators with `write`, `maintain`, or `admin` permission
 can trigger a Codex review, and the PR head must be a branch in this repository.
 This intentionally excludes untrusted fork code from the local execution

--- a/.github/codex/tests/review-policy.test.js
+++ b/.github/codex/tests/review-policy.test.js
@@ -311,7 +311,9 @@ test("routes the Codex review through the dedicated local ChatGPT-auth runner", 
 
 test("keeps trusted review inputs outside the candidate workspace", () => {
   assert.match(WORKFLOW, /Join-Path \$env:RUNNER_TEMP/);
-  assert.match(WORKFLOW, /git archive --format=zip/);
+  assert.match(WORKFLOW, /git -C \$candidateRoot fetch --no-tags --no-recurse-submodules/);
+  assert.match(WORKFLOW, /git -C \$env:CANDIDATE_ROOT archive --format=zip/);
   assert.match(WORKFLOW, /REVIEW_CONTEXT_FILE: \$\{\{ steps\.trusted\.outputs\.context_file \}\}/);
   assert.match(WORKFLOW, /Refusing to remove a path outside RUNNER_TEMP/);
+  assert.doesNotMatch(WORKFLOW, /uses:\s*actions\/checkout/);
 });

--- a/.github/workflows/agent-refactor-review.yml
+++ b/.github/workflows/agent-refactor-review.yml
@@ -60,13 +60,31 @@ jobs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       stack_chain: ${{ steps.resolve.outputs.stack_chain }}
     steps:
-      - name: Check out trusted review policy
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Materialize trusted review policy
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          TRUSTED_SHA: ${{ github.workflow_sha }}
         with:
-          ref: ${{ github.workflow_sha }}
-          path: .review-automation
-          sparse-checkout: .github/codex
-          persist-credentials: false
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const policyPath = ".github/codex/scripts/review-policy.js";
+            const {data} = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: policyPath,
+              ref: process.env.TRUSTED_SHA,
+            });
+            if (Array.isArray(data) || data.type !== "file" || !data.content) {
+              throw new Error("Trusted review policy is not a readable file.");
+            }
+            const destination = path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".review-automation",
+              policyPath,
+            );
+            fs.mkdirSync(path.dirname(destination), {recursive: true});
+            fs.writeFileSync(destination, Buffer.from(data.content, "base64"), {mode: 0o600});
 
       - name: Resolve and authorize the pull request
         id: resolve
@@ -274,43 +292,55 @@ jobs:
     outputs:
       final_message: ${{ steps.codex.outputs.final-message }}
     steps:
-      - name: Check out the pinned target commit
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          ref: ${{ needs.resolve.outputs.base_sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Construct the pinned candidate integration tree
+      - name: Construct the pinned candidate repository
+        id: candidate
         shell: pwsh
         env:
+          CANDIDATE_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
           CANDIDATE_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          TRUSTED_SHA: ${{ github.workflow_sha }}
         run: |
-          git config user.name "Agent refactor review"
-          git config user.email "agent-refactor-review@users.noreply.github.com"
-          git merge --no-commit --no-ff $env:CANDIDATE_HEAD_SHA
+          $candidateRoot = Join-Path $env:RUNNER_TEMP "agent-refactor-candidate-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          New-Item -ItemType Directory -Path $candidateRoot -Force | Out-Null
+
+          git -C $candidateRoot init
+          git -C $candidateRoot remote add origin "https://github.com/$env:GITHUB_REPOSITORY.git"
+          git -C $candidateRoot fetch --no-tags --no-recurse-submodules origin `
+            $env:CANDIDATE_BASE_SHA $env:CANDIDATE_HEAD_SHA $env:TRUSTED_SHA
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not fetch the pinned base, head, and workflow commits."
+          }
+          git -C $candidateRoot checkout --detach $env:CANDIDATE_BASE_SHA
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not check out the pinned target commit."
+          }
+          git -C $candidateRoot config user.name "Agent refactor review"
+          git -C $candidateRoot config user.email "agent-refactor-review@users.noreply.github.com"
+          git -C $candidateRoot merge --no-commit --no-ff $env:CANDIDATE_HEAD_SHA
           if ($LASTEXITCODE -eq 0) {
             "CANDIDATE_MERGE_CLEAN=true" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           } else {
             "CANDIDATE_MERGE_CLEAN=false" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
             Write-Warning "The pinned base and head have merge conflicts; Codex will review them."
           }
+          "candidate_root=$candidateRoot" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Materialize the trusted review bundle outside the candidate workspace
         id: trusted
         shell: pwsh
         env:
+          CANDIDATE_ROOT: ${{ steps.candidate.outputs.candidate_root }}
           TRUSTED_SHA: ${{ github.workflow_sha }}
         run: |
           $reviewRoot = Join-Path $env:RUNNER_TEMP "agent-refactor-review-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
           $archivePath = "$reviewRoot.zip"
           New-Item -ItemType Directory -Path $reviewRoot -Force | Out-Null
 
-          git cat-file -e "$env:TRUSTED_SHA^{commit}"
+          git -C $env:CANDIDATE_ROOT cat-file -e "$env:TRUSTED_SHA^{commit}"
           if ($LASTEXITCODE -ne 0) {
             throw "Trusted workflow commit $env:TRUSTED_SHA is unavailable."
           }
-          git archive --format=zip --output=$archivePath $env:TRUSTED_SHA .github/codex
+          git -C $env:CANDIDATE_ROOT archive --format=zip --output=$archivePath $env:TRUSTED_SHA .github/codex
           if ($LASTEXITCODE -ne 0) {
             throw "Could not archive the trusted review bundle."
           }
@@ -539,6 +569,7 @@ jobs:
         id: codex
         shell: pwsh
         env:
+          CANDIDATE_ROOT: ${{ steps.candidate.outputs.candidate_root }}
           REVIEW_BUNDLE_ROOT: ${{ steps.trusted.outputs.bundle_root }}
           REVIEW_CONTEXT_FILE: ${{ steps.trusted.outputs.context_file }}
           REVIEW_PROMPT_FILE: ${{ steps.trusted.outputs.prompt_file }}
@@ -564,7 +595,7 @@ jobs:
             --ignore-user-config `
             --sandbox workspace-write `
             --approve-for-me `
-            --cd $env:GITHUB_WORKSPACE `
+            --cd $env:CANDIDATE_ROOT `
             --output-schema $env:REVIEW_SCHEMA_FILE `
             --output-last-message $env:REVIEW_RESULT_FILE `
             -
@@ -583,18 +614,21 @@ jobs:
         if: always()
         shell: pwsh
         env:
+          CANDIDATE_ROOT: ${{ steps.candidate.outputs.candidate_root }}
           REVIEW_ROOT: ${{ steps.trusted.outputs.review_root }}
         run: |
-          if (-not $env:REVIEW_ROOT) {
-            exit 0
-          }
-          $reviewRoot = [IO.Path]::GetFullPath($env:REVIEW_ROOT)
           $runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP)
-          if (-not $reviewRoot.StartsWith($runnerTemp, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Refusing to remove a path outside RUNNER_TEMP: $reviewRoot"
-          }
-          if (Test-Path -LiteralPath $reviewRoot) {
-            Remove-Item -LiteralPath $reviewRoot -Recurse -Force
+          foreach ($pathToRemove in @($env:REVIEW_ROOT, $env:CANDIDATE_ROOT)) {
+            if (-not $pathToRemove) {
+              continue
+            }
+            $fullPath = [IO.Path]::GetFullPath($pathToRemove)
+            if (-not $fullPath.StartsWith($runnerTemp, [StringComparison]::OrdinalIgnoreCase)) {
+              throw "Refusing to remove a path outside RUNNER_TEMP: $fullPath"
+            }
+            if (Test-Path -LiteralPath $fullPath) {
+              Remove-Item -LiteralPath $fullPath -Recurse -Force
+            }
           }
 
   publish:
@@ -611,13 +645,31 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Check out trusted review policy
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Materialize trusted review policy
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          TRUSTED_SHA: ${{ github.workflow_sha }}
         with:
-          ref: ${{ github.workflow_sha }}
-          path: .review-automation
-          sparse-checkout: .github/codex
-          persist-credentials: false
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const policyPath = ".github/codex/scripts/review-policy.js";
+            const {data} = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: policyPath,
+              ref: process.env.TRUSTED_SHA,
+            });
+            if (Array.isArray(data) || data.type !== "file" || !data.content) {
+              throw new Error("Trusted review policy is not a readable file.");
+            }
+            const destination = path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".review-automation",
+              policyPath,
+            );
+            fs.mkdirSync(path.dirname(destination), {recursive: true});
+            fs.writeFileSync(destination, Buffer.from(data.content, "base64"), {mode: 0o600});
 
       - name: Publish verdict and merge an accepted PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,7 +8,7 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `codex/local-agent-pr-review-checkout-fix`，目标 `master`）
+- PR：[#98](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/98)（分支 `codex/local-agent-pr-review-checkout-fix`，目标 `master`）
 - 目标：修复真实 workflow dispatch 在 GitHub-hosted resolver 的 checkout 清理阶段失败。
 - 范围：移除三个 job 的 `actions/checkout`；resolver/publisher 通过 GitHub API 读取固定 workflow SHA 的策略文件，本机 review 在 `RUNNER_TEMP` 原生获取固定 base/head/workflow commit；保留 ChatGPT 登录、本地测试和既有审查/合并门禁。
 - 明确不包含：不使用或配置 `OPENAI_API_KEY`/`CODEX_API_KEY`，不修改 Agent 产品代码、#90/#94 分支、工单范围或测试通过规则。

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,11 +8,11 @@
 
 ## 本 PR
 
-- PR：[#97](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/97)（分支 `codex/local-agent-pr-review`，目标 `master`）
-- 目标：把已部署的 API-key/GitHub-hosted Codex 审查改为 ChatGPT 登录、本机测试环境执行的事件审查。
-- 范围：仅将 `review` job 路由到专用 Windows self-hosted runner；使用本机 `codex exec`、ChatGPT 登录预检、可信临时策略目录和结构化输出；保留 GitHub-hosted resolver/publisher、现有门禁、审查标准和合并规则。
+- PR：待创建（分支 `codex/local-agent-pr-review-checkout-fix`，目标 `master`）
+- 目标：修复真实 workflow dispatch 在 GitHub-hosted resolver 的 checkout 清理阶段失败。
+- 范围：移除三个 job 的 `actions/checkout`；resolver/publisher 通过 GitHub API 读取固定 workflow SHA 的策略文件，本机 review 在 `RUNNER_TEMP` 原生获取固定 base/head/workflow commit；保留 ChatGPT 登录、本地测试和既有审查/合并门禁。
 - 明确不包含：不使用或配置 `OPENAI_API_KEY`/`CODEX_API_KEY`，不修改 Agent 产品代码、#90/#94 分支、工单范围或测试通过规则。
-- 验证及结果：策略/工作流静态契约测试扩展为 14 项；待重新运行 workflow 静态校验和真实 `workflow_dispatch` 端到端验证；在真实链路通过前保持 `AGENT_PR_REVIEW_ENABLED=false`。
+- 验证及结果：首次真实 dispatch [run 33961947804](https://github.com/SheepLiu712/Agent-LuoTianyi/actions/runs/33961947804) 在 resolver 的 checkout 认证清理阶段失败，原因是历史 `mineflayer` gitlink 没有 `.gitmodules` URL；review/publish 均未运行，未消耗 Codex 用量或合并 PR。修复后待重新运行静态检查与真实 dispatch；验证期间保持 #90 的人工 `CHANGES_REQUESTED` 合并门禁。
 
 ## 已完成
 
@@ -32,6 +32,7 @@
 - 仓库级 Windows runner `desktop-agent-luotianyi-review` 已注册并以当前用户启动，标签为 `self-hosted/Windows/X64/agent-luotianyi-review/codex-chatgpt-auth`；本机 Codex CLI 当前使用 ChatGPT 登录。
 - 本地 review job 明确拒绝 API-key 环境变量，并通过 `codex exec --ephemeral --ignore-user-config --sandbox workspace-write --approve-for-me` 使用本地仓库、SPEC、开发规范和测试环境。
 - resolver 和 publisher 继续在 GitHub-hosted runner 运行；只有已经通过受信任触发者、同仓库 head、Issue #60-#89 和堆叠链门禁的候选才会派发到本机。
+- PR #97 已 squash merge 到 `master`；首次真实 dispatch 暴露 checkout 兼容问题后，仓库变量 `AGENT_PR_REVIEW_ENABLED` 已恢复为 `false`，等待本修复合入后再开启复验。
 
 ## 已验证
 


### PR DESCRIPTION
## 问题

真实 `workflow_dispatch` run 33961947804 在 resolver 的 `actions/checkout` 认证清理阶段失败：仓库历史 `mineflayer` gitlink 没有匹配的 `.gitmodules` URL。review/publish 未运行，未消耗 Codex 用量。

## 修复

- resolver/publisher 通过 GitHub API 从固定 `github.workflow_sha` 读取单个可信策略文件；
- 本机 review 在 `RUNNER_TEMP` 创建隔离候选目录，原生获取固定 base/head/workflow commit；
- 不再使用 `actions/checkout`，继续保持候选工作区、可信策略和 GitHub 写权限隔离；
- 临时候选与策略目录均经过路径边界检查后清理。

## 验证

- Node 策略/工作流契约测试 14/14；
- workflow YAML、JSON Schema、5 个 github-script 块、5 个 PowerShell 块语法检查通过；
- actionlint v1.7.7 通过；
- git diff --check 通过。