### PR TITLE
fix(ci): 修复本机 Codex CLI 参数冲突

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -118,6 +118,10 @@ account because that account would not share the interactive user's Codex
 login. Start it at user logon under the dedicated runner account, or run
 `run.cmd` manually when reviews should be accepted.
 
+The local invocation uses `codex exec --approve-for-me`. On the installed CLI,
+that option already selects the workspace-write sandbox and cannot be combined
+with a separate `--sandbox` flag.
+
 ## Verification
 
 Run the policy tests with:

--- a/.github/codex/tests/review-policy.test.js
+++ b/.github/codex/tests/review-policy.test.js
@@ -305,6 +305,8 @@ test("routes the Codex review through the dedicated local ChatGPT-auth runner", 
   assert.match(WORKFLOW, /codex login status/);
   assert.match(WORKFLOW, /Logged in using ChatGPT/);
   assert.match(WORKFLOW, /codex exec/);
+  assert.match(WORKFLOW, /--approve-for-me/);
+  assert.doesNotMatch(WORKFLOW, /--sandbox workspace-write/);
   assert.doesNotMatch(WORKFLOW, /uses:\s*openai\/codex-action/);
   assert.doesNotMatch(WORKFLOW, /openai-api-key:/);
 });

--- a/.github/workflows/agent-refactor-review.yml
+++ b/.github/workflows/agent-refactor-review.yml
@@ -593,7 +593,6 @@ jobs:
           $fullPrompt | codex exec `
             --ephemeral `
             --ignore-user-config `
-            --sandbox workspace-write `
             --approve-for-me `
             --cd $env:CANDIDATE_ROOT `
             --output-schema $env:REVIEW_SCHEMA_FILE `

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,7 +8,7 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `codex/local-agent-pr-review-cli-flags`，目标 `master`）
+- PR：[#99](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/99)（分支 `codex/local-agent-pr-review-cli-flags`，目标 `master`）
 - 目标：修复本机 Codex CLI 拒绝重复 sandbox 配置的问题。
 - 范围：保留 `--approve-for-me` 并移除与其冲突的 `--sandbox workspace-write`；前者在当前 CLI 中已经使用 workspace-write sandbox，其余认证、隔离、审查和合并门禁不变。
 - 明确不包含：不使用或配置 `OPENAI_API_KEY`/`CODEX_API_KEY`，不修改 Agent 产品代码、#90/#94 分支、工单范围或测试通过规则。

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,11 +8,11 @@
 
 ## 本 PR
 
-- PR：[#98](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/98)（分支 `codex/local-agent-pr-review-checkout-fix`，目标 `master`）
-- 目标：修复真实 workflow dispatch 在 GitHub-hosted resolver 的 checkout 清理阶段失败。
-- 范围：移除三个 job 的 `actions/checkout`；resolver/publisher 通过 GitHub API 读取固定 workflow SHA 的策略文件，本机 review 在 `RUNNER_TEMP` 原生获取固定 base/head/workflow commit；保留 ChatGPT 登录、本地测试和既有审查/合并门禁。
+- PR：待创建（分支 `codex/local-agent-pr-review-cli-flags`，目标 `master`）
+- 目标：修复本机 Codex CLI 拒绝重复 sandbox 配置的问题。
+- 范围：保留 `--approve-for-me` 并移除与其冲突的 `--sandbox workspace-write`；前者在当前 CLI 中已经使用 workspace-write sandbox，其余认证、隔离、审查和合并门禁不变。
 - 明确不包含：不使用或配置 `OPENAI_API_KEY`/`CODEX_API_KEY`，不修改 Agent 产品代码、#90/#94 分支、工单范围或测试通过规则。
-- 验证及结果：首次真实 dispatch [run 33961947804](https://github.com/SheepLiu712/Agent-LuoTianyi/actions/runs/33961947804) 在 resolver 的 checkout 认证清理阶段失败，原因是历史 `mineflayer` gitlink 没有 `.gitmodules` URL；review/publish 均未运行，未消耗 Codex 用量或合并 PR。修复后待重新运行静态检查与真实 dispatch；验证期间保持 #90 的人工 `CHANGES_REQUESTED` 合并门禁。
+- 验证及结果：第二次真实 dispatch [run 33962112250](https://github.com/SheepLiu712/Agent-LuoTianyi/actions/runs/33962112250) 已通过 resolver、本机固定 SHA 拉取、可信上下文构建和 ChatGPT 登录预检；`codex exec` 在模型调用前以退出码 2 拒绝同时使用 `--sandbox` 与 `--approve-for-me`，因此未产生审查或合并。修复后待重新运行静态检查与真实 dispatch；验证期间保持 #90 的人工 `CHANGES_REQUESTED` 合并门禁。
 
 ## 已完成
 
@@ -30,9 +30,9 @@
 - 只有父链每一层的当前 head 都具有可信审核者的有效批准、且没有当前修改请求时，子 PR 才能进入审查；发布前会重新检查，旧 SHA、已撤销批准和新增修改请求都会阻止合并。
 - 显式关联 #60-#89 但目标分支或堆叠拓扑非法的 PR 会收到可操作的流程修改评论，不再被静默忽略。
 - 仓库级 Windows runner `desktop-agent-luotianyi-review` 已注册并以当前用户启动，标签为 `self-hosted/Windows/X64/agent-luotianyi-review/codex-chatgpt-auth`；本机 Codex CLI 当前使用 ChatGPT 登录。
-- 本地 review job 明确拒绝 API-key 环境变量，并通过 `codex exec --ephemeral --ignore-user-config --sandbox workspace-write --approve-for-me` 使用本地仓库、SPEC、开发规范和测试环境。
+- 本地 review job 明确拒绝 API-key 环境变量，并通过 `codex exec --ephemeral --ignore-user-config --approve-for-me` 使用本地仓库、SPEC、开发规范和 workspace-write 测试环境。
 - resolver 和 publisher 继续在 GitHub-hosted runner 运行；只有已经通过受信任触发者、同仓库 head、Issue #60-#89 和堆叠链门禁的候选才会派发到本机。
-- PR #97 已 squash merge 到 `master`；首次真实 dispatch 暴露 checkout 兼容问题后，仓库变量 `AGENT_PR_REVIEW_ENABLED` 已恢复为 `false`，等待本修复合入后再开启复验。
+- PR #97、#98 已 squash merge 到 `master`；第二次真实 dispatch 暴露 CLI 参数冲突后，仓库变量 `AGENT_PR_REVIEW_ENABLED` 已恢复为 `false`，等待本修复合入后再开启复验。
 
 ## 已验证
 


### PR DESCRIPTION
## 问题

真实 dispatch run 33962112250 已通过远端门禁、本机固定 SHA 拉取、可信上下文和 ChatGPT 登录预检，但当前 Codex CLI 在模型调用前拒绝同时使用 `--sandbox workspace-write` 与 `--approve-for-me`。

## 修复

保留 `--approve-for-me` 并移除重复的 `--sandbox` 参数；当前 CLI 中前者已经选择 workspace-write sandbox。

## 验证

- 策略/工作流契约测试 14/14；
- workflow YAML、JSON Schema 和 actionlint v1.7.7 通过；
- git diff --check 通过。