### PR TITLE
[Agent 深模块][05] 修复计划投递错误日志的源码泄漏

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -9,6 +9,14 @@
 
 ## 已完成事实
 
+### 2026-09-06 PlanEmitter 日志源码隔离 GREEN
+
+- 交付行为：投递失败日志从 traceback 提取文件、行号和函数名，保留角色、request、interaction、plan、ordinal、稳定错误码与异常类型；日志不传递原 traceback，不格式化源码、局部变量或原异常链。处理器捕获投递异常仍留下诊断记录，公开失败报告与消费事实保持正确。
+- interface spec：[PlanEmitter](../../项目说明/项目架构与接口（spec）/接口文档/agent/plan-emitter.md) 已按实现定稿；没有新增公开接口或改变投递恢复行为。
+- commit：SPEC `c6c4a8cc`、RED `5a4fc167`；GREEN 为 `codex/agent-plan-log-errors` 分支上本记录所在提交，原 RED 断言保持不变。
+- 验证及结果：实现前日志用例实跑 1 failed，失败原因是输出含异常源码字面量；实现后 PlanEmitter 聚焦 45 passed。server 下 `D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q --tb=short` 为 **796 passed、2 skipped**。相关 Ruff、compileall、git diff --check 与修改文档的 UTF-8、围栏、相对链接检查通过。
+- 未验证范围：使用真实 utils logger、临时 SQLite 和受控协作者；两个 world 网络探测仍跳过。没有运行真实业务 Handler、外部队列、生产数据库或客户端验收。
+
 ### 2026-09-06 Execution Ledger 取消等待者事实 GREEN
 
 - 交付行为：拥有者任务取消并完成清理后，给并发等待者发布最新完成前缀、效果与已确认输出，避免使用加入前快照；清理中返回可信结果但结算失败时保留当前效果，以 FAILED / DEPENDENCY_UNAVAILABLE 表达未完成持久化，不冒充 ALREADY_COMPLETED。相关存储错误日志使用稳定依赖错误码。

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/plan-emitter.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/plan-emitter.md
@@ -1,6 +1,6 @@
 # PlanEmitter 与计划投递恢复契约
 
-状态：已实现。公开入口保持 `Agent.handle_stimulus(request, plan_sink)`；结果使用现有 HandlingReport，外部接收器使用现有 ActionPlanSink。
+状态：计划投递与恢复已实现；错误日志的源码行隔离为本次修复目标。公开入口保持 `Agent.handle_stimulus(request, plan_sink)`；结果使用现有 HandlingReport，外部接收器使用现有 ActionPlanSink。
 
 ## 所有权与内部输入
 
@@ -61,7 +61,9 @@ sink 等待返回后，先保存成功回执，再检查协作取消；取消不
 
 内部草稿、ordinal 或重投内容冲突映射 INTERNAL_ERROR，保留已确认计划和可信消费事实。外部异常沿用门面错误映射；有持久待重投项时 retryable=True，全部确认或永久拒绝后 False。存储失败且无可信可恢复状态时 retryable=False。
 
-通过 `utils/logger.py` 记录 character_id、request_id、interaction_id、plan_id、ordinal、稳定错误码、异常类型及不含局部变量的栈位置。日志省略协作者异常原文、计划正文、刺激正文、完整序列化数据及连接凭据。处理器捕获 emit 异常不应使投递错误消失于日志。
+通过 `utils/logger.py` 记录 character_id、request_id、interaction_id、plan_id、ordinal、稳定错误码、异常类型及栈位置（文件名、行号和函数名）。日志不格式化 traceback 源码行、局部变量或原异常链，省略协作者异常原文、计划正文、刺激正文、完整序列化数据及连接凭据。源码中的异常字面量同样不得进入日志；仅替换异常消息不满足这一约定。处理器捕获 emit 异常不应使投递错误消失于日志。
+
+从公开 handle 验证：接收器在带有字面量的源码行抛出异常，并携带原始 cause；处理器捕获 emit 异常并返回合法消费结算。报告保留失败状态、错误码和消费事实；格式化后的实际日志保留投递身份、异常类型及接收器栈位置，不包含源码行、异常正文或 cause 正文。
 
 ## 验证入口
 

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/plan-emitter.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/plan-emitter.md
@@ -1,6 +1,6 @@
 # PlanEmitter 与计划投递恢复契约
 
-状态：计划投递与恢复已实现；错误日志的源码行隔离为本次修复目标。公开入口保持 `Agent.handle_stimulus(request, plan_sink)`；结果使用现有 HandlingReport，外部接收器使用现有 ActionPlanSink。
+状态：已实现。公开入口保持 `Agent.handle_stimulus(request, plan_sink)`；结果使用现有 HandlingReport，外部接收器使用现有 ActionPlanSink。
 
 ## 所有权与内部输入
 

--- a/server/src/agent/planning/emitter.py
+++ b/server/src/agent/planning/emitter.py
@@ -1,6 +1,7 @@
 """本次处理的草稿封装、持久投递及原计划恢复。"""
 import asyncio
 from dataclasses import dataclass, replace
+from traceback import walk_tb
 
 import src.domain.agent as d
 from src.agent.ledgers.plan_outbox import PlanSlot
@@ -149,13 +150,15 @@ class PlanEmitter:
         return replace(report, **changes)
 
     def _failed(self, error, ordinal):
+        """保存投递失败；日志只携带身份、错误类型及栈位置，隔离源码和异常链。"""
         self._error = handling_error(error)
-        safe_error = RuntimeError("Collaborator exception message omitted")
+        locations = [(frame.f_code.co_filename, line, frame.f_code.co_name)
+                     for frame, line in walk_tb(error.__traceback__)]
         get_logger(__name__).error(
-            "Plan delivery failed character_id=%s request_id=%s interaction_id=%s plan_id=%s ordinal=%s error_code=%s type=%s",
+            "Plan delivery failed character_id=%s request_id=%s interaction_id=%s plan_id=%s ordinal=%s error_code=%s type=%s stack=%s",
             self._character_id, self._request.request_id, self._request.interaction.interaction_id,
             plan_id(self._character_id, self._request.request_id, ordinal), ordinal, self._error.name,
-            type(error).__name__, exc_info=(RuntimeError, safe_error, error.__traceback__))
+            type(error).__name__, locations)
 
     def close(self):
         """结束本次作用域并释放接收器及请求引用。"""

--- a/server/tests/agent/README.md
+++ b/server/tests/agent/README.md
@@ -1,5 +1,24 @@
 # Agent 门面入口测试
 
+## PlanEmitter 日志源码隔离 GREEN（2026-09-06）
+
+SPEC `c6c4a8cc`、RED `5a4fc167`。实现前重新运行
+`D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent/test_plan_logging.py -q --tb=short --show-capture=no`
+为 **1 failed**：原日志格式化 traceback 时包含接收器抛异常的源码字面量。
+保持 RED 原断言，PlanEmitter 现在从 traceback 提取文件、行号和函数名，日志不携带
+原 traceback、源码行、局部变量或原始异常链；处理器捕获异常仍记录投递身份、稳定错误码和类型。
+
+实际验证（工作目录 `server`）：
+
+- `D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent/test_plan_logging.py tests/agent/test_plan_emission.py tests/agent/test_plan_delivery_recovery.py -q --tb=short`：**45 passed**。
+- `D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q --tb=short`：**796 passed、2 skipped**，一个第三方 pkg_resources 弃用警告。
+- Agent、AgentRuntime 和上述测试目录及 conftest 的 Ruff、Agent/AgentRuntime compileall、git diff --check 通过。
+- 修改文档的 UTF-8、代码围栏和相对链接检查通过。
+
+验证使用真实 utils logger、临时 SQLite 与受控协作者。两个 world 网络探测仍跳过；
+没有运行真实业务 Handler、外部队列、生产数据库或客户端验收。GREEN 为
+`codex/agent-plan-log-errors` 分支上本记录所在提交；独立 PR 审核由后续审查记录证明。
+
 ## 已知回执结算补齐 SPEC / RED 修正（2026-09-06）
 
 SPEC 修正 `d7db3897` 在原 SPEC `2194c0a9` 上明确：有效回执已经确定接收，本地 ack 写入失败不能降级为未知接收。保存报告的事务原子补齐 emitter 实际校验的回执，成功后终态保留 FAILED / DEPENDENCY_UNAVAILABLE 和原计划 ID、retryable=False，重建 Agent 不再交付该计划；补齐或结算失败则保留占用。作者自审确认没有信任 Handler 自报 ID，也没有改变真正未知结果的恢复。

--- a/server/tests/agent/test_plan_logging.py
+++ b/server/tests/agent/test_plan_logging.py
@@ -1,0 +1,58 @@
+"""公开 handle 的投递错误日志保留诊断位置，隔离源码及异常正文。"""
+import re
+
+import pytest
+
+import src.domain.agent as d
+from src.utils.logger import get_logger
+from plan_emission_support import draft
+from routing_support import Sink, request, settlement
+
+
+@pytest.mark.asyncio
+async def test_caught_plan_failure_logs_location_without_source_or_exception_chain(
+    routed_runtime, caplog,
+):
+    offered = []
+
+    async def receive_plan(plan):
+        offered.append(plan)
+        cause = ValueError("synthetic-plan-cause-private-content")
+        raise RuntimeError("synthetic-plan-literal-private-content") from cause
+
+    async def handle(req, plans):
+        try:
+            await plans.emit(draft(text="synthetic-plan-body-private-content"))
+        except RuntimeError:
+            pass
+        return settlement(req)
+
+    runtime, _ = routed_runtime(handle=handle)
+    logger = get_logger("src.agent.planning.emitter")
+    logger.addHandler(caplog.handler)
+    try:
+        report = await runtime.get_agent().handle_stimulus(request(), Sink(receive_plan))
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    assert report.request_status is d.HandlingRequestStatus.FAILED
+    assert report.error_code is d.HandlingErrorCode.INTERNAL_ERROR
+    assert report.retryable is True
+    assert report.consumed_pending_stimulus_ids == ("m2",)
+    assert report.retained_pending_stimulus_ids == ("m1",)
+    assert report.emitted_plan_ids == ()
+    assert len(offered) == 1
+
+    log_text = caplog.text
+    for field in (
+        "character_id=luotianyi", "request_id=r", "interaction_id=i",
+        f"plan_id={offered[0].plan_id}", "ordinal=0", "INTERNAL_ERROR", "RuntimeError",
+    ):
+        assert field in log_text
+    assert "receive_plan" in log_text
+    assert re.search(r"test_plan_logging\.py[^\n]*\b\d+\b", log_text)
+    for private_text in (
+        "synthetic-plan-literal-private-content", "synthetic-plan-cause-private-content",
+        "synthetic-plan-body-private-content", "raise RuntimeError(", "from cause",
+    ):
+        assert private_text not in log_text

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -8,6 +8,7 @@ _ACTIVE_TEST_FILES = {
     (Path(__file__).parent / "agent" / "test_execution_idempotency.py").resolve(),
     (Path(__file__).parent / "agent" / "test_execution_storage_recovery.py").resolve(),
     (Path(__file__).parent / "agent" / "test_plan_emission.py").resolve(),
+    (Path(__file__).parent / "agent" / "test_plan_logging.py").resolve(),
     (Path(__file__).parent / "agent" / "test_plan_delivery_recovery.py").resolve(),
     (Path(__file__).parent / "agent" / "test_request_idempotency.py").resolve(),
     (Path(__file__).parent / "agent" / "test_request_storage_recovery.py").resolve(),


### PR DESCRIPTION
PlanEmitter 即使替换了异常消息，原 traceback 的格式化仍会输出源码行，泄漏其中的敏感字面量。本 PR 改为仅提取文件、行号与函数名，保留角色、请求、交互、计划、ordinal、错误码和异常类型；不再记录源码、局部变量或原异常链。

属于 #64 的 PlanEmitter 日志正确性修复，#64 保持开放。投递恢复、消费结算和公开业务接口不变。

- SPEC：agent/plan-emitter.md，c6c4a8cc；已定稿为实现事实。
- RED：5a4fc167，公开 handle 中 sink 抛字面量异常及 cause、Handler 捕获投递错误；1 failed、44 passed，唯一失败为日志暴露源码字面量。
- GREEN：3805018e，原 RED 断言未改；中文 docstring、进度及测试证据已更新。各阶段均已作者自审。
- 验证（独立工作区 server）：D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q --tb=short：796 passed、2 skipped；PlanEmitter focused 45 passed。Ruff、compileall、diff 与文档检查通过。
- 产品代码新增6行；没有真实 Handler 或生产环境验收，两项 world 真实网络探测仍跳过。
