### PR TITLE
fix(ci): 使用 Codex 兼容的审查输出 Schema

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -122,6 +122,13 @@ The local invocation uses `codex exec --approve-for-me`. On the installed CLI,
 that option already selects the workspace-write sandbox and cannot be combined
 with a separate `--sandbox` flag.
 
+`review-output.schema.json` intentionally uses only the structural subset that
+Codex structured outputs accepts. Semantic constraints that the model endpoint
+does not support—such as unique issue numbers, the issue range, SHA formatting,
+non-empty strings, and conditional test skip rules—remain mandatory and are
+revalidated by `review-policy.js` in the separate publisher job before any
+review or merge operation.
+
 ## Verification
 
 Run the policy tests with:

--- a/.github/codex/review-output.schema.json
+++ b/.github/codex/review-output.schema.json
@@ -24,8 +24,7 @@
       "enum": ["PASS", "CHANGES_REQUESTED", "WAITING", "BLOCKED"]
     },
     "summary": {
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "target_branch": {
       "type": "string",
@@ -33,17 +32,10 @@
     },
     "issue_numbers": {
       "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "integer",
-        "minimum": 60,
-        "maximum": 89
-      }
+      "items": {"type": "integer"}
     },
     "head_sha": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{40}$"
+      "type": "string"
     },
     "flow_findings": {
       "$ref": "#/$defs/findings"
@@ -62,16 +54,14 @@
         "required": ["command", "status", "details", "required", "skip_reason"],
         "properties": {
           "command": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           },
           "status": {
             "type": "string",
             "enum": ["PASS", "FAIL", "EXPECTED_RED", "NOT_RUN"]
           },
           "details": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           },
           "required": {
             "type": "boolean"
@@ -80,24 +70,7 @@
             "type": ["string", "null"],
             "enum": ["slow", "live", "external", "real_llm", null]
           }
-        },
-        "allOf": [
-          {
-            "if": {
-              "properties": {"status": {"const": "NOT_RUN"}},
-              "required": ["status"]
-            },
-            "then": {
-              "properties": {
-                "required": {"const": false},
-                "skip_reason": {"type": "string"}
-              }
-            },
-            "else": {
-              "properties": {"skip_reason": {"const": null}}
-            }
-          }
-        ]
+        }
       }
     }
   },
@@ -121,23 +94,19 @@
             "enum": ["P0", "P1", "P2", "P3"]
           },
           "title": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           },
           "detail": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           },
           "file": {
             "type": ["string", "null"]
           },
           "line": {
-            "type": ["integer", "null"],
-            "minimum": 1
+            "type": ["integer", "null"]
           },
           "required_change": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           }
         }
       }

--- a/.github/codex/tests/review-policy.test.js
+++ b/.github/codex/tests/review-policy.test.js
@@ -21,6 +21,9 @@ const WORKFLOW = fs.readFileSync(
   path.join(__dirname, "..", "..", "workflows", "agent-refactor-review.yml"),
   "utf8",
 );
+const OUTPUT_SCHEMA = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "review-output.schema.json"), "utf8"),
+);
 
 function testRecord(overrides = {}) {
   return {
@@ -318,4 +321,27 @@ test("keeps trusted review inputs outside the candidate workspace", () => {
   assert.match(WORKFLOW, /REVIEW_CONTEXT_FILE: \$\{\{ steps\.trusted\.outputs\.context_file \}\}/);
   assert.match(WORKFLOW, /Refusing to remove a path outside RUNNER_TEMP/);
   assert.doesNotMatch(WORKFLOW, /uses:\s*actions\/checkout/);
+});
+
+test("keeps the model output schema inside the Codex structured-output subset", () => {
+  const unsupported = new Set([
+    "allOf",
+    "else",
+    "if",
+    "maximum",
+    "minItems",
+    "minimum",
+    "minLength",
+    "pattern",
+    "then",
+    "uniqueItems",
+  ]);
+  const visit = (value) => {
+    if (!value || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value)) {
+      assert.equal(unsupported.has(key), false, `unsupported schema keyword: ${key}`);
+      visit(child);
+    }
+  };
+  visit(OUTPUT_SCHEMA);
 });

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,7 +8,7 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `codex/local-agent-pr-review-schema`，目标 `master`）
+- PR：[#100](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/100)（分支 `codex/local-agent-pr-review-schema`，目标 `master`）
 - 目标：让审查结果 Schema 符合 Codex 结构化输出支持的 JSON Schema 子集。
 - 范围：从模型侧 Schema 移除 `uniqueItems`、格式/范围/长度和条件关键字；这些语义继续由独立 publisher 中的 `assertValidReviewResult` 全量校验，认证、隔离、审查和合并门禁不变。
 - 明确不包含：不使用或配置 `OPENAI_API_KEY`/`CODEX_API_KEY`，不修改 Agent 产品代码、#90/#94 分支、工单范围或测试通过规则。

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,11 +8,11 @@
 
 ## 本 PR
 
-- PR：[#99](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/99)（分支 `codex/local-agent-pr-review-cli-flags`，目标 `master`）
-- 目标：修复本机 Codex CLI 拒绝重复 sandbox 配置的问题。
-- 范围：保留 `--approve-for-me` 并移除与其冲突的 `--sandbox workspace-write`；前者在当前 CLI 中已经使用 workspace-write sandbox，其余认证、隔离、审查和合并门禁不变。
+- PR：待创建（分支 `codex/local-agent-pr-review-schema`，目标 `master`）
+- 目标：让审查结果 Schema 符合 Codex 结构化输出支持的 JSON Schema 子集。
+- 范围：从模型侧 Schema 移除 `uniqueItems`、格式/范围/长度和条件关键字；这些语义继续由独立 publisher 中的 `assertValidReviewResult` 全量校验，认证、隔离、审查和合并门禁不变。
 - 明确不包含：不使用或配置 `OPENAI_API_KEY`/`CODEX_API_KEY`，不修改 Agent 产品代码、#90/#94 分支、工单范围或测试通过规则。
-- 验证及结果：第二次真实 dispatch [run 33962112250](https://github.com/SheepLiu712/Agent-LuoTianyi/actions/runs/33962112250) 已通过 resolver、本机固定 SHA 拉取、可信上下文构建和 ChatGPT 登录预检；`codex exec` 在模型调用前以退出码 2 拒绝同时使用 `--sandbox` 与 `--approve-for-me`，因此未产生审查或合并。修复后待重新运行静态检查与真实 dispatch；验证期间保持 #90 的人工 `CHANGES_REQUESTED` 合并门禁。
+- 验证及结果：第三次真实 dispatch [run 33962260226](https://github.com/SheepLiu712/Agent-LuoTianyi/actions/runs/33962260226) 已启动 ChatGPT 登录的 `gpt-5.6-sol`，但模型生成前以 `invalid_json_schema` 拒绝 `issue_numbers.uniqueItems`，因此未产生审查或合并。修复后待重新运行静态检查与真实 dispatch；验证期间保持 #90 的人工 `CHANGES_REQUESTED` 合并门禁。
 
 ## 已完成
 
@@ -32,7 +32,7 @@
 - 仓库级 Windows runner `desktop-agent-luotianyi-review` 已注册并以当前用户启动，标签为 `self-hosted/Windows/X64/agent-luotianyi-review/codex-chatgpt-auth`；本机 Codex CLI 当前使用 ChatGPT 登录。
 - 本地 review job 明确拒绝 API-key 环境变量，并通过 `codex exec --ephemeral --ignore-user-config --approve-for-me` 使用本地仓库、SPEC、开发规范和 workspace-write 测试环境。
 - resolver 和 publisher 继续在 GitHub-hosted runner 运行；只有已经通过受信任触发者、同仓库 head、Issue #60-#89 和堆叠链门禁的候选才会派发到本机。
-- PR #97、#98 已 squash merge 到 `master`；第二次真实 dispatch 暴露 CLI 参数冲突后，仓库变量 `AGENT_PR_REVIEW_ENABLED` 已恢复为 `false`，等待本修复合入后再开启复验。
+- PR #97—#99 已 squash merge 到 `master`；第三次真实 dispatch 暴露结构化输出 Schema 不兼容后，仓库变量 `AGENT_PR_REVIEW_ENABLED` 已恢复为 `false`，等待本修复合入后再开启复验。
 
 ## 已验证
 


### PR DESCRIPTION
## 问题

真实 dispatch run 33962260226 已使用 ChatGPT 登录启动 `gpt-5.6-sol`，但在生成前因 `issue_numbers.uniqueItems` 不属于 Codex 结构化输出 Schema 子集而失败。

## 修复

- 模型侧 Schema 只保留结构化输出支持的对象、必填字段、类型、枚举和引用；
- 唯一性、Issue 范围、SHA 格式、非空文本和测试跳过条件继续由 publisher 的 `assertValidReviewResult` 独立强校验；
- 新增静态契约测试，禁止再次引入当前模型接口不支持的关键字。

## 验证

- 策略/工作流/Schema 契约测试 15/15；
- workflow YAML、Draft 2020-12 Schema 与 actionlint v1.7.7 通过；
- git diff --check 通过。