### PR TITLE
docs(ci): 记录默认分支迁移完成

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,7 +8,7 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `codex/record-pr-review-branch-migration`，目标 `dev`）
+- PR：[#104](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/104)（分支 `codex/record-pr-review-branch-migration`，目标 `dev`）
 - 目标：记录默认分支迁移和发布分支清理的最终结果。
 - 范围：只更新本进度文档，关联迁移 PR #102 和清理 PR #103 的验证事实。
 - 明确不包含：不修改工作流、审查策略、Agent 产品代码、#90/#94 分支或本机 Runner 配置。

--- a/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
+++ b/docs/开发进程文档/开发进度/Agent-PR事件审查自动化.md
@@ -8,22 +8,22 @@
 
 ## 本 PR
 
-- PR：[#102](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/102)（分支 `codex/migrate-pr-review-to-dev`，目标 `dev`）
-- 目标：把事件审查的可信工作流和配套资产从发布分支迁移到 GitHub 默认开发分支，并明确 `dev`/`master` 的职责。
-- 范围：同步 `.github` 审查资产到 `dev`；将工作流内部重新派发引用从 `master` 改为 `dev`；更新分支治理和本进度文档。
-- 明确不包含：本 PR 不修改 Agent 产品代码、#90/#94 分支、工单范围、审查通过规则或本机 Runner 身份；不在本 PR 中清理 `master`，清理由迁移生效后的独立 revert PR 完成。
-- 验证及结果：新增默认分支契约测试后先得到 1 项预期失败，实际值为两处 `master`、期望为两处 `dev`；改为 `dev` 后 Node 策略测试 16/16 通过，actionlint 通过，Schema JSON 解析和 `git diff --check` 通过。
+- PR：待创建（分支 `codex/record-pr-review-branch-migration`，目标 `dev`）
+- 目标：记录默认分支迁移和发布分支清理的最终结果。
+- 范围：只更新本进度文档，关联迁移 PR #102 和清理 PR #103 的验证事实。
+- 明确不包含：不修改工作流、审查策略、Agent 产品代码、#90/#94 分支或本机 Runner 配置。
+- 验证及结果：GitHub 默认分支为 `dev`；`dev` 上的 `Agent refactor PR review` 工作流为 active；`master` 当前文件树与自动化引入前的发布提交 `450c1a53` 无差异。
 
 ## 已完成
 
 - 建立新建、更新、重新打开、Ready、retarget、review 提交/编辑/撤销、普通评论和行内评论事件入口。
 - 在付费调用前限制目标分支、工单范围、同仓库 head 和 write/maintain/admin 触发者。
 - 将候选 target base 与 PR head 同时固定，构造并测试对应的候选集成树。
-- 将 API Key 所在的只读审查 job 与拥有 GitHub 写权限的发布 job 分离。
+- 将使用本机 Codex 的只读审查 job 与拥有 GitHub 写权限的发布 job 分离。
 - 发布前独立校验完整输出契约、工单集合、base/head SHA、PASS 测试证据、P0/P1 finding 和人工 review 最新状态。
 - 将核心合并策略提取到 `.github/codex/scripts/review-policy.js`，并增加 Node 内建测试。
 - 将第三方 Actions 固定到已核验的提交 SHA；同一次运行的三个 job 使用同一个 `github.workflow_sha` 读取可信策略。
-- 仓库已允许 GitHub Actions 创建 PR review；变量 `AGENT_PR_REVIEW_ENABLED` 已创建并保持为 `false`。
+- 仓库已允许 GitHub Actions 创建 PR review；变量 `AGENT_PR_REVIEW_ENABLED` 已创建并设置为 `true`。
 - 支持根 PR 直接指向 `refactor/agent`，以及同仓库开放父 PR 组成、最终终止于该根 PR 的无环堆叠链。
 - 子 PR 使用直接父 PR 的固定 head 作为审查基线，只能合入父分支；父 PR 更新后必须触发新的完整候选审查。
 - 默认跳过真实学歌、B 站/VCPedia 实时抓取和其他长耗时外部测试；仅非必需检查可用结构化 `skip_reason` 标成 `NOT_RUN`，必需测试不能靠静态检查通过来绕过。
@@ -34,18 +34,20 @@
 - resolver 和 publisher 继续在 GitHub-hosted runner 运行；只有已经通过受信任触发者、同仓库 head、Issue #60-#89 和堆叠链门禁的候选才会派发到本机。
 - PR #97—#99 已 squash merge 到 `master`；第三次真实 dispatch 暴露结构化输出 Schema 不兼容后，仓库变量 `AGENT_PR_REVIEW_ENABLED` 已恢复为 `false`，等待本修复合入后再开启复验。
 - PR #100 已 squash merge 到 `master`；仓库变量 `AGENT_PR_REVIEW_ENABLED` 已重新设为 `true`。
+- PR #102 已 squash merge 到 `dev`，工作流内部重新派发使用的可信 ref 已从 `master` 改为 `dev`；GitHub 默认分支随后切换为 `dev`。
+- PR #103 已以普通 revert 提交 squash merge 到 `master`，撤销 #92、#96—#101 的自动审查文件，不改写历史；清理后 `master` 文件树与发布提交 `450c1a53` 无差异。
 - 真实审查已读取固定 PR/Issue/SPEC 上下文，执行 focused/domain pytest、Ruff、`PersistPolicy` 公开身份检查和 `git diff --check`；所有记录的检查均通过，真实学歌、B 站/VCPedia、真实模型/TTS/GPU/设备测试未运行。
 - publisher 已把 Standards finding 发布到 PR #90：新增公开 `src.domain.agent` interface 尚未同步到当前 domain interface 文档。PR 保持开放和 `CHANGES_REQUESTED`，证明失败结论不会触发合并。
 - 原 Codex 桌面心跳轮询任务 `agent-pr` 已删除；后续由 GitHub PR 事件直接派发，不再定时轮询。
 
 ## 已验证
 
-- `node --test .github/codex/tests/review-policy.test.js`：共 12 项通过。
+- `node --test .github/codex/tests/review-policy.test.js`：共 16 项通过，包括重新派发必须固定到 `dev` 的契约测试。
 - `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/agent-refactor-review.yml`：通过。
 - Workflow YAML、三个 `actions/github-script` 脚本和 Draft 2020-12 JSON Schema 静态解析：通过。
 - `git diff --check`：通过。
 
-上述结果只证明静态配置和本地策略行为，不代表 Secret-enabled 的 GitHub 真实事件链路已经通过。
+静态配置、本地策略以及根 PR 的真实审查/拒绝合并链路已经通过；尚未验证的真实事件、PASS 合并和堆叠 PR 场景继续列在下节。
 
 ## 待完成
 


### PR DESCRIPTION
## 目标
记录 Agent PR 自动审查默认分支迁移和 `master` 清理的最终事实。

## 已确认
- 迁移 PR #102 已合并到 `dev`
- GitHub 默认分支已切换为 `dev`
- `Agent refactor PR review` 在 `dev` 上处于 active
- 清理 PR #103 已合并到 `master`
- `master` 文件树与自动化引入前的发布提交 `450c1a53` 无差异

本 PR 仅更新开发进度文档，不改变工作流或产品代码。