### PR TITLE
docs(agent): 固定 Stimulus 构造错误契约

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -2,7 +2,7 @@
 
 > 最后更新：2026-09-05
 >
-> 当前阶段：工单 01 `TextMessage` 完整 Green 根 PR，等待 owner 复审
+> 当前阶段：工单 01 Stimulus 构造错误 interface 设计
 >
 > 总体状态：进行中
 
@@ -16,13 +16,12 @@
 
 ## 本 PR
 
-- PR：[#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90)（完整 Green 根 PR，目标 `refactor/agent`，Ready，等待 owner 复审）
-- 目标：交付已批准的 `TextMessage` 契约测试及足以让该测试通过的最小 `src.domain.agent` 协议实现。
-- 范围：包含 `TextMessage` 公开契约测试；公开导出 `TextMessage`、`StimulusKind.TEXT_MESSAGE`、`StimulusSource.USER` 和四成员单一 `PersistPolicy`；旧 `src.domain.stimulus` 导入并重导出同一 `PersistPolicy`，保持现有调用兼容。
-- 明确不包含：不实现其余 21 个 Stimulus、非法组合校验、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
-- 前置门禁：interface 设计 PR [#91](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/91) 已获 owner 批准并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `661b7d2`。
-- 测试与实现门禁：PR #90 的 Red-only seam 已获 owner 批准，head `c724c1f`；最小 Green 子 PR [#94](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/94) 已获 owner 批准，并于 2026-09-05 squash merge 到本分支，合并提交 `3b156739`。旧批准和测试证据不作为当前完整候选的最终依据。
-- 验证及结果：相对当前 `origin/refactor/agent` 的完整候选重新验证：focused 测试 `1 passed in 0.18s`，`tests/domain -q` 为 `1 passed in 0.18s`；相关文件 `py_compile`、Ruff、`src/domain/agent` BasedPyright（0 errors、0 warnings）和 `git diff --check` 均通过；导入检查确认 `src.domain`、`src.domain.agent`、`src.domain.stimulus` 暴露同一个四成员 `PersistPolicy`。离线回归在排除真实图片/TTS/唱歌资源测试、真实 B 站/VCPedia 抓取和 `real_llm` 后为 `400 passed, 4 deselected, 6 failed`；当前 `refactor/agent` 用同一命令为 `399 passed, 4 deselected, 6 failed`，六个失败集合一致，分别来自 diary Fake 接口漂移、测试直接调用无效外部 LLM key、已删除的数据库私有 helper、主动话题既有行为差异和项目计划路由测试假设，不是本切片引入。
+- PR：待创建（分支 `docs/agent-dm-01-stimulus-error-contract`，目标 `refactor/agent`）
+- 目标：在编写下一条非法 `TextMessage` 组合 Red 测试前，固定 Stimulus 构造失败的公开异常接口。
+- 范围：定义 `StimulusErrorCode`、`InvalidStimulusError(ValueError)`、稳定 `code / retryable` 字段、直接构造抛出行为和非契约异常文本；同步 domain 当前/目标 interface 边界。
+- 明确不包含：不写测试或产品实现；不实现 source/persist/ephemeral 校验、其他 Stimulus、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
+- 前置门禁：`TextMessage` 合法构造 PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 已获自动审查通过并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `42580dad`。
+- 验证及结果：本 PR 为纯 interface 文档门禁；三份文档均存在且无 Unicode replacement character，关键字段检查确认异常类型、稳定 code/retryable、直接构造抛出和非契约异常文本均已写入，`git diff --check` 通过；未运行 pytest、模型、TTS、GPU、设备或真实外部服务。
 
 ## 历史设计轮次目标与范围
 
@@ -102,6 +101,7 @@
 - [x] Green：同一 focused 命令在当前完整候选上为 `1 passed in 0.18s`；
 - [x] 已实现 `src.domain.agent` 的 `TextMessage` 最小切片，并让旧 Stimulus 复用同一四成员 `PersistPolicy`；
 - [x] 已同步 domain 当前 interface 文档，记录 `src.domain.agent` 公开路径、`TextMessage` 字段与不变量、无副作用及当前仅支持合法构造的校验边界；
+- [ ] Stimulus 构造错误接口设计等待评审；设计通过后才为非法 `TextMessage` 组合编写 Red-only 契约测试；
 - [ ] 工单 01 的其余 Stimulus、InteractionSnapshot、HandleStimulusRequest、CancellationToken、HandlingReport、稳定枚举和错误族测试尚未开始；
 - [x] `tests/domain -q` 为 `1 passed in 0.18s`；Ruff、py_compile、BasedPyright 和 `git diff --check` 通过；三处公开路径导出的 `PersistPolicy` 为同一对象且四成员完整；
 - [ ] 离线回归为 `400 passed, 4 deselected, 6 failed`；当前 `refactor/agent` 对照为 `399 passed, 4 deselected, 6 failed`，失败集合一致，未发现本切片新增回归，但仓库默认回归门禁仍未全绿；
@@ -124,4 +124,4 @@
 
 ## 下一步
 
-owner 复审通过后，由 owner 将 PR #90 squash merge 到 `refactor/agent`。工单 01 的下一可观察行为必须另开新的 TDD 切片。
+提交 Stimulus 构造错误 interface 设计 PR 并等待评审；通过后另开 Red-only PR，从 `src.domain.agent` 公开导出验证非法 `TextMessage` 组合抛出 `InvalidStimulusError`，并只断言稳定 `code` 与 `retryable`。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -16,7 +16,7 @@
 
 ## 本 PR
 
-- PR：待创建（分支 `docs/agent-dm-01-stimulus-error-contract`，目标 `refactor/agent`）
+- PR：[#105](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/105)（分支 `docs/agent-dm-01-stimulus-error-contract`，目标 `refactor/agent`，Ready，等待评审）
 - 目标：在编写下一条非法 `TextMessage` 组合 Red 测试前，固定 Stimulus 构造失败的公开异常接口。
 - 范围：定义 `StimulusErrorCode`、`InvalidStimulusError(ValueError)`、稳定 `code / retryable` 字段、直接构造抛出行为和非契约异常文本；同步 domain 当前/目标 interface 边界。
 - 明确不包含：不写测试或产品实现；不实现 source/persist/ephemeral 校验、其他 Stimulus、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。

--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -18,10 +18,10 @@
 
 - PR：[#105](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/105)（分支 `docs/agent-dm-01-stimulus-error-contract`，目标 `refactor/agent`，Ready，等待评审）
 - 目标：在编写下一条非法 `TextMessage` 组合 Red 测试前，固定 Stimulus 构造失败的公开异常接口。
-- 范围：定义 `StimulusErrorCode`、`InvalidStimulusError(ValueError)`、稳定 `code / retryable` 字段、直接构造抛出行为和非契约异常文本；同步 domain 当前/目标 interface 边界。
+- 范围：定义 `StimulusErrorCode` 的 `CONTRACT_INVALID_STIMULUS / CONTRACT_UNSUPPORTED_SCHEMA` 两个构造错误码、`InvalidStimulusError(ValueError)`、稳定 `code / retryable` 字段、schema 与一般字段的触发边界、直接构造抛出行为和非契约异常文本；同步 domain 当前/目标 interface 边界。
 - 明确不包含：不写测试或产品实现；不实现 source/persist/ephemeral 校验、其他 Stimulus、InteractionSnapshot、request/report、Agent façade 或生产调用链迁移。
 - 前置门禁：`TextMessage` 合法构造 PR [#90](https://github.com/SheepLiu712/Agent-LuoTianyi/pull/90) 已获自动审查通过并于 2026-09-05 squash merge 到 `refactor/agent`，合并提交 `42580dad`。
-- 验证及结果：本 PR 为纯 interface 文档门禁；三份文档均存在且无 Unicode replacement character，关键字段检查确认异常类型、稳定 code/retryable、直接构造抛出和非契约异常文本均已写入，`git diff --check` 通过；未运行 pytest、模型、TTS、GPU、设备或真实外部服务。
+- 验证及结果：本 PR 为纯 interface 文档门禁；三份文档均存在且无 Unicode replacement character，关键字段检查确认异常类型、两个稳定 code、schema 构造校验边界、`retryable=False`、直接构造抛出和非契约异常文本均已写入，`git diff --check` 通过；未运行 pytest、模型、TTS、GPU、设备或真实外部服务。
 
 ## 历史设计轮次目标与范围
 
@@ -124,4 +124,4 @@
 
 ## 下一步
 
-提交 Stimulus 构造错误 interface 设计 PR 并等待评审；通过后另开 Red-only PR，从 `src.domain.agent` 公开导出验证非法 `TextMessage` 组合抛出 `InvalidStimulusError`，并只断言稳定 `code` 与 `retryable`。
+等待 PR #105 重新评审；通过后另开 Red-only PR，从 `src.domain.agent` 公开导出验证非法 `TextMessage` 组合抛出 `InvalidStimulusError`，并只断言稳定 `code` 与 `retryable`。

--- a/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
@@ -297,10 +297,11 @@ Agent 已由角色 ID 取得，请求不重复携带 `character_id`。请求不�
 
 Stimulus 构造契约错误使用独立于 HandlingReport 运行时失败的最小公开接口：
 
-- `StimulusErrorCode = Literal["CONTRACT_INVALID_STIMULUS"]`；当前只包含这一构造错误码，后续增加成员属于公开协议变更；
-- `InvalidStimulusError(ValueError)` 是不可变的公开异常，稳定暴露 `code: StimulusErrorCode` 和 `retryable: Literal[False]`；`code` 始终为 `CONTRACT_INVALID_STIMULUS`，`retryable` 始终为 `False`；
+- `StimulusErrorCode = Literal["CONTRACT_INVALID_STIMULUS", "CONTRACT_UNSUPPORTED_SCHEMA"]`；后续增加成员属于公开协议变更；
+- `InvalidStimulusError(ValueError)` 是不可变的公开异常，稳定暴露 `code: StimulusErrorCode` 和 `retryable: Literal[False]`；`retryable` 始终为 `False`；
 - `str(error)` 只用于人工诊断，措辞不属于公开契约；调用方不得解析异常字符串，也不依赖字段名、规则 ID、非法值字典或内部 cause；
-- 各强类型 Stimulus 保持直接构造入口，不增加 `create()` factory 或 Result 返回。合法参数原子地产生不可变实例；字段非法、目标角色非法或 `source / persist_policy / ephemeral` 组合不在矩阵中时，直接抛出 `InvalidStimulusError`，不产生部分实例；
+- 各强类型 Stimulus 保持直接构造入口，不增加 `create()` factory 或 Result 返回。合法参数原子地产生不可变实例；一般结构或语义不变量失败、目标角色非法、缺失/非整数 `schema_version`，以及 `source / persist_policy / ephemeral` 组合不在矩阵中时，抛出 `InvalidStimulusError(code="CONTRACT_INVALID_STIMULUS")`；类型为整数但不受支持的 `schema_version`（包括非正数和未知未来版本）抛出 `InvalidStimulusError(code="CONTRACT_UNSUPPORTED_SCHEMA")`。两种情况均不产生部分实例；
+- schema 兼容性在构造阶段校验；构造失败发生在 handle 开始前，不产生 `HandlingReport`。稳定错误族中出现 `CONTRACT_UNSUPPORTED_SCHEMA` 不表示必须把该构造错误包装成运行时报告；
 - `InvalidStimulusError` 与 `StimulusErrorCode` 从 `src.domain.agent` 公开导出，只用于 Stimulus 构造契约；不替代 HandlingReport、ExecutionReport 或 ActionExecutionResult 的错误类型。
 
 #### 当前版本 Stimulus 强类型变体

--- a/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/设计文档/Agent-handle-realize-深模块重构.md
@@ -295,6 +295,14 @@ Agent 已由角色 ID 取得，请求不重复携带 `character_id`。请求不�
 - `persist_policy` 只决定 Stimulus 原始内容是否进入会话记录和是否成为自动长期记忆候选。`DynamicObserved`、`SongLearned` 等 `NONE` 事实仍可按 Agent 内部状态变更或 Reflection 契约写入领域数据；
 - `CONVERSATION_ONLY` 在当前 22 个 kind 中没有生产者，但因复用现有唯一枚举而保留。任何 kind 改用该策略都属于需要先修改本矩阵的公开协议变更。
 
+Stimulus 构造契约错误使用独立于 HandlingReport 运行时失败的最小公开接口：
+
+- `StimulusErrorCode = Literal["CONTRACT_INVALID_STIMULUS"]`；当前只包含这一构造错误码，后续增加成员属于公开协议变更；
+- `InvalidStimulusError(ValueError)` 是不可变的公开异常，稳定暴露 `code: StimulusErrorCode` 和 `retryable: Literal[False]`；`code` 始终为 `CONTRACT_INVALID_STIMULUS`，`retryable` 始终为 `False`；
+- `str(error)` 只用于人工诊断，措辞不属于公开契约；调用方不得解析异常字符串，也不依赖字段名、规则 ID、非法值字典或内部 cause；
+- 各强类型 Stimulus 保持直接构造入口，不增加 `create()` factory 或 Result 返回。合法参数原子地产生不可变实例；字段非法、目标角色非法或 `source / persist_policy / ephemeral` 组合不在矩阵中时，直接抛出 `InvalidStimulusError`，不产生部分实例；
+- `InvalidStimulusError` 与 `StimulusErrorCode` 从 `src.domain.agent` 公开导出，只用于 Stimulus 构造契约；不替代 HandlingReport、ExecutionReport 或 ActionExecutionResult 的错误类型。
+
 #### 当前版本 Stimulus 强类型变体
 
 当前版本不保留 `payload: Mapping` 作为扩展口。下表中的每个专有字段都给出类型和用途：

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/domain/README.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/domain/README.md
@@ -57,7 +57,7 @@
 - 创建这些对象只做字段校验和默认值生成，不产生外部副作用。
 - `TextMessage` 构造后不可变，不提供任意 `payload` 扩展口，并逐项保留调用方提供的公共字段和文字消息专有字段。
 - 当前契约测试只锁定合法样例：`source=USER`、`persist_policy=CONVERSATION_AND_MEMORY_CANDIDATE`、`ephemeral=False`。本切片尚未实现 source/persist/ephemeral 组合校验，因此其他组合当前不会按目标 spec 稳定返回 `CONTRACT_INVALID_STIMULUS`；调用方不得把这种暂未校验视为受支持行为。
-- **目标 interface**：非法 Stimulus 构造将直接抛出公开 `InvalidStimulusError(ValueError)`；调用方只读取稳定的 `code="CONTRACT_INVALID_STIMULUS"` 和 `retryable=False`，不解析异常文本。该异常与 `StimulusErrorCode` 尚未在当前源码实现，不能提前用于业务代码。
+- **目标 interface**：非法 Stimulus 构造将直接抛出公开 `InvalidStimulusError(ValueError)`；一般字段/目标/组合非法时 `code="CONTRACT_INVALID_STIMULUS"`，整数但不受支持的 schema 版本时 `code="CONTRACT_UNSUPPORTED_SCHEMA"`，两者的 `retryable=False`。构造失败发生在 handle 前，不产生 `HandlingReport`；调用方不解析异常文本。该异常与 `StimulusErrorCode` 尚未在当前源码实现，不能提前用于业务代码。
 - 枚举值和字段名属于跨模块协议；修改时必须先更新 spec 和消费者测试。
 - `Stimulus` 默认不持久化。调用方必须显式选择 `PersistPolicy`，不能仅凭消息来源猜测。
 - 构造参数不合法时由 dataclass、枚举或 Pydantic 抛出类型/校验异常，调用方不应静默吞掉。

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/domain/README.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/domain/README.md
@@ -57,6 +57,7 @@
 - 创建这些对象只做字段校验和默认值生成，不产生外部副作用。
 - `TextMessage` 构造后不可变，不提供任意 `payload` 扩展口，并逐项保留调用方提供的公共字段和文字消息专有字段。
 - 当前契约测试只锁定合法样例：`source=USER`、`persist_policy=CONVERSATION_AND_MEMORY_CANDIDATE`、`ephemeral=False`。本切片尚未实现 source/persist/ephemeral 组合校验，因此其他组合当前不会按目标 spec 稳定返回 `CONTRACT_INVALID_STIMULUS`；调用方不得把这种暂未校验视为受支持行为。
+- **目标 interface**：非法 Stimulus 构造将直接抛出公开 `InvalidStimulusError(ValueError)`；调用方只读取稳定的 `code="CONTRACT_INVALID_STIMULUS"` 和 `retryable=False`，不解析异常文本。该异常与 `StimulusErrorCode` 尚未在当前源码实现，不能提前用于业务代码。
 - 枚举值和字段名属于跨模块协议；修改时必须先更新 spec 和消费者测试。
 - `Stimulus` 默认不持久化。调用方必须显式选择 `PersistPolicy`，不能仅凭消息来源猜测。
 - 构造参数不合法时由 dataclass、枚举或 Pydantic 抛出类型/校验异常，调用方不应静默吞掉。


### PR DESCRIPTION
## 对应工单

Part of #60

这是 Issue #60 下一条非法 `TextMessage` 组合 TDD 切片的 interface 设计门禁，不关闭 #60。

## 目标

在编写 Red 测试前，固定 Stimulus 直接构造失败时的最小公开错误接口，消除“抛异常、Result 返回或 factory”之间的歧义。

## 设计

- `StimulusErrorCode = Literal["CONTRACT_INVALID_STIMULUS"]`；
- `InvalidStimulusError(ValueError)` 公开、不可变，稳定暴露 `code` 和 `retryable=False`；
- `str(error)` 仅用于诊断，不属于契约；
- 强类型 Stimulus 保持直接构造，非法字段、目标角色或 source/persist/ephemeral 组合直接抛出异常，不产生部分实例；
- 错误接口从 `src.domain.agent` 导出，且不替代 HandlingReport/ExecutionReport 的运行时错误。

## 范围

- 更新 Agent handle/realize interface SPEC；
- 在 domain interface 文档中明确该接口仍为目标、尚未实现；
- 更新开发进度和下一 Red-only PR 边界。

## 明确不包含

- 不写测试或产品实现；
- 不实现 `TextMessage` 非法组合校验；
- 不实现其他 Stimulus、InteractionSnapshot、request/report、Agent facade 或生产调用链迁移；
- 不引入通用错误框架、Result 类型或构造 factory。

## 验证

- 三份文档存在且无 Unicode replacement character；
- 关键字段检查确认异常类型、稳定 code/retryable、直接构造抛出和非契约异常文本均已写入；
- `git diff --check` 通过；
- 本 PR 为纯 interface 文档门禁，未运行 pytest、模型、TTS、GPU、设备或真实外部服务。

## 下一步

本设计通过后另开 Red-only PR，从 `src.domain.agent` 公开导出验证非法 `TextMessage` 组合抛出 `InvalidStimulusError`，并只断言稳定 `code` 与 `retryable`。
