### PR TITLE
[Agent 深模块][06] 恢复原输出并补齐可信接收事实

### DIFF
--- a/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
+++ b/docs/开发进程文档/开发进度/Agent-handle-realize-深模块重构.md
@@ -9,6 +9,15 @@
 
 ## 已完成事实
 
+### 2026-09-06 原输出恢复与可信结算补齐 GREEN
+
+- 交付行为：可信完成或不安全失败行动的safe pending只投递原值，不重跑Handler；安全失败仍先重入Handler。恢复经过全计划准入与执行所有权，错误报告保留原效果及输出事实，失败不转换成业务完成。确认临时存储失败在最终可信结算补齐，本次仍停止新工作；首次payload保存失败保持未知，已有完整payload的尝试标记失败保留安全恢复值。
+- interface spec：[输出投递契约](../../项目说明/项目架构与接口（spec）/接口文档/agent/output-delivery.md)、execution-ledger、facade、handler-routing已定稿为实现事实，项目架构及中文docstring同步。
+- commit与SPEC：SPEC `a1c44e5e`、RED `1e44947c`均已作者自审；本记录所在 `codex/agent-output-recovery` 提交为GREEN，87项RED未改。`4d60a521`、`aff3bc6d`由独立测试作者修订最终资源清理预算，保留所有在途等待断言；Execution和PlanEmitter实际复现短预算抖动，Request Ledger为同形审计修订。
+- 验证及结果：四个输出文件87 passed；server使用 `D:/Anaconda/envs/lty/python.exe -X utf8` 执行相关agent、agent_runtime、domain、world、system回归883 passed、2 skipped。Ruff、compileall、7份Agent SPEC UTF-8/围栏/链接和diff检查通过。包括真实临时SQLite故障、独立Python进程原音频恢复、UNKNOWN封闭、恢复等待者及重复取消清理。
+- 未验证范围：两个world真实网络探测跳过；没有真实业务Handler、客户端播放、外部接收器或生产数据库验收；不表示#65业务Say已实现。
+
+
 ### 2026-09-06 确认输出后取消的可信结果 GREEN
 
 - 交付行为：输出确认后协作取消不再覆盖处理器可信ActionResult；已完成项保留完成及效果，整体取消并只允许后续未开始行动继续；可信失败保留实际失败原因。UNKNOWN、未确认输出、持久故障和内容冲突仍阻断后续工作。

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/execution-ledger.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/execution-ledger.md
@@ -1,6 +1,6 @@
 # Execution Ledger 与逐行动恢复契约
 
-状态：逐行动账本与输出生产者已实现；[输出投递契约](output-delivery.md)中的仅投递恢复和最终结算补齐为目标增量，尚未实现。公开入口保持 `Agent.realize_action_plan(plan, execution_context, output_sink)`，输入、输出和错误使用现有 domain 类型。
+状态：逐行动账本及[输出投递契约](output-delivery.md)中的仅投递恢复和最终结算补齐已实现。公开入口保持 `Agent.realize_action_plan(plan, execution_context, output_sink)`，输入、输出和错误使用现有 domain 类型。
 
 ## 所有权与装配
 

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/execution-ledger.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/execution-ledger.md
@@ -1,6 +1,6 @@
 # Execution Ledger 与逐行动恢复契约
 
-状态：逐行动账本及[输出投递契约](output-delivery.md)已实现。公开入口保持 `Agent.realize_action_plan(plan, execution_context, output_sink)`，输入、输出和错误使用现有 domain 类型。
+状态：逐行动账本与输出生产者已实现；[输出投递契约](output-delivery.md)中的仅投递恢复和最终结算补齐为目标增量，尚未实现。公开入口保持 `Agent.realize_action_plan(plan, execution_context, output_sink)`，输入、输出和错误使用现有 domain 类型。
 
 ## 所有权与装配
 
@@ -16,7 +16,7 @@ ActionHandler 的内部协议为 `realize(action, execution_context, outputs: Ou
 
 顶层类型错误抛 TypeError；计划包含编码白名单以外的具体类型时返回 INTERNAL_ERROR、无投递；绑定角色或 plan/context 交互身份错误，以及运行时停止接受时，沿用门面的入口拒绝，不读取其他执行事实。接受状态通过后先读取匹配执行，再检查当前 revision、令牌和全计划路由。首次执行的修订过期、预取消、任一行动未注册均零行动、零输出，不占用该 execution；预取消报告保持 retryable=False，换新令牌仍可首次执行。
 
-已有匹配记录全部已完成，或者已有不可安全继续的可信失败，且没有未完成交付时，直接读取既有终态；完成项转换为 ALREADY_COMPLETED，保留 effect_ref、不可逆标记和累计 output_started，retryable=False。新的 revision、令牌或路由集合不改变已经发生的终态事实。可重入 Handler 的 safe pending 仍经过当前准入。对于仍可安全继续的执行，准入拒绝只阻止本次新动作：旧 revision 返回 STALE_INTERACTION，未注册返回 UNSUPPORTED_ACTION，预取消返回 CANCELLED；完成前缀仍为 ALREADY_COMPLETED，其余为本次 NOT_STARTED，retryable=False。存储中原可信失败保留，准入拒绝不覆盖它；后续合法调用仍可从该安全位置继续。output_started 表示已确认接收事实，False 不证明未知输出没有发生。
+已有匹配记录全部已完成，或者已有不可安全继续的可信失败，且没有未完成交付时，直接读取既有终态；完成项转换为 ALREADY_COMPLETED，保留 effect_ref、不可逆标记和累计 output_started，retryable=False。新的 revision、令牌或路由集合不改变已经发生的终态事实。safe pending 的 Handler 重入或仅投递恢复都经过当前准入。对于仍可安全继续的执行，准入拒绝只阻止本次新动作：旧 revision 返回 STALE_INTERACTION，未注册返回 UNSUPPORTED_ACTION，预取消返回 CANCELLED；已可信完成项仍为 ALREADY_COMPLETED；仅投递恢复的原失败项按本次拒绝投影并保留效果，尚未开始项为 NOT_STARTED，retryable=False，详细规则见输出投递契约。存储中原可信失败保留，准入拒绝不覆盖它；后续合法调用仍可从该安全位置继续。output_started 表示已确认接收事实，False 不证明未知输出没有发生。
 
 ## 持久执行与恢复
 
@@ -27,9 +27,9 @@ ActionHandler 的内部协议为 `realize(action, execution_context, outputs: Ou
 | 行动事实 | 同 execution 的安全继续 |
 | --- | --- |
 | NOT_STARTED | 可在准入检查通过后开始 |
-| COMPLETED / ALREADY_COMPLETED | 保留结果，跳过 Handler；safe pending 表示未完成交付、retryable=False，不启动下一行动；UNKNOWN 不重投 |
+| COMPLETED / ALREADY_COMPLETED | 保留结果，跳过 Handler；safe pending 先仅投递原值，确认后才推进下一行动；UNKNOWN 不重投 |
 | 可信 FAILED/CANCELLED，未提交效果且本行动没有已确认或未知输出 | 允许再次执行该行动；已有 safe pending 由重入 Handler 同内容复用 |
-| 可信 FAILED/CANCELLED，已有不可逆效果或已确认输出 | 不重做 Handler、不补投；保留原失败和 pending，retryable=False |
+| 可信 FAILED/CANCELLED，已有不可逆效果或已确认输出 | 不重做 Handler；有 safe pending 时仅投递，之后仍保留原失败和效果；没有 pending 时 retryable=False |
 | 存在未知输出 | DEPENDENCY_UNAVAILABLE、retryable=False，不重投、不重做 |
 | STARTED，缺少可信结算 | 无法证明未发生效果，DEPENDENCY_UNAVAILABLE、retryable=False，不接管执行 |
 
@@ -43,7 +43,7 @@ ActionHandler 的内部协议为 `realize(action, execution_context, outputs: Ou
 
 SinkRejectedError 表示此次明确没有新增接收；可清除此轮新产生的未知标记，但不能清除更早的已确认或未知投递。普通异常、超时、错误回执、投递中 task 取消均保留未知状态。处理器吞掉投递异常并返回“无效果失败”不能使未知输出变得可重试。未知输出不得因外部接收器没有确认而自动重投。多个 emit 的已确认及未知事实是累计关系，后一轮拒绝不能覆盖前一轮。
 
-已确认回执的本地写入失败时，本次报告保留已观察到的 output_started=True，但禁止继续行动；持久未知状态阻止以后重做，不把本次内存已知回执视为已持久确认。单项结算失败同样保留本次可信效果与接收事实，整体以 DEPENDENCY_UNAVAILABLE 表达无法安全结算；必要时将本项状态改为 FAILED 以符合报告状态关系，不能宣称完成已持久化。
+已确认回执的本地写入失败时，本次报告保留已观察到的 output_started=True，但禁止继续行动；最终可信结算可按输出投递契约原子补齐回执与结果；仅投递恢复使用已有可信结果。补齐失败时持久未知状态阻止以后重做，不把本次内存已知回执视为已持久确认。单项结算失败同样保留本次可信效果与接收事实，整体以 DEPENDENCY_UNAVAILABLE 表达无法安全结算；必要时将本项状态改为 FAILED 以符合报告状态关系，不能宣称完成已持久化。
 
 ## 并发、取消、存储失败
 
@@ -51,7 +51,7 @@ SinkRejectedError 表示此次明确没有新增接收；可清除此轮新产�
 
 其他 Agent/Runtime/进程看到运行占用而没有本地拥有者时，不调用 Handler/sink，返回 DEPENDENCY_UNAVAILABLE/retryable=False，并保留可读取的完成前缀和输出事实。拥有者可信结算后释放运行权，后续调用按逐行动规则恢复。进程硬退出留下 STARTED 时不能根据时间或内存为空推断无效果。
 
-拥有者 task 取消沿用门面受控清理与 CancelledError 传播规则，重复取消只向处理器转发一次。若处理器在取消清理中正常返回可信 ActionResult，先持久保存该结果，再向拥有者传播 CancelledError；已完成行动以后不重做。无可信结果的在执行行动保持未知；并发等待者取得依赖不可用报告，不接管任务。所有已进入账本的调用及等待者计入运行时在途集合；shutdown 停止接受后等待清理与结算，超时保留依赖供后续关闭重试。
+拥有者 task 取消沿用门面受控清理与 CancelledError 传播规则，重复取消只向处理器或仅投递恢复的 sink worker 转发一次。若处理器在取消清理中正常返回可信 ActionResult，先持久保存该结果；恢复 sink 清理正常返回有效回执时先保存确认，再向拥有者传播 CancelledError；已完成行动以后不重做。无可信结果的在执行行动保持未知；并发等待者取得依赖不可用报告，不接管任务。所有已进入账本的调用及等待者计入运行时在途集合；shutdown 停止接受后等待清理与结算，超时保留依赖供后续关闭重试。
 
 登记、读取、开始标记或结算失败均返回 DEPENDENCY_UNAVAILABLE/retryable=False。登记/开始失败不开始外部工作；结算失败保留已知事实并阻止重做。未知版本、损坏 JSON、计划指纹或行动身份不一致、非法状态组合均拒绝恢复，不丢弃记录重建。使用 utils/logger.py 记录角色、execution、interaction、稳定错误码、异常类型和栈文件、行号和函数名，省略源码行、局部变量、异常原文及计划正文。
 

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/facade.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/facade.md
@@ -1,6 +1,6 @@
 # Agent 两接口门面契约
 
-状态：门面、逐行动账本及输出生产者已实现；[输出契约](output-delivery.md)中的仅投递恢复与结算补齐为尚未实现的目标增量。本文记录门面入口校验、内部处理器调用、交付结算与生命周期行为；领域对象以 [handle 输入](../domain/handle-input.md)、[处理报告](../domain/handling-report.md) 和 [计划与执行](../domain/realization.md) 为准。
+状态：门面、逐行动账本及[输出契约](output-delivery.md)中的仅投递恢复与结算补齐已实现。本文记录门面入口校验、内部处理器调用、交付结算与生命周期行为；领域对象以 [handle 输入](../domain/handle-input.md)、[处理报告](../domain/handling-report.md) 和 [计划与执行](../domain/realization.md) 为准。
 
 ## 模块与实例
 

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/facade.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/facade.md
@@ -1,6 +1,6 @@
 # Agent 两接口门面契约
 
-状态：门面、逐行动账本及[输出身份与持久序列](output-delivery.md)已实现。本文记录门面入口校验、内部处理器调用、交付结算与生命周期行为；领域对象以 [handle 输入](../domain/handle-input.md)、[处理报告](../domain/handling-report.md) 和 [计划与执行](../domain/realization.md) 为准。
+状态：门面、逐行动账本及输出生产者已实现；[输出契约](output-delivery.md)中的仅投递恢复与结算补齐为尚未实现的目标增量。本文记录门面入口校验、内部处理器调用、交付结算与生命周期行为；领域对象以 [handle 输入](../domain/handle-input.md)、[处理报告](../domain/handling-report.md) 和 [计划与执行](../domain/realization.md) 为准。
 
 ## 模块与实例
 
@@ -51,9 +51,9 @@ async def realize_action_plan(
 持久身份、逐行动事实和安全继续以 [Execution Ledger](execution-ledger.md) 为准。
 
 1. 顶层参数类型错误抛出 TypeError；角色和 plan/context 交互身份不匹配返回 FAILED / CONTRACT_MISMATCH。运行时停止接受则返回 DEPENDENCY_UNAVAILABLE；这些检查不读取执行历史。
-2. 匹配执行的完成或不安全失败终态优先于本次 revision、令牌和路由检查。完成项返回 ALREADY_COMPLETED，原输出和效果不重复。相同 execution_id 的不同完整计划返回 CONTRACT_MISMATCH；报告不携带原计划事实。
-3. 新执行及可安全继续的执行，检查 basis_interaction_revision 与 current_interaction_revision 一致、令牌未取消，以及全计划均有已注册处理器；对应拒绝为 STALE_INTERACTION、CANCELLED、UNSUPPORTED_ACTION。StartThinking 传入 realize 返回 UNSUPPORTED_ACTION。
-4. 首次准入拒绝不占用执行，全部行动 NOT_STARTED。恢复准入拒绝保留完成前缀及累计输出事实，其余为本次 NOT_STARTED；不覆盖原有安全失败结算。所有准入拒绝均 retryable=False，不执行新行动或调用 sink。
+2. 匹配执行没有可恢复 pending 的完成或不安全失败终态优先于本次 revision、令牌和路由检查。完成项返回 ALREADY_COMPLETED，原输出和效果不重复。相同 execution_id 的不同完整计划返回 CONTRACT_MISMATCH；报告不携带原计划事实。
+3. 新执行、可安全继续的行动及仅投递恢复，检查 basis_interaction_revision 与 current_interaction_revision 一致、令牌未取消，以及全计划均有已注册处理器；对应拒绝为 STALE_INTERACTION、CANCELLED、UNSUPPORTED_ACTION。StartThinking 传入 realize 返回 UNSUPPORTED_ACTION。
+4. 首次准入拒绝不占用执行，全部行动 NOT_STARTED。恢复准入拒绝保留可信完成项及累计输出事实；仅投递恢复的原失败项按本次拒绝投影并保留效果，安全 Handler 重入及尚未开始项为 NOT_STARTED；不覆盖账本原业务结算，具体规则见输出投递契约。所有准入拒绝均 retryable=False，不执行新行动或调用 sink。
 5. 原子取得执行权后，持久登记单项开始、顺序调用处理器，提交可信 ActionResult 且本行动输出均已确认后才开始下一项。失败或取消立即停止后续行动；完成前缀的效果不阻止后续无效果、无已确认或未知输出的可信失败重试。未可信结算的开始状态禁止自动重做。
 
 执行身份取自 context，计划身份取自 plan。output_started 表示累计已确认接收；False 不证明未知投递没有发生。输出保持正常调用顺序及 MessageEndOutput 的位置，sink 回执不代表播放完成。

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/handler-routing.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/handler-routing.md
@@ -1,6 +1,6 @@
 # Handler 路由契约
 
-状态：路由已实现；仅投递恢复的准入及拥有者清理为输出契约的目标增量。内部 plans 使用 [PlanEmitter](plan-emitter.md)，outputs 使用 [OutputEmitter](output-delivery.md)。本文记录 Agent 内部的处理器注册、查找和调用；业务入口继续使用 [Agent 门面](facade.md) 的两个方法。
+状态：路由及仅投递恢复的准入与拥有者清理已实现。内部 plans 使用 [PlanEmitter](plan-emitter.md)，outputs 使用 [OutputEmitter](output-delivery.md)。本文记录 Agent 内部的处理器注册、查找和调用；业务入口继续使用 [Agent 门面](facade.md) 的两个方法。
 
 ## 文件与所有权
 

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/handler-routing.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/handler-routing.md
@@ -1,6 +1,6 @@
 # Handler 路由契约
 
-状态：路由已实现；内部 plans 使用 [PlanEmitter](plan-emitter.md)，outputs 使用 [OutputEmitter](output-delivery.md)。本文记录 Agent 内部的处理器注册、查找和调用；业务入口继续使用 [Agent 门面](facade.md) 的两个方法。
+状态：路由已实现；仅投递恢复的准入及拥有者清理为输出契约的目标增量。内部 plans 使用 [PlanEmitter](plan-emitter.md)，outputs 使用 [OutputEmitter](output-delivery.md)。本文记录 Agent 内部的处理器注册、查找和调用；业务入口继续使用 [Agent 门面](facade.md) 的两个方法。
 
 ## 文件与所有权
 
@@ -127,7 +127,7 @@ AgentRuntime 创建每角色 router，并通过 Agent 的装配参数传入；�
 | 入口 | 查询方式 | 未注册的公开结果 |
 | --- | --- | --- |
 | handle_stimulus | 用触发刺激 kind 查询 StimulusRouter | FAILED / UNSUPPORTED_STIMULUS，pending 全部 retained，consumed 和 emitted_plan_ids 为空 |
-| realize_action_plan | 按计划行动顺序逐项查询 ActionRouter | 新工作中任一项未注册则 FAILED / UNSUPPORTED_ACTION；已有完成前缀保留，其余 NOT_STARTED，不产生新的输出或效果 |
+| realize_action_plan | 按计划行动顺序逐项查询 ActionRouter | 新工作中任一项未注册则 FAILED / UNSUPPORTED_ACTION；已有可信完成及效果保留；输出恢复的原失败项按拒绝投影，尚未开始项 NOT_STARTED，不产生新的输出或效果 |
 
 门面只将 resolve 的“合法枚举未注册”KeyError 转成上述结果；不能用包住整个处理流程的 KeyError 捕获来误吞业务错误。路由器的构造异常属于启动错误，不包装为 HandlingReport 或 ExecutionReport。
 
@@ -157,6 +157,8 @@ class ActionHandler(Protocol):
 - ActionResult 必须匹配当前 action_id，且不能用 NOT_STARTED 冒充已调用的结果；无效返回转 INTERNAL_ERROR。已完成行动按原顺序保留，失败或取消停止后续行动。返回的 effect_ref 与 irreversible_effect_committed 是内部处理器已确认的事实，失败或取消不能清除它们。
 - 行动等待返回时令牌取消：已返回 COMPLETED/ALREADY_COMPLETED 的效果仍为完成；整体报告为 CANCELLED，后续行动 NOT_STARTED。行动返回 FAILED 优先保留实际失败，不能用晚到取消掩盖。处理器返回 CANCELLED 时整体同样取消。
 - 处理器内部 KeyError 是 INTERNAL_ERROR，不能误判为路由缺失。TimeoutError 和 SinkRejectedError 按门面错误表转换；通过 utils/logger.py 记录调用身份、稳定错误码、异常类型及无局部变量的栈位置，省略协作者异常原文。
+
+仅投递恢复仍预检全计划路由，但不调用已可信结算的 Handler；Agent 持有恢复 sink worker，并按输出契约保存回执及原业务结算。
 
 ## 在途调用与关闭
 

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/output-delivery.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/output-delivery.md
@@ -1,10 +1,10 @@
 # 输出身份、持久序列与安全投递
 
-状态：已实现。公开入口为 `Agent.realize_action_plan(plan, execution_context, output_sink) -> ExecutionReport`；领域输出、回执、错误和报告沿用 [realization](../domain/realization.md)。
+状态：输出生产者与持久序列已实现；本文的仅投递恢复及最终结算补齐为目标契约，尚未实现。公开入口为 `Agent.realize_action_plan(plan, execution_context, output_sink) -> ExecutionReport`；领域输出、回执、错误和报告沿用 [realization](../domain/realization.md)。
 
 ## 所有权和调用
 
-`agent/outputs/drafts.py` 定义私有不可变、关键字构造的草稿；`agent/outputs/emitter.py` 负责身份分配、串行投递与回执处理；`agent/ledgers/output_outbox.py` 保存完整输出和投递事实，显式编码辅助文件放在同目录。`agent/execution.py` 决定可安全重入的行动，并阻止未完成交付后的新行动。会话工厂沿用 Execution Ledger 的运行时注入，数据库事务不跨越外部 await。
+`agent/outputs/drafts.py` 定义私有不可变、关键字构造的草稿；`agent/outputs/emitter.py` 负责身份分配、串行投递与回执处理；`agent/ledgers/output_outbox.py` 保存完整输出和投递事实，显式编码辅助文件放在同目录。`agent/execution.py` 决定重入安全行动或只恢复已生成输出，并阻止未完成交付后的新行动。会话工厂沿用 Execution Ledger 的运行时注入，数据库事务不跨越外部 await。
 
 ActionHandler 的内部参数为 `outputs: OutputEmitter`，调用 `await outputs.emit(draft) -> OutputReceipt`。Handler 不填写 interaction_id、execution_id、action_id 或 sequence_no，也不能取得外部 sink 和账本。输出对象在处理器清理退出后失效。Agent 包仍只导出 Agent，两个公开业务方法保持不变，生产处理器注册集合为空。
 
@@ -31,16 +31,16 @@ OutputDraft 表达以上四类的联合；字段含义与领域输出相同。�
 
 | 状态 | 事实 | 同 execution 再调用 |
 | --- | --- | --- |
-| PREPARED | 已保存完整值，尚未开始外部 emit | 只有行动本身可安全重入时，由 Handler 同内容复用 |
-| REJECTED | 明确未新增接收，且没有更早未知接收 | 只有行动本身可安全重入时，由 Handler 同内容复用 |
+| PREPARED | 已保存完整值，尚未开始外部 emit | 按下方行动结算规则重入 Handler 或仅投递存储原值 |
+| REJECTED | 明确未新增接收，且没有更早未知接收 | 按下方行动结算规则重入 Handler 或仅投递存储原值 |
 | UNKNOWN | 已进入外部 emit，未取得可信接收或明确拒绝结果 | 不重投、不跳过、不重跑行动 |
 | ACCEPTED | 有效 ACCEPTED/ALREADY_ACCEPTED 回执已确认接收 | 永不再调用外部 sink |
 
 外部 emit 前先持久写 UNKNOWN；失败时不调用 sink。有效回执必须匹配 execution_id、sequence_no；先记录已确认事实再返回并检查令牌。SinkRejectedError 仅证明本次没有新增接收，不能消除更早 UNKNOWN。普通超时、错误回执、连接异常及投递中任务取消均保持 UNKNOWN；即使 Handler 吞错并返回 COMPLETED，也不能报告整个 execution 完成、开始后续行动或允许重投。首次调用保留已捕获异常的稳定映射，例如超时 PROVIDER_TIMEOUT、错误回执 INTERNAL_ERROR；任务取消仍传播 CancelledError。后续读取未知输出返回 DEPENDENCY_UNAVAILABLE/retryable=False。
 
-有效回执后本地确认提交失败，本次保留 output_started=True，停止本次新工作并报告 DEPENDENCY_UNAVAILABLE/retryable=False。持久 UNKNOWN 保守阻止重投，不把内存已知回执当作跨进程已确认事实。存储失败不因 Handler 吞错并返回 COMPLETED 而解除；本次保留已知效果，持久执行保留未可信结算的 STARTED。
+有效回执后本地确认提交失败，本次保留 output_started=True，停止本次新工作并报告 DEPENDENCY_UNAVAILABLE/retryable=False。Handler 最终返回可信 ActionResult 时，最终结算事务原子补齐已经校验的回执与结果；仅投递恢复使用账本中已有的可信结果完成同样补齐，不要求重新运行 Handler。补齐成功后，后续调用读取已确认事实，不再次发送；补齐仍失败则持久 UNKNOWN 保守阻止重投。即使补齐成功，本次仍报告存储失败，不开始下一行动。
 
-完整 payload 首次保存失败时没有可恢复输出值，即使 Handler 吞错返回 COMPLETED、随后数据库恢复，也不能只保存该完成结果；保留未可信结算的 STARTED，后续 DEPENDENCY_UNAVAILABLE，不生成空 outbox 的成功终态。PREPARED 已保存但外部尝试标记写入失败也属于本次存储失败，保持停止状态，不开始外部工作。
+完整 payload 首次保存失败时没有可恢复输出值，即使 Handler 吞错返回 COMPLETED、随后数据库恢复，也不能只保存该完成结果；保留未可信结算的 STARTED，后续 DEPENDENCY_UNAVAILABLE，不生成空 outbox 的成功终态。PREPARED/REJECTED 的完整值已持久保存，但本轮 UNKNOWN 标记提交失败时，尚未调用外部 sink；最终可信结算可以保存原 safe pending 状态与可信结果，后续按行动分流恢复。本次仍停止新工作并报告 DEPENDENCY_UNAVAILABLE/retryable=False。最终结算再次失败时不得宣称已恢复。此规则同样适用于仅投递恢复，不把未实际调用 sink 的内存 UNKNOWN 当作接收事实。
 
 output_started 仅表示该 execution 曾确认接收过输出，未知接收不会令其变 True。已有 confirmed 后又出现 UNKNOWN，仍保持 output_started=True。当前接收协议没有跨连接去重保证；本机制只重投可证明未接收的原值，不借任意 sink 声称恰好一次投递。
 
@@ -52,30 +52,38 @@ Action 的可信结果与其输出接收事实分别保存。完成 Action 的�
 | --- | --- |
 | 完成，所有输出已确认 | ALREADY_COMPLETED，跳过 Handler 与 sink，继续后续安全行动 |
 | 可信 FAILED/CANCELLED，无不可逆效果且本行动没有 confirmed/unknown | 重入 Handler；首次 emit 复用旧 safe pending 槽位；先运行 Handler，再由它提交原草稿 |
-| 可信 COMPLETED，有 safe pending | 保留未完成交付，FAILED/retryable=False，不重跑 Handler，不向 sink 补投，不开始下一行动 |
-| 可信 FAILED/CANCELLED，已有不可逆效果或 confirmed | 保留原失败/取消与效果，retryable=False，不重跑 Handler 或补投 |
+| 可信 COMPLETED/ALREADY_COMPLETED，有 safe pending | 只投递存储原值，不重跑 Handler；确认后报告 ALREADY_COMPLETED，再继续后续行动 |
+| 可信 FAILED/CANCELLED，已有不可逆效果或 confirmed，且有 safe pending | 只投递存储原值，不重跑 Handler；确认后保留原失败/取消、错误与效果，后续行动 NOT_STARTED |
+| 可信 FAILED/CANCELLED，已有不可逆效果或 confirmed，且没有 pending | 保留原终态，retryable=False，不重跑 Handler 或调用 sink |
 | 存在 UNKNOWN，或 STARTED 没有可信 ActionResult | DEPENDENCY_UNAVAILABLE/retryable=False；不接管 Handler 或输出 |
 
-safe FAILED/CANCELLED 重入时如果未 emit 旧 pending 就返回 COMPLETED，仍保存 pending，不丢弃、不跳号；本次及后续调用都返回未完成交付，不再重跑已经可信完成的 Handler，也不开始下一行动。新的可信结果为失败时继续按上表判定。
+safe FAILED/CANCELLED 重入时如果未 emit 旧 pending 就返回 COMPLETED，仍保存 pending，不丢弃、不跳号；本次返回未完成交付且 retryable=True，不开始下一行动；后续调用转为仅投递恢复，确认后才能继续。已可信完成的 Handler 不再重跑。新的可信结果为失败时继续按上表判定。
 
-可信完成但交付被明确拒绝时，本次报告 FAILED，使用拒绝映射错误并保留效果；报告中该行动以 FAILED 表达未完成交付，账本仍保留处理器可信完成结果。可信失败/取消与 pending 并存时保留其原状态和错误。retryable=True 只表示行动本身可安全继续；已可信完成或已有副作用的行动留下 pending 时，当前调用返回 retryable=False。存储故障报告 retryable=False。
+可信完成但交付被明确拒绝时，本次报告 FAILED，使用拒绝映射错误并保留效果；报告中该行动以 FAILED 表达未完成交付，账本仍保留处理器可信完成结果。可信失败/取消与 pending 并存时保留其原状态和错误。retryable=True 表示仍有安全行动或 safe pending 可以继续，可能只剩投递恢复；仅投递恢复成功不能把可信业务失败变成完成，恢复完仍有不可安全重入的失败时 retryable=False。一次恢复调用遇明确拒绝只尝试一次，原 safe pending 留待下次，不自动循环。存储故障报告 retryable=False。
 
-已有完成前缀的输出、效果和序列不妨碍后续安全行动重入。无需新工作的终态沿用历史优先规则；可安全重入的行动必须再次通过 current revision、当前令牌、运行时接受状态和全计划路由检查。准入拒绝不投递、不改变旧事实；保留已完成前缀的效果/ALREADY_COMPLETED，其余为本次 NOT_STARTED，拒绝报告 retryable=False。之后合法调用仍能从安全行动继续。
+已有完成前缀的输出、效果和序列不妨碍后续安全行动重入。没有 pending 且无需新工作的终态沿用历史优先规则；安全行动和仅投递恢复都必须再次通过 current revision、当前令牌和全计划路由检查，后续行动未注册也拒绝当前补投。运行时停止接受沿用 facade 的入口拒绝，不读取账本；已经接受的恢复计入关闭等待。
+
+恢复准入拒绝只影响本次报告，retryable=False，不投递、不覆盖账本原业务结算。已可信完成的行动即使留有 safe pending，仍以 ALREADY_COMPLETED 保留效果；尚未开始行动为 NOT_STARTED。仅投递恢复的可信 FAILED/CANCELLED 行动，用本次拒绝对应的状态和错误码投影该项，保留 effect_ref、不可逆标记和累计 output_started，使单项与整体报告符合领域约束。安全 Handler 重入的准入拒绝沿用原有 NOT_STARTED 投影；之后合法调用仍可恢复并返回原业务失败。
+
+仅投递恢复遇新的未知接收或存储故障，同样只将本次报告投影为对应稳定错误并保留已知效果/接收事实，不能覆写账本原 ActionResult。超时为 PROVIDER_TIMEOUT、错误回执为 INTERNAL_ERROR；后续 UNKNOWN 读取为 DEPENDENCY_UNAVAILABLE，均 retryable=False。补投成功或明确拒绝时，可信 FAILED/CANCELLED 保留原状态和错误；完成行动被明确拒绝则按拒绝映射报告未完成交付。
 
 ## 在途、取消和日志
 
-Handler 调用取得 Execution Ledger 的原子执行权。同实例同 execution 并发者加入拥有者；等待者的 sink 不使用，等待者取消不取消拥有者。其他 Runtime/进程不接管在途工作。等待者观察拥有者结束后的最新接收、效果和结算事实。
+Handler 调用与仅投递恢复都取得 Execution Ledger 的原子执行权。同实例同 execution 并发者加入拥有者；等待者的 sink 不使用，等待者取消不取消拥有者。其他 Runtime/进程不接管在途工作。等待者观察拥有者结束后的最新接收、效果和结算事实。
 
-拥有者任务取消只向正在运行的 Handler 转发一次，等待清理退出后传播 CancelledError；正常返回可信 ActionResult 时按存储和输出事实结算。取消中没有可信回执的投递保持 UNKNOWN。协作令牌在 emit 前及确认后检查，确认后取消不抹掉接收事实。在途调用与等待者均计入 AgentRuntime.shutdown 的等待，超时保持依赖可用。
+拥有者任务取消只向正在运行的 Handler 或恢复 sink worker 转发一次，重复取消仍等待清理退出后传播 CancelledError；清理正常返回有效 receipt 时先持久确认，返回可信 ActionResult 时先持久结算。仅投递恢复始终保留已有 ActionResult，不以未开始 Handler 为由重置历史。取消中没有可信回执的投递保持 UNKNOWN。协作令牌在 emit 前及确认后检查，确认后取消不抹掉接收事实。在途调用与等待者均计入 AgentRuntime.shutdown 的等待，超时保持依赖可用。
 
 输出错误通过 utils/logger.py 记录角色、execution、interaction、action、sequence、稳定错误码、异常类型及栈位置；不记录输出正文、音频 bytes、异常原文、局部变量和源码行。
 
 ## 公开验证
 
-测试入口为公开 realize_action_plan；使用真实临时 SQLite、受控内部 Handler 与外部 sink，数据库故障在 SQL 会话边界注入。取消和关闭沿用 AgentRuntime.shutdown 的现有公开回归。
+测试入口为公开 realize_action_plan 与 AgentRuntime.shutdown；使用真实临时 SQLite、受控内部 Handler 与外部 sink，数据库故障在 SQL 会话边界注入。
 
 - 四种输出字段与完整音频保真，跨 Action 连续编号，并发 emit 按 await 串行发送。
 - 完成前缀跨 Runtime 不重发；safe pending 同槽重入与内容冲突，未再次 emit 不能丢弃。
-- 可信完成仍有 pending 时不开始下一行动、不重跑 Handler、不虚报可重试。
+- 可信完成/不安全失败只恢复原 payload，不重做效果；恢复后继续的行动沿用连续序号，失败不伪造成完成。
+- 恢复准入保留原结算；全计划路由、同实例等待者、跨 Runtime 占用及重复取消清理都遵守原子所有权。
+- ack 临时故障在最终结算补齐；已保存 payload 的尝试标记失败与首次 payload 丢失严格区分。
+- 新 Python 进程恢复完整音频；恢复 sink 及等待者退出前 shutdown 不释放依赖。
 - UNKNOWN、错误回执、取消及进程硬退出不自动重投；确认后存储失败仍保留本次已知事实。
 - 旧存储历史输出序列不可猜测；损坏、缺号、缺失输出记录均拒绝继续。

--- a/docs/项目说明/项目架构与接口（spec）/接口文档/agent/output-delivery.md
+++ b/docs/项目说明/项目架构与接口（spec）/接口文档/agent/output-delivery.md
@@ -1,6 +1,6 @@
 # 输出身份、持久序列与安全投递
 
-状态：输出生产者与持久序列已实现；本文的仅投递恢复及最终结算补齐为目标契约，尚未实现。公开入口为 `Agent.realize_action_plan(plan, execution_context, output_sink) -> ExecutionReport`；领域输出、回执、错误和报告沿用 [realization](../domain/realization.md)。
+状态：输出生产者、持久序列、仅投递恢复及最终结算补齐已实现。公开入口为 `Agent.realize_action_plan(plan, execution_context, output_sink) -> ExecutionReport`；领域输出、回执、错误和报告沿用 [realization](../domain/realization.md)。
 
 ## 所有权和调用
 

--- a/docs/项目说明/项目架构与接口（spec）/项目架构.md
+++ b/docs/项目说明/项目架构与接口（spec）/项目架构.md
@@ -43,7 +43,7 @@
 2. `Agent` 提供 `handle_stimulus` 与 `realize_action_plan` 两个业务入口；旧链路仍使用 `LuoTianyiAgent` 兼容入口。
 
 目前主要实现了以下模块：
-- `Agent`：校验并路由请求、顺序执行已注册行动。内部 `ledgers/request_ledger.py` 在现有 SQL 数据库保存角色请求身份和终态；`planning/emitter.py` 为草稿分配稳定计划身份，`ledgers/plan_outbox.py` 保存完整计划、确认及恢复状态，重复 handle 只读取终态或恢复原计划，不重跑处理器。会话工厂由 AgentRuntime 显式注入，持久行为见 [请求账本契约](接口文档/agent/request-ledger.md)。内部 `execution.py` 通过 `ledgers/execution_ledger.py` 保存执行身份、逐行动开始/结算及输出事实；重复 realize 跳过已完成前缀，仅继续可证明安全的行动，见 [Execution Ledger](接口文档/agent/execution-ledger.md)。内部 `outputs/emitter.py` 接收内容草稿，由 `ledgers/output_outbox.py` 保存完整输出与连续序列，确认后才推进后续输出和行动，见[输出投递契约](接口文档/agent/output-delivery.md)。生产处理器注册表为空。
+- `Agent`：校验并路由请求、顺序执行已注册行动。内部 `ledgers/request_ledger.py` 在现有 SQL 数据库保存角色请求身份和终态；`planning/emitter.py` 为草稿分配稳定计划身份，`ledgers/plan_outbox.py` 保存完整计划、确认及恢复状态，重复 handle 只读取终态或恢复原计划，不重跑处理器。会话工厂由 AgentRuntime 显式注入，持久行为见 [请求账本契约](接口文档/agent/request-ledger.md)。内部 `execution.py` 通过 `ledgers/execution_ledger.py` 保存执行身份、逐行动开始/结算及输出事实；重复 realize 跳过已完成前缀，继续可证明安全的行动；已可信结算的行动仅恢复原输出，确认临时存储故障由最终结算补齐，见 [Execution Ledger](接口文档/agent/execution-ledger.md)。内部 `outputs/emitter.py` 接收内容草稿，由 `ledgers/output_outbox.py` 保存完整输出与连续序列，确认后才推进后续输出和行动，见[输出投递契约](接口文档/agent/output-delivery.md)。生产处理器注册表为空。
 - `LuoTianyiAgent`：提供外部世界调用的接口，处理用户输入，生成智能体的响应。其包括主回复模块、潜意识模块、能力模块以及角色档案等。
 - `MainChat`：主回复模块，处理用户输入，生成智能体的响应，并解析为项目定义的对象。
 

--- a/server/src/agent/execution.py
+++ b/server/src/agent/execution.py
@@ -62,6 +62,44 @@ class Execution:
                 return results[:index]
         return results
 
+    def output_only(self, index):
+        """可信完成或不可重做的行动，仅恢复其安全待投递输出。"""
+        fact = self.facts[index]
+        return (fact.result is not None and not fact.unknown and self.pending(index) is not None
+                and (fact.complete or not fact.safe))
+
+    def admission(self, error):
+        """准入仅投影本次报告，保留恢复行动的效果及原持久结算。"""
+        results = self.prefix()
+        index = len(results)
+        if index < len(self.facts) and self.output_only(index):
+            result = self.facts[index].result
+            if self.facts[index].complete:
+                result = replace(result, status=d.ActionExecutionStatus.ALREADY_COMPLETED)
+            else:
+                result = self.project(result, error)
+            results.append(result)
+        return self.report(error, results)
+
+    @staticmethod
+    def project(result, error):
+        """以本次失败或取消投影行动，保留已知效果而不修改账本事实。"""
+        status = (d.ActionExecutionStatus.CANCELLED if error is d.ExecutionErrorCode.CANCELLED
+                  else d.ActionExecutionStatus.FAILED)
+        return replace(result, status=status, error_code=error)
+
+    def settle(self, index, outputs):
+        """可信结果与内存已确认回执一起提交；本次存储失败仍向上报告。"""
+        try:
+            if outputs.payload_lost:
+                raise outputs.error
+            self.save()
+            if isinstance(outputs.error, _StorageError):
+                raise outputs.error
+        except _StorageError:
+            self._failed_settlement_index = index
+            raise
+
     def historical(self):
         """终态优先于本次准入；未知开始不解释为安全的无效果失败。"""
         prefix = self.prefix()
@@ -70,10 +108,8 @@ class Execution:
         fact = self.facts[len(prefix)]
         if fact.unknown or (fact.started and fact.result is None):
             return self.unavailable()
-        if fact.complete and self.pending(len(prefix)):
-            result = replace(fact.result, status=d.ActionExecutionStatus.FAILED,
-                             error_code=d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE)
-            return self.report(result.error_code, [*prefix, result])
+        if self.output_only(len(prefix)):
+            return None
         if not fact.safe:
             result = fact.result or self.agent._action_result(
                 self.plan.actions[len(prefix)], d.ActionExecutionStatus.FAILED,
@@ -110,13 +146,13 @@ class Execution:
             if terminal is not None:
                 return terminal
             if self.plan.basis_interaction_revision != self.context.current_interaction_revision:
-                return self.report(d.ExecutionErrorCode.STALE_INTERACTION)
+                return self.admission(d.ExecutionErrorCode.STALE_INTERACTION)
             if self.context.cancellation.is_cancelled:
-                return self.report(d.ExecutionErrorCode.CANCELLED)
+                return self.admission(d.ExecutionErrorCode.CANCELLED)
             try:
                 handlers = tuple(self.agent._action_router.resolve(action.kind) for action in self.plan.actions)
             except KeyError:
-                return self.report(d.ExecutionErrorCode.UNSUPPORTED_ACTION)
+                return self.admission(d.ExecutionErrorCode.UNSUPPORTED_ACTION)
             try:
                 if self.ledger.claim(self.context.execution_id, payload, self.facts, new=state == "missing", legacy=slots is None):
                     break
@@ -150,46 +186,53 @@ class Execution:
         results = self.prefix()
         for index in range(len(results), len(self.facts)):
             action, fact = self.plan.actions[index], self.facts[index]
+            recovery = self.output_only(index)
             if self.context.cancellation.is_cancelled:
+                if recovery:
+                    return self.admission(d.ExecutionErrorCode.CANCELLED)
                 return self.report(d.ExecutionErrorCode.CANCELLED, results, retryable=True)
             outputs = OutputEmitter(self, index)
+            previous = replace(fact)
 
             async def execute():
+                if recovery:
+                    try:
+                        await outputs._recover()
+                    except _StorageError:
+                        self.settle(index, outputs)
+                    except (d.SinkRejectedError, _DeliveryCancelled):
+                        pass
+                    return (replace(fact.result, status=d.ActionExecutionStatus.ALREADY_COMPLETED)
+                            if fact.complete else fact.result)
                 result = await handlers[index].realize(action, self.context, outputs)
                 if (type(result) is not d.ActionResult or result.action_id != action.action_id
                         or result.status is d.ActionExecutionStatus.NOT_STARTED):
                     raise ValueError("invalid action result")
                 fact.result = result
-                try:
-                    if isinstance(outputs.error, _StorageError):
-                        raise outputs.error
-                    self.save()  # 在拥有的 worker 内提交，取消清理正常返回也保存可信结果。
-                except _StorageError:
-                    self._failed_settlement_index = index
-                    raise
+                self.settle(index, outputs)  # 取消清理正常返回也在拥有的 worker 内持久结算。
                 return result
 
             try:
-                fact.started, fact.result = True, None
-                self.save()
+                if not recovery:
+                    fact.started, fact.result = True, None
+                    self.save()
                 result = await self.agent._call_handler(execute, self.context.cancellation,
                                                        self.context.execution_id, self.context.interaction_id)
             except _HandlerNotStarted:
-                fact.started = False
+                fact.started, fact.result = previous.started, previous.result
                 try:
                     self.save()
                 except _StorageError as error:
                     return self.unavailable(error, results)
-                return self.report(d.ExecutionErrorCode.CANCELLED, results, retryable=True)
+                return (self.admission(d.ExecutionErrorCode.CANCELLED) if recovery else
+                        self.report(d.ExecutionErrorCode.CANCELLED, results, retryable=True))
             except Exception as error:
                 code = (d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE if isinstance(error, _StorageError)
                         else d.ExecutionErrorCode.CANCELLED if isinstance(error, _DeliveryCancelled)
                         else outputs.code or self.agent._error_code(error, d.ExecutionErrorCode))
                 self.agent._record_exception(self.context.execution_id, self.context.interaction_id, code, error)
                 result = fact.result or self.agent._action_result(action)
-                status = (d.ActionExecutionStatus.CANCELLED if code is d.ExecutionErrorCode.CANCELLED
-                          else d.ActionExecutionStatus.FAILED)
-                result = replace(result, status=status, error_code=code)
+                result = self.project(result, code)
                 return self.report(code, [*results, result])
             finally:
                 outputs.close()
@@ -197,13 +240,11 @@ class Execution:
             delivery_failed = outputs.error is not None and not isinstance(outputs.error, _DeliveryCancelled)
             if delivery_failed or fact.unknown or (fact.complete and self.pending(index)):
                 code = outputs.code or d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE
-                status = (d.ActionExecutionStatus.CANCELLED if code is d.ExecutionErrorCode.CANCELLED
-                          else d.ActionExecutionStatus.FAILED)
-                result = replace(result, status=status, error_code=code)
-                return self.report(code, [*results, result])
+                result = self.project(result, code)
+                return self.report(code, [*results, result], retryable=not delivery_failed and not fact.unknown)
             results.append(result)
             if result.error_code is not None:
-                return self.report(result.error_code, results, retryable=fact.safe)
+                return self.report(result.error_code, results, retryable=fact.safe or self.pending(index) is not None)
             if self.context.cancellation.is_cancelled:
                 return self.report(d.ExecutionErrorCode.CANCELLED, results, retryable=index + 1 < len(self.facts))
         return self.report(results=results)

--- a/server/src/agent/facade.py
+++ b/server/src/agent/facade.py
@@ -262,6 +262,8 @@ class Agent:
         未结算的开始状态阻止重做。相同执行的并发等待者共享拥有者报告。
         输出由 Agent 绑定身份与连续序号，完整落库后串行投递；已有槽位只接受
         原内容，未知接收禁止重发，未完成交付阻止后续行动。
+        已可信结算的行动仅恢复安全待投递原值；确认写入失败由最终结算补齐，
+        本次仍报告存储失败，不继续新行动。
         类型错误抛 TypeError；任务取消在可信结果持久结算和清理后传播。
         """
         if not isinstance(plan, d.ActionPlan) or not isinstance(execution_context, d.ExecutionContext):

--- a/server/src/agent/outputs/emitter.py
+++ b/server/src/agent/outputs/emitter.py
@@ -26,9 +26,17 @@ class OutputEmitter:
         self._lock = asyncio.Lock()
         self.error = None
         self.code = None
+        self.payload_lost = False
 
     async def emit(self, draft: OutputDraft) -> d.OutputReceipt:
         """校验草稿并持久投递；明确拒绝可同值重试，其余错误封闭本次输出。"""
+        return await self._deliver(draft)
+
+    async def _recover(self) -> d.OutputReceipt:
+        """由执行协调器投递已有槽位的原值，不分配身份或再次生成内容。"""
+        return await self._deliver(None, recovery=True)
+
+    async def _deliver(self, draft, *, recovery=False):
         async with self._lock:
             execution = self._execution
             if execution is None:
@@ -43,7 +51,7 @@ class OutputEmitter:
                 _check_cancellation(context.cancellation)
                 if pending and pending.state == "UNKNOWN":
                     raise _UnknownDelivery("output receipt unknown")
-                output = bind(draft, context, action_id, sequence)
+                output = pending.output if recovery else bind(draft, context, action_id, sequence)
                 payload = encode(output)
                 if pending and payload != encode(pending.output):
                     raise _ContentConflict("output slot content changed")
@@ -51,11 +59,18 @@ class OutputEmitter:
                     try:
                         pending = execution.ledger.outbox.prepare(context.execution_id, output)
                     except Exception as error:
+                        self.payload_lost = True
                         raise OutputStorageError("output prepare failed") from error
                     execution.slots.append(pending)
                 fact = execution.facts[self._index]
+                prior_state, prior_unknown = pending.state, fact.unknown
                 pending.state, fact.unknown = "UNKNOWN", True
-                execution.save()
+                try:
+                    execution.save()
+                except OutputStorageError:
+                    # 外部调用尚未开始，最终结算只能保存原本已持久的安全槽位。
+                    pending.state, fact.unknown = prior_state, prior_unknown
+                    raise
                 try:
                     receipt = await execution.sink.emit(pending.output)
                 except d.SinkRejectedError:

--- a/server/tests/agent/README.md
+++ b/server/tests/agent/README.md
@@ -396,3 +396,14 @@ SPEC `a1c44e5e` 已提交并作者自审：仅投递恢复、可信结果分流�
 作者自审边界：本提交只含测试、启用清单和本记录；未改产品代码或追加完成进度。
 A的交付测试除两项已确认期望变更外，经AST比较保持原样；没有导入桥、私有结构断言或放宽原UNKNOWN保护。
 本轮尚无GREEN，没有真实业务Handler、外部接收器、生产库或客户端验收。
+
+
+## 原输出恢复与结算补齐 GREEN（2026-09-06）
+
+SPEC `a1c44e5e` 与 RED `1e44947c` 已落实；87项输出验收未改。Execution在全计划准入及原子占用后，对可信完成或不安全失败只恢复安全槽位的原payload；safe FAILED/CANCELLED仍先重入Handler。补投成功保留原业务失败或跳过已完成行动继续，UNKNOWN和未可信STARTED保持封闭。
+
+OutputEmitter复用既有持久投递路径。已确认回执的本地提交临时失败时，最终可信结果（恢复时使用已存结果）原子补齐回执和结算；本次仍报告DEPENDENCY_UNAVAILABLE，不开始新行动。完整payload已存但UNKNOWN标记失败时恢复原safe状态；首次payload保存失败不允许补出空完成。恢复任务由门面拥有，重复取消只转发一次，清理返回有效回执先保存，再传播取消。
+
+四个输出文件 **87 passed，22.81s**。首次完整回归的旧Execution关闭测试、再次回归的旧PlanEmitter关闭测试，均在owner/waiter结束后的最终资源关闭沿用20ms预算而超时。独立测试作者提交 `4d60a521` 与 `aff3bc6d`，只在业务等待断言已完成后恢复1s清理预算；Request Ledger同形路径为审计修订，不伪造失败证据。前半在途超时、资源保留与取消断言均保留，87项RED未变。
+
+最终server目录执行 `D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q --tb=short`：**883 passed、2 skipped，72.86s**。两个跳过仍为world真实网络探测；另有第三方pkg_resources弃用警告。相关Ruff、Agent compileall、7份Agent SPEC UTF-8/代码围栏/相对链接及git diff --check通过。四份接口SPEC已定稿为事实，公开realize及新增私有协调方法具有中文docstring。没有新增领域字段、数据库格式或真实Handler；只验证本地SQLite、独立Python进程和受控接收器，不代表真实外部服务或生产库验收。

--- a/server/tests/agent/README.md
+++ b/server/tests/agent/README.md
@@ -362,3 +362,37 @@ PR #119 独立 SPEC 审查的 RED `c2897f54` 两例要求确认输出后取消�
 保持三项 RED 不变；执行协调器仅将协作取消与交付故障区分，可信行动结果继续参与正常结算。UNKNOWN、未确认槽位、存储失败、内容冲突保护保留。现有execution-ledger和handler-routing SPEC已覆盖，不新增接口或修改契约。
 
 三个输出文件 **37 passed**。最终server目录命令 `D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q --tb=short` 为 **833 passed、2 skipped**；Ruff、Agent compileall、git diff --check通过。首轮完整回归曾在既有关闭测试的20ms最终资源关闭超时失败，原样定向复跑及两轮完整回归通过，没有修改该测试。真实网络探测仍跳过，未运行真实Handler或生产依赖。
+
+## 原输出恢复与结算补齐 SPEC / RED（2026-09-06）
+
+基线为已合并 PR119 的 `e2bf72d9`，独立分支 `codex/agent-output-recovery`。
+SPEC `a1c44e5e` 已提交并作者自审：仅投递恢复、可信结果分流、最终回执补齐、
+恢复准入的报告投影与原业务结算保留、恢复所有权和取消清理；公开接口/domain 字段不变。
+静态估算产品实现增改160–230行，仍受500行门禁约束。本阶段产品实现未修改。
+
+从 `13e8732d` 按函数恢复原17项定位中的15项、更新2项重叠期望，再参数化补充：
+
+- `test_output_delivery_recovery.py`：四类原 payload 恢复和后续行动连续序号；不可逆效果或仅confirmed导致的不安全FAILED/CANCELLED只补投；明确拒绝每次只尝试一次；revision、取消、当前/后续行动缺路由的准入；恢复未知错误的报告投影及效果保留。
+- `test_output_storage_recovery.py`：恢复ack_once及新Python进程safe_pending分支；完成/失败结果的首次及恢复ack临时/永久故障；PREPARED或旧REJECTED完整值已存后，UNKNOWN标记提交失败的恢复。原unknown_crash分支断言保留。
+- `test_output_recovery_lifecycle.py`：取消/不取消等待者共享拥有者事实，另一Runtime不能接管；在途shutdown超时保留依赖；owner重复取消等待sink清理；清理未知、有效回执及确认临时/永久提交失败。任务释放后恢复充裕关闭预算，不用最终资源关闭的调度抖动证明RED。
+- 新生命周期文件加入根conftest启用清单；测试不查询私有映射，仅通过realize/shutdown、外部sink和SQL会话故障观察结果。原SQL夹具、草稿/domain、A的UNKNOWN及3项确认后取消回归未改。
+
+正确工作目录为 `server`，运行时为 `D:/Anaconda/envs/lty/python.exe -X utf8`：
+
+1. `-m pytest tests/agent/test_output_sequences.py tests/agent/test_output_delivery_recovery.py tests/agent/test_output_storage_recovery.py tests/agent/test_output_recovery_lifecycle.py --collect-only -q -p no:cacheprovider`：**87 tests collected**。
+2. 同四文件 `-q -p no:cacheprovider --tb=short --show-capture=no`：**49 failed、38 passed，20.44s**。
+3. `-m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q -p no:cacheprovider --tb=line --show-capture=no`：**49 failed、834 passed、2 skipped，70.13s**；仅上述49项目标失败，两个world真实网络探测跳过，另有一项第三方pkg_resources弃用警告。
+4. 四个输出测试文件及根conftest的Ruff、git diff --check通过；SPEC UTF-8、代码围栏和相对链接检查通过。
+
+相对A新增50个展开项，另2项原期望改变，共52项本片验证。其中49项真实失败；
+新增 `failed-prepare`、`failed-prepare_once`、`failed-ack_persistent` 三项首次通过，是补回归，不伪造RED。
+49项失败分别来自恢复资格仍为False、可信完成的原输出未补投、当前准入仍被旧终态掩盖、
+恢复未知场景零sink尝试、ack_once未补齐持久确认，以及已有完整payload仍无法恢复。
+部分综合用例首先在retryable、状态/错误码或接收次数断言失败；其后payload保真、
+后续序号、重建零重发及取消/关闭清理断言尚未运行到，必须在GREEN完整复验。
+其中恢复中的SQL故障尚未实际进入注入点，当前RED只证明缺少恢复入口，不宣称已验证故障补齐。
+首次collect误从仓库根目录运行导致导入错误，已改为server目录重新收集成功；该环境错误不计入RED。
+
+作者自审边界：本提交只含测试、启用清单和本记录；未改产品代码或追加完成进度。
+A的交付测试除两项已确认期望变更外，经AST比较保持原样；没有导入桥、私有结构断言或放宽原UNKNOWN保护。
+本轮尚无GREEN，没有真实业务Handler、外部接收器、生产库或客户端验收。

--- a/server/tests/agent/test_execution_idempotency.py
+++ b/server/tests/agent/test_execution_idempotency.py
@@ -395,6 +395,7 @@ async def test_shutdown_waits_for_execution_owner_and_joiner(routed_runtime):
         release.set()
         left, right = await asyncio.wait_for(asyncio.gather(owner, waiter), 1)
         assert left == right and sink.values == []
+        runtime.shutdown_timeout_seconds = 1
         await runtime.shutdown()
         assert store.close_calls == 1
     finally:

--- a/server/tests/agent/test_output_delivery_recovery.py
+++ b/server/tests/agent/test_output_delivery_recovery.py
@@ -147,7 +147,7 @@ async def test_completed_handler_with_rejected_output_cannot_start_next_action(r
         return await reject(value)
 
     report = await runtime.get_agent().realize_action_plan(plan, context, Sink(receiver))
-    assert report.error_code is d.ExecutionErrorCode.BACKPRESSURE_TIMEOUT and not report.retryable
+    assert report.error_code is d.ExecutionErrorCode.BACKPRESSURE_TIMEOUT and report.retryable
     assert report.action_results[0].effect_ref.effect_id == "kept-effect"
     assert report.action_results[1].status is d.ActionExecutionStatus.NOT_STARTED
     assert len(attempts) == 1 and not report.output_started
@@ -172,17 +172,21 @@ async def test_safe_reentry_that_omits_pending_cannot_drop_it_or_begin_next_acti
     replacement, _ = routed_runtime(realize=omit)
     intermediate_sink = Sink()
     intermediate = await replacement.get_agent().realize_action_plan(plan, fresh(context), intermediate_sink)
-    assert intermediate.status is d.ExecutionStatus.FAILED and not intermediate.retryable
+    assert intermediate.status is d.ExecutionStatus.FAILED and intermediate.retryable
     assert intermediate.action_results[1].status is d.ActionExecutionStatus.NOT_STARTED
     assert intermediate_sink.values == []
     await replacement.shutdown()
 
-    final, _ = routed_runtime(realize=no_reentry)
+    async def remainder(action, current, outputs):
+        if action.action_id == "a2":
+            return await no_reentry(action, current, outputs)
+        return completed(action)
+
+    final, _ = routed_runtime(realize=remainder)
     sink = Sink()
     report = await final.get_agent().realize_action_plan(plan, fresh(context), sink)
-    assert report.status is d.ExecutionStatus.FAILED and not report.retryable
-    assert report.action_results[1].status is d.ActionExecutionStatus.NOT_STARTED
-    assert sink.values == []
+    assert report.status is d.ExecutionStatus.COMPLETED
+    assert [(value.action_id, value.sequence_no, value.text) for value in sink.values] == [("a2", 0, "原始文字")]
 
 
 @pytest.mark.parametrize("mode", ["timeout", "wrong_receipt", "accepted_then_timeout"])
@@ -239,3 +243,191 @@ async def test_caught_output_rejection_still_logs_identity_without_payload(route
     finally:
         for logger in loggers:
             logger.removeHandler(caplog.handler)
+
+
+@pytest.mark.parametrize("kind", ["TextFinal", "AudioChunk", "MessageEnd", "Expression"])
+@pytest.mark.parametrize("with_remaining_action", [False, True])
+async def test_completed_action_recovers_original_payload_without_handler_reentry(
+    routed_runtime, kind, with_remaining_action,
+):
+    attempted = []
+
+    async def receiver(value):
+        attempted.append(value)
+        return await reject(value)
+
+    async def initial(action, context, outputs):
+        try:
+            await outputs.emit(draft(kind, action, context, delivery=d.OutputDelivery.EPHEMERAL_REACTION))
+        except d.SinkRejectedError:
+            pass
+        return completed(action)
+
+    runtime, _ = routed_runtime(realize=initial)
+    plan, context = plan_and_context() if with_remaining_action else single()
+    await runtime.get_agent().realize_action_plan(plan, context, Sink(receiver))
+    await runtime.shutdown()
+
+    async def remaining(action, current, outputs):
+        if action.action_id == "a2":
+            return await no_reentry(action, current, outputs)
+        await outputs.emit(draft("Expression", action, current))
+        return completed(action)
+
+    replacement, _ = routed_runtime(realize=remaining)
+    sink = Sink()
+    report = await replacement.get_agent().realize_action_plan(plan, fresh(context), sink)
+    assert report.status is d.ExecutionStatus.COMPLETED and report.output_started and not report.retryable
+    assert report.action_results[0].status is d.ActionExecutionStatus.ALREADY_COMPLETED
+    assert sink.values[:1] == attempted and len(attempted) == 1
+    assert [(value.action_id, value.sequence_no) for value in sink.values] == (
+        [("a2", 0), ("a1", 1)] if with_remaining_action else [("a2", 0)]
+    )
+    assert [result.status for result in report.action_results[1:]] == (
+        [d.ActionExecutionStatus.COMPLETED] if with_remaining_action else []
+    )
+    await replacement.shutdown()
+    final, _ = routed_runtime(realize=no_reentry)
+    final_sink = Sink()
+    replay = await final.get_agent().realize_action_plan(plan, fresh(context), final_sink)
+    assert replay.status is d.ExecutionStatus.COMPLETED and replay.output_started
+    assert final_sink.values == []
+
+
+@pytest.mark.parametrize("cancelled", [False, True])
+@pytest.mark.parametrize("unsafe_fact", ["effect", "confirmed"])
+@pytest.mark.parametrize("reject_recovery", [False, True])
+async def test_unsafe_failed_action_only_recovers_output_and_retains_original_failure(
+    routed_runtime, cancelled, unsafe_fact, reject_recovery,
+):
+    attempted = []
+
+    async def initial_receiver(value):
+        attempted.append(value)
+        if unsafe_fact == "confirmed" and value.sequence_no == 0:
+            return accepted(value)
+        return await reject(value)
+
+    async def initial(action, context, outputs):
+        try:
+            if unsafe_fact == "confirmed":
+                await outputs.emit(draft("Expression", action, context))
+            await outputs.emit(draft("TextFinal", action, context))
+        except d.SinkRejectedError:
+            pass
+        return failed(action, cancelled=cancelled, effect=unsafe_fact == "effect")
+
+    runtime, _ = routed_runtime(realize=initial)
+    plan, context = plan_and_context()
+    original = await runtime.get_agent().realize_action_plan(plan, context, Sink(initial_receiver))
+    assert original.retryable  # 这里只允许补投原输出，不表示可以重跑有副作用的行动。
+    await runtime.shutdown()
+    replacement, _ = routed_runtime(realize=no_reentry)
+    if reject_recovery:
+        rejected = []
+
+        async def reject_again(value):
+            rejected.append(value)
+            return await reject(value)
+
+        incomplete = await replacement.get_agent().realize_action_plan(plan, fresh(context), Sink(reject_again))
+        assert incomplete.status is original.status and incomplete.error_code is original.error_code
+        assert incomplete.action_results == original.action_results and incomplete.retryable
+        assert rejected == attempted[-1:]  # 一次调用只补投一次，且使用持久原值。
+    sink = Sink()
+    report = await replacement.get_agent().realize_action_plan(plan, fresh(context), sink)
+    assert sink.values == attempted[-1:]
+    assert report.status is original.status and report.error_code is original.error_code
+    assert report.action_results[0].effect_ref == original.action_results[0].effect_ref
+    assert report.action_results[1].status is d.ActionExecutionStatus.NOT_STARTED
+    assert report.output_started and not report.retryable
+
+
+@pytest.mark.parametrize("gate", ["revision", "cancel", "route", "later_route"])
+@pytest.mark.parametrize("settlement", ["completed", "failed", "cancelled"])
+async def test_output_only_recovery_checks_current_admission_without_losing_facts(
+    routed_runtime, gate, settlement,
+):
+    async def initial(action, current, outputs):
+        result = await pending_completed(action, current, outputs)
+        return result if settlement == "completed" else failed(
+            action, cancelled=settlement == "cancelled", effect=True,
+        )
+
+    runtime, _ = routed_runtime(realize=initial)
+    plan, context = plan_and_context()
+    original = await runtime.get_agent().realize_action_plan(plan, context, Sink(reject))
+    await runtime.shutdown()
+    kinds = {"route": (), "later_route": (d.ActionKind.SAY,)}.get(
+        gate, (d.ActionKind.SAY, d.ActionKind.SING),
+    )
+    replacement, _ = routed_runtime(realize=no_reentry,
+                                    action_kinds=kinds)
+    current = fresh(context, current_interaction_revision=99 if gate == "revision" else 3)
+    if gate == "cancel":
+        current.cancellation.cancel(d.CancellationReason.SUPERSEDED)
+    sink = Sink()
+    report = await replacement.get_agent().realize_action_plan(plan, current, sink)
+    assert report.error_code is {"revision": d.ExecutionErrorCode.STALE_INTERACTION,
+                                 "cancel": d.ExecutionErrorCode.CANCELLED,
+                                 "route": d.ExecutionErrorCode.UNSUPPORTED_ACTION,
+                                 "later_route": d.ExecutionErrorCode.UNSUPPORTED_ACTION}[gate]
+    assert report.irreversible_effect_committed and not report.retryable and sink.values == []
+    assert report.action_results[0].effect_ref == original.action_results[0].effect_ref
+    assert report.output_started is original.output_started
+    if settlement == "completed":
+        assert report.action_results[0].status is d.ActionExecutionStatus.ALREADY_COMPLETED
+    else:
+        assert report.action_results[0].error_code is report.error_code
+    assert report.action_results[1].status is d.ActionExecutionStatus.NOT_STARTED
+    await replacement.shutdown()
+
+    async def remaining(action, current, outputs):
+        if action.action_id == "a2":
+            return await no_reentry(action, current, outputs)
+        return completed(action)
+
+    final, _ = routed_runtime(realize=remaining)
+    recovered = await final.get_agent().realize_action_plan(plan, fresh(context), sink)
+    assert len(sink.values) == 1 and not recovered.retryable
+    if settlement == "completed":
+        assert recovered.status is d.ExecutionStatus.COMPLETED
+        assert recovered.action_results[0].status is d.ActionExecutionStatus.ALREADY_COMPLETED
+    else:
+        assert recovered.status is original.status and recovered.error_code is original.error_code
+        assert recovered.action_results == original.action_results
+
+
+@pytest.mark.parametrize("mode", ["timeout", "wrong_receipt"])
+@pytest.mark.parametrize("cancelled", [False, True])
+async def test_output_recovery_unknown_projects_error_without_erasing_effects(routed_runtime, mode, cancelled):
+    async def initial(action, context, outputs):
+        await pending_completed(action, context, outputs)
+        return failed(action, cancelled=cancelled, effect=True)
+
+    runtime, _ = routed_runtime(realize=initial)
+    plan, context = single()
+    original = await runtime.get_agent().realize_action_plan(plan, context, Sink(reject))
+    await runtime.shutdown()
+    replacement, _ = routed_runtime(realize=no_reentry)
+    attempts = []
+
+    async def receiver(value):
+        attempts.append(value)
+        if mode == "wrong_receipt":
+            return replace(accepted(value), sequence_no=99)
+        raise TimeoutError("unknown recovery receipt")
+
+    report = await replacement.get_agent().realize_action_plan(plan, fresh(context), Sink(receiver))
+    expected = d.ExecutionErrorCode.INTERNAL_ERROR if mode == "wrong_receipt" else d.ExecutionErrorCode.PROVIDER_TIMEOUT
+    assert len(attempts) == 1
+    assert report.status is d.ExecutionStatus.FAILED and report.error_code is expected
+    assert report.action_results[0].effect_ref == original.action_results[0].effect_ref
+    assert report.irreversible_effect_committed and not report.output_started and not report.retryable
+    await replacement.shutdown()
+    final, _ = routed_runtime(realize=no_reentry)
+    sink = Sink()
+    replay = await final.get_agent().realize_action_plan(plan, fresh(context), sink)
+    assert replay.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE and not replay.retryable
+    assert replay.action_results[0].effect_ref == original.action_results[0].effect_ref
+    assert sink.values == []

--- a/server/tests/agent/test_output_recovery_lifecycle.py
+++ b/server/tests/agent/test_output_recovery_lifecycle.py
@@ -1,0 +1,139 @@
+"""仅投递恢复的执行所有权、取消清理和关闭等待。"""
+import asyncio
+
+import pytest
+from sqlalchemy import event
+
+import src.domain.agent as d
+from output_support import accepted, draft, fresh, no_reentry, reject, single
+from routing_support import Sink, completed
+
+pytestmark = pytest.mark.asyncio
+
+
+async def pending_completed(action, context, outputs):
+    try:
+        await outputs.emit(draft("AudioChunk", action, context))
+    except d.SinkRejectedError:
+        pass
+    return completed(action, irreversible_effect_committed=True,
+                     effect_ref=d.EffectRef(kind=d.EffectKind.DYNAMIC_POST, effect_id="kept-effect"))
+
+
+@pytest.mark.parametrize("cancel_waiter", [False, True])
+async def test_recovery_waiter_cancel_and_shutdown_wait_for_owned_sink(routed_runtime, cancel_waiter):
+    runtime, _ = routed_runtime(realize=pending_completed)
+    plan, context = single()
+    first = await runtime.get_agent().realize_action_plan(plan, context, Sink(reject))
+    assert first.retryable  # 先观察恢复资格；尚未实现时不以等待事件超时制造 RED。
+    await runtime.shutdown()
+    replacement, store = routed_runtime(realize=no_reentry)
+    other, _ = routed_runtime(realize=no_reentry)
+    close_before = store.close_calls
+    replacement.shutdown_timeout_seconds = .02
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def receiver(value):
+        entered.set()
+        await release.wait()
+        return accepted(value)
+
+    owner = asyncio.create_task(replacement.get_agent().realize_action_plan(plan, fresh(context), Sink(receiver)))
+    waiter = None
+    try:
+        await asyncio.wait_for(entered.wait(), 1)
+        waiter_sink = Sink()
+        waiter = asyncio.create_task(replacement.get_agent().realize_action_plan(plan, fresh(context), waiter_sink))
+        await asyncio.sleep(0)
+        other_sink = Sink()
+        occupied = await other.get_agent().realize_action_plan(plan, fresh(context), other_sink)
+        assert occupied.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE
+        assert occupied.irreversible_effect_committed and not occupied.retryable
+        assert other_sink.values == []
+        if cancel_waiter:
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+        with pytest.raises(RuntimeError):
+            await replacement.shutdown()
+        assert not owner.done() and store.close_calls == close_before
+        release.set()
+        report = await asyncio.wait_for(owner, 1)
+        assert report.status is d.ExecutionStatus.COMPLETED and report.output_started
+        if not cancel_waiter:
+            assert await asyncio.wait_for(waiter, 1) == report
+        assert waiter_sink.values == []
+        replacement.shutdown_timeout_seconds = 1
+        await replacement.shutdown()
+        assert store.close_calls == close_before + 1
+    finally:
+        release.set()
+        await asyncio.gather(*(task for task in (owner, waiter) if task is not None), return_exceptions=True)
+
+
+@pytest.mark.parametrize("receipt_mode", ["unknown", "accepted", "ack_once", "ack_persistent"])
+async def test_recovery_owner_cancel_keeps_receipt_or_unknown_after_cleanup(
+    routed_runtime, runtime_dependencies, receipt_mode,
+):
+    runtime, _ = routed_runtime(realize=pending_completed)
+    plan, context = single()
+    first = await runtime.get_agent().realize_action_plan(plan, context, Sink(reject))
+    assert first.retryable
+    await runtime.shutdown()
+    replacement, store = routed_runtime(realize=no_reentry)
+    close_before = store.close_calls
+    replacement.shutdown_timeout_seconds = .02
+    entered, cleaning, release = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    sessions = runtime_dependencies[0]["database_manager"].open_sql_session
+    failing = False
+
+    def fail_commit(session):
+        nonlocal failing
+        if failing:
+            failing = receipt_mode == "ack_persistent"
+            raise RuntimeError("cannot save cleanup receipt")
+
+    async def receiver(value):
+        nonlocal failing
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleaning.set()
+            await release.wait()
+            if receipt_mode != "unknown":
+                failing = receipt_mode.startswith("ack_")
+                return accepted(value)
+            raise
+
+    event.listen(sessions, "before_commit", fail_commit)
+    owner = asyncio.create_task(replacement.get_agent().realize_action_plan(plan, fresh(context), Sink(receiver)))
+    try:
+        await asyncio.wait_for(entered.wait(), 1)
+        owner.cancel()
+        await asyncio.wait_for(cleaning.wait(), 1)
+        owner.cancel()  # 第二次取消不能击穿 sink 清理或提前释放恢复执行权。
+        await asyncio.sleep(0)
+        with pytest.raises(RuntimeError):
+            await replacement.shutdown()
+        assert not owner.done() and store.close_calls == close_before
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(owner, 1)
+    finally:
+        release.set()
+        if not owner.done():
+            owner.cancel()
+        await asyncio.gather(owner, return_exceptions=True)
+        failing = False
+        event.remove(sessions, "before_commit", fail_commit)
+    replacement.shutdown_timeout_seconds = 1
+    await replacement.shutdown()
+    final, _ = routed_runtime(realize=no_reentry)
+    sink = Sink()
+    report = await final.get_agent().realize_action_plan(plan, fresh(context), sink)
+    if receipt_mode in {"accepted", "ack_once"}:
+        assert report.status is d.ExecutionStatus.COMPLETED and report.output_started
+    else:
+        assert report.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE and not report.retryable
+    assert report.irreversible_effect_committed and sink.values == []

--- a/server/tests/agent/test_output_storage_recovery.py
+++ b/server/tests/agent/test_output_storage_recovery.py
@@ -1,5 +1,6 @@
 """真实 SQL 故障、旧账本与新 Python 进程的公开输出恢复契约。"""
 import asyncio
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -8,7 +9,7 @@ import pytest
 from sqlalchemy import MetaData, delete, event, update
 
 import src.domain.agent as d
-from output_support import accepted, draft, fresh, no_reentry, single
+from output_support import accepted, draft, failed, fresh, no_reentry, reject, single
 from routing_support import Sink, completed, plan_and_context
 
 pytestmark = pytest.mark.asyncio
@@ -42,9 +43,12 @@ async def test_pre_output_ledger_history_does_not_restart_sequence_unsafely(rout
         assert sink.values == []
 
 
-@pytest.mark.parametrize("phase", ["prepare", "prepare_once", "ack_persistent"])
+@pytest.mark.parametrize("phase", [
+    "prepare", "prepare_once", "ack_once", "ack_persistent", "recovery_ack_once", "recovery_ack_persistent",
+])
+@pytest.mark.parametrize("settlement", ["completed", "failed"])
 async def test_output_storage_fault_preserves_known_receipt_and_final_settlement(
-    routed_runtime, runtime_dependencies, phase,
+    routed_runtime, runtime_dependencies, phase, settlement,
 ):
     sessions = runtime_dependencies[0]["database_manager"].open_sql_session
     failing = False
@@ -70,16 +74,23 @@ async def test_output_storage_fault_preserves_known_receipt_and_final_settlement
             await outputs.emit(draft("AudioChunk", action, context))
         except Exception:
             pass
-        return completed(action, irreversible_effect_committed=True,
-                         effect_ref=d.EffectRef(kind=d.EffectKind.DYNAMIC_POST, effect_id="stored-effect"))
+        result = failed(action, effect=True) if settlement == "failed" else completed(action)
+        return d.ActionResult(action_id=action.action_id, status=result.status, error_code=result.error_code,
+                              irreversible_effect_committed=True,
+                              effect_ref=d.EffectRef(kind=d.EffectKind.DYNAMIC_POST, effect_id="stored-effect"))
 
     runtime, _ = routed_runtime(realize=handler)
     plan, context = single()
+    if phase.startswith("recovery_"):
+        await runtime.get_agent().realize_action_plan(plan, context, Sink(reject))
+        await runtime.shutdown()
+        runtime, _ = routed_runtime(realize=no_reentry)
     sink = Sink(receiver)
     event.listen(sessions, "before_commit", fail_commit)
     try:
         first = await runtime.get_agent().realize_action_plan(plan, context, sink)
         assert first.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE
+        assert not first.retryable
         assert first.output_started is (not phase.startswith("prepare"))
         assert first.irreversible_effect_committed
         assert len(sink.values) == (0 if phase.startswith("prepare") else 1)
@@ -90,7 +101,13 @@ async def test_output_storage_fault_preserves_known_receipt_and_final_settlement
     replacement, _ = routed_runtime(realize=no_reentry)
     replay_sink = Sink()
     replay = await replacement.get_agent().realize_action_plan(plan, fresh(context), replay_sink)
-    assert replay.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE and not replay.retryable
+    if phase in {"ack_once", "recovery_ack_once"}:
+        assert replay.status is (d.ExecutionStatus.FAILED if settlement == "failed" else d.ExecutionStatus.COMPLETED)
+        assert replay.error_code is (d.ExecutionErrorCode.PROVIDER_TIMEOUT if settlement == "failed" else None)
+        assert replay.output_started and not replay.retryable
+        assert replay.action_results[0].effect_ref.effect_id == "stored-effect"
+    else:
+        assert replay.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE and not replay.retryable
     assert replay_sink.values == []
 
 
@@ -135,43 +152,52 @@ async def test_corrupt_output_records_fail_closed_before_replay(routed_runtime, 
     assert sink.values == []
 
 
-async def test_fresh_python_process_does_not_take_unknown_action(
-    routed_runtime, runtime_dependencies, tmp_path,
+@pytest.mark.parametrize("mode", ["safe_pending", "unknown_crash"])
+async def test_fresh_python_process_preserves_original_audio_and_never_takes_unknown_action(
+    routed_runtime, runtime_dependencies, tmp_path, mode,
 ):
     sessions = runtime_dependencies[0]["database_manager"].open_sql_session
     url = str(sessions.kw["bind"].url)
-    marker = tmp_path / "effect.txt"
+    marker, result_path = tmp_path / "effect.txt", tmp_path / "result.json"
     server = Path(__file__).resolve().parents[2]
     script = '''
-import asyncio, os, sys
+import asyncio, json, os, sys
 from pathlib import Path
 from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from src.agent import Agent
 from src.agent.handlers.action.router import ActionRouter
-from routing_support import Sink
-from output_support import draft, single
+from routing_support import Sink, completed
+from output_support import draft, reject, single
 import src.domain.agent as d
 engine = create_engine(sys.argv[1])
 async def receiver(value):
-    os._exit(23)
+    if sys.argv[4] == "unknown_crash":
+        os._exit(23)
+    return await reject(value)
 async def handler(action, context, outputs):
     Path(sys.argv[2]).write_text("effect committed", encoding="utf-8")
-    await outputs.emit(draft("AudioChunk", action, context,
-        data=b"RIFF\\x00\\xff\\x10\\x80WAVE", delivery=d.OutputDelivery.EPHEMERAL_REACTION))
+    try:
+        await outputs.emit(draft("AudioChunk", action, context,
+            data=b"RIFF\\x00\\xff\\x10\\x80WAVE", delivery=d.OutputDelivery.EPHEMERAL_REACTION))
+    except d.SinkRejectedError:
+        pass
+    return completed(action, irreversible_effect_committed=True,
+        effect_ref=d.EffectRef(kind=d.EffectKind.DYNAMIC_POST, effect_id="child-effect"))
 agent = Agent(character_id="luotianyi", sql_session_factory=sessionmaker(bind=engine),
     action_router=ActionRouter(((d.ActionKind.SAY, SimpleNamespace(realize=handler)),)))
 plan, context = single()
-asyncio.run(agent.realize_action_plan(plan, context, Sink(receiver)))
+report = asyncio.run(agent.realize_action_plan(plan, context, Sink(receiver)))
+Path(sys.argv[3]).write_text(json.dumps({"status": report.status.value}), encoding="utf-8")
 engine.dispose()
 '''
     bootstrap = f"import sys; sys.path[:0] = {[str(server), str(server / 'tests'), str(server / 'tests/agent')]!r}\n"
     process = await asyncio.to_thread(subprocess.run,
-        [sys.executable, "-X", "utf8", "-c", bootstrap + script, url, str(marker)],
+        [sys.executable, "-X", "utf8", "-c", bootstrap + script, url, str(marker), str(result_path), mode],
         cwd=server, capture_output=True, text=True, encoding="utf-8", timeout=20,
     )
-    assert process.returncode == 23, process.stderr
+    assert process.returncode == (23 if mode == "unknown_crash" else 0), process.stderr
     assert marker.read_text(encoding="utf-8") == "effect committed"
 
     async def replacement(action, context, outputs):
@@ -182,6 +208,61 @@ engine.dispose()
     plan, context = single()
     sink = Sink()
     report = await runtime.get_agent().realize_action_plan(plan, context, sink)
-    assert report.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE and not report.retryable
-    assert sink.values == []
+    if mode == "safe_pending":
+        assert len(sink.values) == 1 and sink.values[0].data == b"RIFF\x00\xff\x10\x80WAVE"
+        assert sink.values[0].delivery is d.OutputDelivery.EPHEMERAL_REACTION
+        assert sink.values[0].sequence_no == 0 and report.status is d.ExecutionStatus.COMPLETED
+        assert report.action_results[0].effect_ref.effect_id == "child-effect"
+        assert json.loads(result_path.read_text(encoding="utf-8"))["status"] == "failed"
+    else:
+        assert report.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE and not report.retryable
+        assert sink.values == []
     assert marker.read_text(encoding="utf-8") == "effect committed"
+
+
+@pytest.mark.parametrize("during_recovery", [False, True])
+async def test_prepared_payload_survives_failure_before_external_attempt(
+    routed_runtime, runtime_dependencies, during_recovery,
+):
+    sessions = runtime_dependencies[0]["database_manager"].open_sql_session
+    engine = sessions.kw["bind"]
+    failed_once = False
+
+    def stop_before_unknown(connection, cursor, statement, parameters, context, executemany):
+        nonlocal failed_once
+        values = parameters.values() if isinstance(parameters, dict) else parameters
+        if (not failed_once and "output" in statement.lower()
+                and statement.lstrip().upper().startswith(("INSERT", "UPDATE"))
+                and any(isinstance(value, str) and value.lower() == "unknown" for value in values)):
+            failed_once = True
+            raise RuntimeError("cannot mark external attempt")
+
+    async def handler(action, context, outputs):
+        try:
+            await outputs.emit(draft("AudioChunk", action, context))
+        except Exception:
+            pass
+        return completed(action)
+
+    runtime, _ = routed_runtime(realize=handler)
+    plan, context = single()
+    if during_recovery:
+        await runtime.get_agent().realize_action_plan(plan, context, Sink(reject))
+        await runtime.shutdown()
+        runtime, _ = routed_runtime(realize=no_reentry)
+    first_sink = Sink()
+    event.listen(engine, "before_cursor_execute", stop_before_unknown)
+    try:
+        first = await runtime.get_agent().realize_action_plan(plan, context, first_sink)
+        assert first.error_code is d.ExecutionErrorCode.DEPENDENCY_UNAVAILABLE
+        assert not first.retryable
+        assert not first.output_started and first_sink.values == []
+    finally:
+        event.remove(engine, "before_cursor_execute", stop_before_unknown)
+    await runtime.shutdown()
+    replacement, _ = routed_runtime(realize=no_reentry)
+    sink = Sink()
+    report = await replacement.get_agent().realize_action_plan(plan, fresh(context), sink)
+    assert report.status is d.ExecutionStatus.COMPLETED
+    assert len(sink.values) == 1 and sink.values[0].sequence_no == 0
+    assert sink.values[0].data == b"RIFF\x00\xff\x10\x80WAVE"

--- a/server/tests/agent/test_plan_delivery_recovery.py
+++ b/server/tests/agent/test_plan_delivery_recovery.py
@@ -342,6 +342,7 @@ async def test_concurrent_recovery_has_one_owner_and_shutdown_retains_dependenci
         first_report, second_report = await asyncio.gather(owner, waiter)
         assert first_report == second_report
         assert unused.values == [] and seen == original.values
+        runtime.shutdown_timeout_seconds = 1
         await runtime.shutdown()
     finally:
         release.set()

--- a/server/tests/agent/test_request_idempotency.py
+++ b/server/tests/agent/test_request_idempotency.py
@@ -374,6 +374,7 @@ async def test_shutdown_waits_for_owner_and_duplicate_before_releasing_dependenc
         left, right = await asyncio.wait_for(asyncio.gather(first, second), 1)
         assert left == right
         assert duplicate_sink.values == []
+        runtime.shutdown_timeout_seconds = 1
         await runtime.shutdown()
         assert store.close_calls == 1
     finally:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -8,6 +8,7 @@ _ACTIVE_TEST_FILES = {
     (Path(__file__).parent / "agent" / "test_output_sequences.py").resolve(),
     (Path(__file__).parent / "agent" / "test_output_delivery_recovery.py").resolve(),
     (Path(__file__).parent / "agent" / "test_output_storage_recovery.py").resolve(),
+    (Path(__file__).parent / "agent" / "test_output_recovery_lifecycle.py").resolve(),
     (Path(__file__).parent / "agent" / "test_execution_idempotency.py").resolve(),
     (Path(__file__).parent / "agent" / "test_execution_storage_recovery.py").resolve(),
     (Path(__file__).parent / "agent" / "test_plan_emission.py").resolve(),


### PR DESCRIPTION
公开 realize_action_plan 可恢复已持久保存、可证明尚未接收的原输出。可信完成或已有副作用的失败行动只补投原 payload，不重新运行 Handler；成功补投后，完成行动跳过，后续行动沿用连续序号；真实失败/取消与效果保留。安全无效果失败仍先重入 Handler，再复用原槽。

有效回执的确认提交暂时失败时，最终可信结算补齐接收事实和结果；本次仍报告 DEPENDENCY_UNAVAILABLE 并停止新工作，后续不重复投递。已有完整 payload 但发送前标记失败可恢复，首次 payload 保存失败仍保持未结算，UNKNOWN 不接管。恢复遵守当前准入、全计划路由、原子执行权、等待者取消隔离、拥有者清理和 shutdown 等待。

完成 #65 本轮限定的 realization 核心与安全重试范围，#65 保持开放；没有实现 Say 或真实业务 Handler，没有增加 domain 字段、数据库格式或公开业务方法。

- SPEC：a1c44e5e；输出投递、Execution Ledger、门面和路由文档按实现事实定稿，公开方法中文 docstring 已同步。
- RED：1e44947c，由独立 SPEC/RED 作者完成；87项输出测试49 failed、38 passed；完整相关49 failed、834 passed、2 skipped，仅目标行为失败。保留原测试定位，50项新增展开场景中3项首次通过，作为补回归；后半断言未运行到的首次失败边界如实记录。
- GREEN：48110aca，由不同作者完成，87项输出测试保持不变且全部通过；阶段提交均已作者自审。
- 验证：server 下 D:/Anaconda/envs/lty/python.exe -X utf8 -m pytest tests/agent tests/agent_runtime tests/domain tests/world tests/system -q --tb=short：883 passed、2 skipped（72.86s）。Ruff、compileall、diff及7份Agent SPEC编码/围栏/相对链接检查通过。
- 两次完整候选验证曾遇旧测试把20ms在途超时预算沿用到最终资源关闭。4d60a521、aff3bc6d 分别修正三个旧测试：业务和等待者结束后恢复1s资源关闭预算，所有前半短预算、超时、资源保留和取消断言不变；其中Request Ledger为同形审计修订，没有伪造RED。两改动文件独立65 passed。
- 使用真实临时SQLite、SQL故障、新Python进程及受控Handler/sink验证。两个world真实网络探测跳过；未验证真实业务Handler、客户端播放、外部服务或生产数据库。
- 产品新增86行、删除28行，集中在执行协调、OutputEmitter及门面说明；完成事实、测试证据和架构索引已同步。